### PR TITLE
Fix: Percentage error that causes loss of controls

### DIFF
--- a/src/app/utils/sample-url-generation.ts
+++ b/src/app/utils/sample-url-generation.ts
@@ -12,7 +12,7 @@ export function parseSampleUrl(url: string, version?: string) {
     queryVersion = (version) ? version : urlObject.pathname.substring(1, 5);
 
     const searchParameters = urlObject.search;
-    if (searchParameters && searchParameters !== '') {
+    if (searchParameters !== '') {
       try {
         search = decodeURI(searchParameters);
       } catch (error) {

--- a/src/app/utils/sample-url-generation.ts
+++ b/src/app/utils/sample-url-generation.ts
@@ -12,7 +12,7 @@ export function parseSampleUrl(url: string, version?: string) {
     queryVersion = (version) ? version : urlObject.pathname.substring(1, 5);
 
     const searchParameters = urlObject.search;
-    if (searchParameters !== '') {
+    if (searchParameters) {
       try {
         search = decodeURI(searchParameters);
       } catch (error) {

--- a/src/app/utils/sample-url-generation.ts
+++ b/src/app/utils/sample-url-generation.ts
@@ -10,10 +10,17 @@ export function parseSampleUrl(url: string, version?: string) {
     const urlObject: URL = new URL(url);
     requestUrl = urlObject.pathname.substr(6).replace(/\/$/, '');
     queryVersion = (version) ? version : urlObject.pathname.substring(1, 5);
-    search = decodeURI(urlObject.search);
+
+    const searchParameters = urlObject.search;
+    if (searchParameters && searchParameters !== '') {
+      try {
+        search = decodeURI(searchParameters);
+      } catch (error) {
+        search = searchParameters;
+      }
+    }
+
     sampleUrl = `${GRAPH_URL}/${queryVersion}/${requestUrl + search}`;
   }
-
   return { queryVersion, requestUrl, sampleUrl, search };
-
 }


### PR DESCRIPTION
## Overview
When typing in a url to send a request to and the url has a % character. The controls get lost. 
This PR sorts this out.
Fixes #284.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Try adding a request to the url and enter a % sign
* Note that the controls do not get lost