### PR TITLE
Fix: sign in area issues

### DIFF
--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -349,7 +349,12 @@ class App extends Component<IAppProps, IAppState> {
 
                 <hr className={classes.separator} />
                 {!mobileScreen && <>
-                  <div style={{ display: minimised ? 'block' : 'flex' }}>
+                  <div style={
+                    {
+                      display: minimised ? 'block' : 'flex',
+                      justifyContent: 'center',
+                      alignItems: 'center'
+                    }}>
                     <div className={minimised ? '' : 'col-md-10'}>
                       <Authentication />
                     </div>

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -29,6 +29,7 @@ import { Banner } from './opt-in-out-banner';
 import { QueryResponse } from './query-response';
 import { QueryRunner } from './query-runner';
 import { parse } from './query-runner/util/iframe-message-parser';
+import { Settings } from './settings';
 import { Sidebar } from './sidebar/Sidebar';
 
 
@@ -347,7 +348,15 @@ class App extends Component<IAppProps, IAppState> {
 
 
                 <hr className={classes.separator} />
-                {!mobileScreen && <><Authentication />
+                {!mobileScreen && <>
+                  <div style={{ display: minimised ? 'block' : 'flex' }}>
+                    <div className={minimised ? '' : 'col-md-10'}>
+                      <Authentication />
+                    </div>
+                    <div className={minimised ? '' : 'col-md-2'}>
+                      <Settings />
+                    </div>
+                  </div>
                   <hr className={classes.separator} /></>}
 
                 {showSidebar && <>

--- a/src/app/views/authentication/Authentication.styles.ts
+++ b/src/app/views/authentication/Authentication.styles.ts
@@ -1,30 +1,7 @@
 import { FontSizes, ITheme } from '@uifabric/styling';
-import { ThemeContext } from '../../../themes/theme-context';
 
 export const authenticationStyles = (theme: ITheme) => {
   return {
-    authenticationContainer: {
-      justifyContent: 'space-between',
-    },
-    authenticationLayout: {
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'space-between'
-    },
-    profile: {
-      width: '100%',
-    },
-    personaText: {
-      fontSize: FontSizes.mediumPlus,
-      fontWeight: 600
-    },
-    personaSecondaryText: {
-      fontSize: FontSizes.small,
-      whiteSpace: 'nowrap',
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      textTransform: 'lowercase'
-    },
     authenticationLabel: {
       fontSize: FontSizes.large,
       fontWeight: 400,

--- a/src/app/views/authentication/Authentication.tsx
+++ b/src/app/views/authentication/Authentication.tsx
@@ -1,4 +1,4 @@
-import { Icon, Label, Spinner, SpinnerSize, Stack, styled } from 'office-ui-fabric-react';
+import { Icon, Label, Spinner, SpinnerSize, styled } from 'office-ui-fabric-react';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
@@ -8,7 +8,6 @@ import { IAuthenticationProps } from '../../../types/authentication';
 import * as authActionCreators from '../../services/actions/auth-action-creators';
 import { logIn } from '../../services/graph-client/msal-service';
 import { classNames } from '../classnames';
-import { Settings } from '../settings';
 import { showSignInButtonOrProfile } from './auth-util-components';
 import { authenticationStyles } from './Authentication.styles';
 
@@ -44,40 +43,40 @@ export class Authentication extends Component<IAuthenticationProps, { loginInPro
     const { loginInProgress } = this.state;
 
     return (
-      <div className={classes.authenticationContainer}>
-        {loginInProgress ? <div className={classes.spinnerContainer}>
-          <Spinner className={classes.spinner} size={SpinnerSize.medium} />
-          {!minimised && <Label>
-            <FormattedMessage id='Signing you in...' />
-          </Label>
-          }
-        </div>
+      <>
+        {loginInProgress ? showLoginInProgressSpinner(classes, minimised)
           :
           mobileScreen ? showSignInButtonOrProfile(tokenPresent, mobileScreen, this.signIn, minimised) :
-            <Stack>
-              {!tokenPresent &&
-                <>
-                  <div className={classes.authenticationLayout}>
-
-                    {!minimised && <Label className={classes.authenticationLabel}>
-                      <Icon iconName='Permissions' className={classes.keyIcon} />
-                      <FormattedMessage id='Authentication' />
-                    </Label>
-                    }
-                    <Settings />
-                  </div>
-
-                  <br />
-                  {!minimised && <Label>
-                    <FormattedMessage id='Using demo tenant' /> <FormattedMessage id='To access your own data:' />
-                  </Label>}
-                </>
-              }
+            <>
+              {!tokenPresent && showUnAuthenticatedText(classes)}
               <span><br />{showSignInButtonOrProfile(tokenPresent, mobileScreen, this.signIn, minimised)}<br /> </span>
-            </Stack>}
-      </div>
+            </>}
+      </>
     );
   }
+}
+
+function showUnAuthenticatedText(classes: any): React.ReactNode {
+  return <>
+    <Label className={classes.authenticationLabel}>
+      <Icon iconName='Permissions' className={classes.keyIcon} />
+      <FormattedMessage id='Authentication' />
+    </Label>
+
+    <br />
+    <Label>
+      <FormattedMessage id='Using demo tenant' /> <FormattedMessage id='To access your own data:' />
+    </Label>
+  </>;
+}
+
+function showLoginInProgressSpinner(classes: any, minimised: boolean): React.ReactNode {
+  return <div className={classes.spinnerContainer}>
+    <Spinner className={classes.spinner} size={SpinnerSize.medium} />
+    {!minimised && <Label>
+      <FormattedMessage id='Signing you in...' />
+    </Label>}
+  </div>;
 }
 
 function mapStateToProps(state: any) {

--- a/src/app/views/authentication/profile/Profile.tsx
+++ b/src/app/views/authentication/profile/Profile.tsx
@@ -1,19 +1,13 @@
-import { Card } from '@uifabric/react-cards';
-import {
-  ActionButton, Icon, IPersonaSharedProps, Label, Persona,
-  PersonaSize, Stack, styled
-} from 'office-ui-fabric-react';
+import { ActionButton, IPersonaSharedProps, Persona, PersonaSize, styled } from 'office-ui-fabric-react';
 import React, { Component } from 'react';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
-
 import { IProfileProps, IProfileState } from '../../../../types/profile';
 import * as authActionCreators from '../../../services/actions/auth-action-creators';
 import * as profileActionCreators from '../../../services/actions/profile-action-creators';
 import { USER_INFO_URL, USER_PICTURE_URL } from '../../../services/graph-constants';
 import { classNames } from '../../classnames';
-import { Settings } from '../../settings';
 import { authenticationStyles } from '../Authentication.styles';
 
 export class Profile extends Component<IProfileProps, IProfileState> {
@@ -138,33 +132,12 @@ export class Profile extends Component<IProfileProps, IProfileState> {
       ]
     };
 
-    const profileCardTokens: any = {
-      boxShadow: 'none',
-      childrenGap: 10,
+    const personaStyleToken: any = {
+      secondaryText:
+      {
+        textTransform: 'lowercase'
+      },
     };
-
-
-    const profileDisplay = minimised ? <>
-      <Settings />
-      <br />
-      <Persona {...persona} coinSize={30} hidePersonaDetails={true} />
-    </> : <div style={{
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-    }}>
-        <Card compact={true} tokens={profileCardTokens}>
-          <Persona {...persona} coinSize={50} size={PersonaSize.size48} hidePersonaDetails={true} />
-          {!minimised && <Card.Section>
-            <span className={classes.personaText}>
-              {persona.text}
-            </span>
-            <span className={classes.personaSecondaryText}>{persona.secondaryText}</span>
-          </Card.Section>}
-        </Card>
-        <Settings />
-      </div>;
-
 
     return (
       <div className={classes.profile}>
@@ -174,7 +147,12 @@ export class Profile extends Component<IProfileProps, IProfileState> {
           </ActionButton>
         }
 
-        {!mobileScreen && profileDisplay}
+        {!mobileScreen && <Persona
+          {...persona}
+          coinSize={minimised ? 30 : 48}
+          styles={personaStyleToken}
+          hidePersonaDetails={minimised}
+        />}
       </div>
     );
   }

--- a/src/app/views/authentication/profile/Profile.tsx
+++ b/src/app/views/authentication/profile/Profile.tsx
@@ -135,6 +135,7 @@ export class Profile extends Component<IProfileProps, IProfileState> {
     const personaStyleToken: any = {
       secondaryText:
       {
+        paddingBottom: 20,
         textTransform: 'lowercase'
       },
     };

--- a/src/app/views/authentication/profile/Profile.tsx
+++ b/src/app/views/authentication/profile/Profile.tsx
@@ -135,7 +135,7 @@ export class Profile extends Component<IProfileProps, IProfileState> {
     const personaStyleToken: any = {
       secondaryText:
       {
-        paddingBottom: 20,
+        paddingBottom: 10,
         textTransform: 'lowercase'
       },
     };
@@ -150,7 +150,7 @@ export class Profile extends Component<IProfileProps, IProfileState> {
 
         {!mobileScreen && <Persona
           {...persona}
-          coinSize={minimised ? 30 : 48}
+          size={minimised ? PersonaSize.size32 : PersonaSize.size72}
           styles={personaStyleToken}
           hidePersonaDetails={minimised}
         />}

--- a/src/app/views/settings/Settings.tsx
+++ b/src/app/views/settings/Settings.tsx
@@ -27,7 +27,6 @@ class Settings extends Component<ISettingsProps, ISettingsState> {
 
   public componentDidMount = () => {
     const {
-      authenticated,
       intl: { messages }
     }: any = this.props;
 
@@ -51,17 +50,6 @@ class Settings extends Component<ISettingsProps, ISettingsState> {
       }
     ];
 
-    if (authenticated) {
-      items.push({
-        key: 'sign-out',
-        text: messages['sign out'],
-        iconProps: {
-          iconName: 'SignOut',
-        },
-        onClick: () => this.handleSignOut(),
-      });
-    }
-
     this.setState({ items });
   }
 
@@ -83,15 +71,28 @@ class Settings extends Component<ISettingsProps, ISettingsState> {
 
     const {
       intl: { messages },
-      appTheme
+      appTheme,
+      authenticated,
     }: any = this.props;
 
     const { hideThemeChooserDialog, items } = this.state;
+    const menuOptions: any = [...items];
+
+    if (authenticated) {
+      menuOptions.push({
+        key: 'sign-out',
+        text: messages['sign out'],
+        iconProps: {
+          iconName: 'SignOut',
+        },
+        onClick: () => this.handleSignOut(),
+      });
+    }
 
     const menuProperties = {
       shouldFocusOnMount: true,
       alignTargetEdge: true,
-      items
+      items: menuOptions
     };
 
     return (


### PR DESCRIPTION
## Overview

Fixes layout problems on the sign in area when on different screens where the gear icon and the email overflow.

Fixes #352 
Fixes #332 

### Demo
Below are different screenshots on screens of varying sizes
1. 
![image](https://user-images.githubusercontent.com/58787602/74656481-42c3ce80-519f-11ea-9f4f-531529a0bea7.png)

2. 
![image](https://user-images.githubusercontent.com/58787602/74656527-52431780-519f-11ea-84ee-aacf893073d5.png)

3. 
![image](https://user-images.githubusercontent.com/58787602/74656549-5f600680-519f-11ea-9879-8dd5121933c4.png)

4. 
![image](https://user-images.githubusercontent.com/58787602/74656577-6edf4f80-519f-11ea-8706-9d49921219a5.png)


### Notes

The name and the email address are wrapped with an ellipsis. The full descriptions are displayed on hover using tooltips.
The previous implementation used bespoke wrappers . This current one uses only the UI fabric and a design token to change the email to lowercase

## Testing Instructions

* Resize your screen 
* Notice the gear icon does not overflow