### PR TITLE
Fix: Display text/plain results

### DIFF
--- a/src/app/services/actions/query-action-creator-util.ts
+++ b/src/app/services/actions/query-action-creator-util.ts
@@ -86,6 +86,9 @@ export function parseResponse(response: any, respHeaders: any): Promise<any> {
       case ContentType.XML:
         return response.text();
 
+      case ContentType.TextPlain:
+        return response.text();
+
       default:
         return response;
     }

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -11,7 +11,8 @@ export enum LoginType {
 export enum ContentType {
   XML = 'application/xml',
   Json = 'application/json',
-  Image = 'image/jpeg'
+  Image = 'image/jpeg',
+  TextPlain = 'text/plain'
 }
 
 export enum AppTheme {


### PR DESCRIPTION
## Overview

Displays results on the response component that have a 'text/plain' in the content type header.
Fixed #377 

### Demo

Exhibit A :-)
![image](https://user-images.githubusercontent.com/58787602/74924069-ddf8b600-53e2-11ea-8bcf-bc6724ca51d7.png)


## Testing Instructions

* Run this query: https://graph.microsoft.com/beta/me/calendars/$count
*  Find the results in the response component