### PR TITLE
Feature: clear history

### DIFF
--- a/src/app/services/actions/request-history-action-creators.ts
+++ b/src/app/services/actions/request-history-action-creators.ts
@@ -1,7 +1,11 @@
 import { Dispatch } from 'redux';
+
 import { IHistoryItem } from '../../../types/history';
-import { ADD_HISTORY_ITEM_SUCCESS, QUERY_GRAPH_SUCCESS,
-  REMOVE_HISTORY_ITEM_SUCCESS, VIEW_HISTORY_ITEM_SUCCESS } from '../redux-constants';
+import { removeHistoryData } from '../../views/sidebar/history/history-utils';
+import {
+  ADD_HISTORY_ITEM_SUCCESS, QUERY_GRAPH_SUCCESS,
+  REMOVE_HISTORY_ITEM_SUCCESS, VIEW_HISTORY_ITEM_SUCCESS
+} from '../redux-constants';
 
 export function addHistoryItem(response: IHistoryItem): any {
   return {
@@ -9,12 +13,19 @@ export function addHistoryItem(response: IHistoryItem): any {
     response,
   };
 }
-export function removeHistoryItem(response: IHistoryItem): any {
-  return {
-    type: REMOVE_HISTORY_ITEM_SUCCESS,
-    response,
+
+export function removeHistoryItem(response: IHistoryItem): Function {
+  return async (dispatch: Function) => {
+    return removeHistoryData(response)
+      .then(res => {
+        dispatch({
+          type: REMOVE_HISTORY_ITEM_SUCCESS,
+          response,
+        });
+      });
   };
 }
+
 export function viewHistoryItem(response: IHistoryItem): any {
   return {
     type: VIEW_HISTORY_ITEM_SUCCESS,

--- a/src/app/services/actions/request-history-action-creators.ts
+++ b/src/app/services/actions/request-history-action-creators.ts
@@ -14,13 +14,15 @@ export function addHistoryItem(response: IHistoryItem): any {
   };
 }
 
-export function removeHistoryItem(response: IHistoryItem): Function {
+export function removeHistoryItem(query: IHistoryItem): Function {
+
+  delete query.category;
   return async (dispatch: Function) => {
-    return removeHistoryData(response)
+    return removeHistoryData(query)
       .then(res => {
         dispatch({
           type: REMOVE_HISTORY_ITEM_SUCCESS,
-          response,
+          response: query,
         });
       });
   };

--- a/src/app/services/actions/request-history-action-creators.ts
+++ b/src/app/services/actions/request-history-action-creators.ts
@@ -1,36 +1,36 @@
-import { Dispatch } from 'redux';
 
 import { IHistoryItem } from '../../../types/history';
 import { removeHistoryData } from '../../views/sidebar/history/history-utils';
 import {
-  ADD_HISTORY_ITEM_SUCCESS, QUERY_GRAPH_SUCCESS,
-  REMOVE_HISTORY_ITEM_SUCCESS, VIEW_HISTORY_ITEM_SUCCESS
+  ADD_HISTORY_ITEM_SUCCESS,
+  REMOVE_HISTORY_ITEM_SUCCESS,
+  VIEW_HISTORY_ITEM_SUCCESS
 } from '../redux-constants';
 
-export function addHistoryItem(response: IHistoryItem): any {
+export function addHistoryItem(historyItem: IHistoryItem): any {
   return {
     type: ADD_HISTORY_ITEM_SUCCESS,
-    response,
+    response: historyItem,
   };
 }
 
-export function removeHistoryItem(query: IHistoryItem): Function {
+export function removeHistoryItem(historyItem: IHistoryItem): Function {
 
-  delete query.category;
+  delete historyItem.category;
   return async (dispatch: Function) => {
-    return removeHistoryData(query)
-      .then(res => {
+    return removeHistoryData(historyItem)
+      .then(() => {
         dispatch({
           type: REMOVE_HISTORY_ITEM_SUCCESS,
-          response: query,
+          response: historyItem,
         });
       });
   };
 }
 
-export function viewHistoryItem(response: IHistoryItem): any {
+export function viewHistoryItem(historyItem: IHistoryItem): any {
   return {
     type: VIEW_HISTORY_ITEM_SUCCESS,
-    response,
+    response: historyItem,
   };
 }

--- a/src/app/views/sidebar/Sidebar.styles.ts
+++ b/src/app/views/sidebar/Sidebar.styles.ts
@@ -29,6 +29,9 @@ export const sidebarStyles = (theme: ITheme) => {
     pullLeft: {
       float: 'left'
     },
+    pullRight: {
+      float: 'right'
+    },
 
     /* Group Headers */
 

--- a/src/app/views/sidebar/history/History.tsx
+++ b/src/app/views/sidebar/history/History.tsx
@@ -214,7 +214,7 @@ export class History extends Component<IHistoryProps, any> {
               calloutProps={{ gapSpace: 0 }}
               styles={{ root: { display: 'inline-block' } }}
             >
-              <span aria-labelledby={hostId} className={classes.queryContent}>
+              <span aria-describedby={hostId} className={classes.queryContent}>
                 {queryContent.replace(GRAPH_URL, '')}
               </span>
             </TooltipHost>
@@ -360,7 +360,7 @@ export class History extends Component<IHistoryProps, any> {
           onChange={(value) => this.searchValueChanged(value)}
         />
         <hr />
-        {groupedList.items && <DetailsList
+        {groupedList.items.length > 0 && <DetailsList
           className={classes.queryList}
           onRenderItemColumn={this.renderItemColumn}
           items={groupedList.items}

--- a/src/app/views/sidebar/history/History.tsx
+++ b/src/app/views/sidebar/history/History.tsx
@@ -17,7 +17,7 @@ import { GRAPH_URL } from '../../../services/graph-constants';
 import { parseSampleUrl } from '../../../utils/sample-url-generation';
 import { classNames } from '../../classnames';
 import { sidebarStyles } from '../Sidebar.styles';
-import { dynamicSort } from './history-utils';
+import { dynamicSort, removeHistoryData } from './history-utils';
 
 export class History extends Component<IHistoryProps, any> {
 
@@ -191,7 +191,7 @@ export class History extends Component<IHistoryProps, any> {
               iconProps: {
                 iconName: 'Delete'
               },
-              onClick: () => this.onDeleteQuery(item)
+              onClick: () => this.deleteQuery(item)
             },
           ];
 
@@ -227,20 +227,36 @@ export class History extends Component<IHistoryProps, any> {
     const classes = classNames(this.props);
 
     return (
-      <div aria-label={props.group!.name} onClick={this.onToggleCollapse(props)}>
-        <div className={classes.groupHeaderRow}>
-          <IconButton
-            className={`${classes.pullLeft} ${classes.groupHeaderRowIcon}`}
-            iconProps={{ iconName: props.group!.isCollapsed ? 'ChevronRightSmall' : 'ChevronDownSmall' }}
-            title={props.group!.isCollapsed ?
-              `Expand ${props.group!.name}` : `Collapse ${props.group!.name}`}
-            ariaLabel='expand collapse group'
-            onClick={() => this.onToggleCollapse(props)}
-          />
-          <div className={classes.groupTitle}>
-            <span>{props.group!.name}</span>
-            <span className={classes.headerCount}>({props.group!.count})</span>
+      <div aria-label={props.group!.name} style={
+        {
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center'
+        }}>
+        <div className={'col-md-10'}>
+          <div className={classes.groupHeaderRow} onClick={this.onToggleCollapse(props)}>
+            <IconButton
+              className={`${classes.pullLeft} ${classes.groupHeaderRowIcon}`}
+              iconProps={{ iconName: props.group!.isCollapsed ? 'ChevronRightSmall' : 'ChevronDownSmall' }}
+              title={props.group!.isCollapsed ?
+                `Expand ${props.group!.name}` : `Collapse ${props.group!.name}`}
+              ariaLabel='expand collapse group'
+              onClick={() => this.onToggleCollapse(props)}
+            />
+            <div className={classes.groupTitle}>
+              <span>{props.group!.name}</span>
+              <span className={classes.headerCount}>({props.group!.count})</span>
+            </div>
           </div>
+        </div>
+        <div className={'col-md-2'}>
+          <IconButton
+            className={`${classes.pullRight} ${classes.groupHeaderRowIcon}`}
+            iconProps={{ iconName: 'Delete' }}
+            title={`Delete requests in ${props.group!.name}`}
+            ariaLabel='delete group'
+            onClick={() => this.deleteCategoryHistory(props.group!.name)}
+          />
         </div>
       </div>
     );
@@ -257,9 +273,8 @@ export class History extends Component<IHistoryProps, any> {
     const queries = groupedList.items;
     const itemsToDelete = queries.filter((query: IHistoryItem) => query.category === category);
     itemsToDelete.forEach((item: IHistoryItem) => {
-      this.onDeleteQuery(item);
+      this.deleteQuery(item);
     });
-    console.log('delete history from ' + category);
   }
 
   private renderDetailsHeader() {
@@ -289,10 +304,12 @@ export class History extends Component<IHistoryProps, any> {
   }
 
 
-  private onDeleteQuery = (query: IHistoryItem) => {
+  private deleteQuery = (query: IHistoryItem) => {
     const { actions } = this.props;
     if (actions) {
+      delete query.category;
       actions.removeHistoryItem(query);
+      removeHistoryData(query);
     }
   }
 

--- a/src/app/views/sidebar/history/History.tsx
+++ b/src/app/views/sidebar/history/History.tsx
@@ -252,6 +252,16 @@ export class History extends Component<IHistoryProps, any> {
     };
   }
 
+  private deleteCategoryHistory = (category: string) => {
+    const { groupedList } = this.state;
+    const queries = groupedList.items;
+    const itemsToDelete = queries.filter((query: IHistoryItem) => query.category === category);
+    itemsToDelete.forEach((item: IHistoryItem) => {
+      this.onDeleteQuery(item);
+    });
+    console.log('delete history from ' + category);
+  }
+
   private renderDetailsHeader() {
     return (
       <div />

--- a/src/app/views/sidebar/history/History.tsx
+++ b/src/app/views/sidebar/history/History.tsx
@@ -263,7 +263,7 @@ export class History extends Component<IHistoryProps, any> {
             iconProps={{ iconName: 'Delete' }}
             title={`${messages['Delete requests']} : ${props.group!.name}`}
             ariaLabel='delete group'
-            onClick={() => this.deleteCategoryHistory(props.group!.name)}
+            onClick={() => this.deleteHistoryCategory(props.group!.name)}
           />
         </div>
       </div>
@@ -276,10 +276,9 @@ export class History extends Component<IHistoryProps, any> {
     };
   }
 
-  private deleteCategoryHistory = (category: string) => {
-    const { groupedList } = this.state;
-    const queries = groupedList.items;
-    const itemsToDelete = queries.filter((query: IHistoryItem) => query.category === category);
+  private deleteHistoryCategory = (category: string) => {
+    const { groupedList: { items } } = this.state;
+    const itemsToDelete = items.filter((query: IHistoryItem) => query.category === category);
     itemsToDelete.forEach((item: IHistoryItem) => {
       this.deleteQuery(item);
     });

--- a/src/app/views/sidebar/history/History.tsx
+++ b/src/app/views/sidebar/history/History.tsx
@@ -315,7 +315,6 @@ export class History extends Component<IHistoryProps, any> {
   private deleteQuery = async (query: IHistoryItem) => {
     const { actions } = this.props;
     if (actions) {
-      delete query.category;
       actions.removeHistoryItem(query);
     }
   }

--- a/src/app/views/sidebar/history/History.tsx
+++ b/src/app/views/sidebar/history/History.tsx
@@ -304,12 +304,11 @@ export class History extends Component<IHistoryProps, any> {
   }
 
 
-  private deleteQuery = (query: IHistoryItem) => {
+  private deleteQuery = async (query: IHistoryItem) => {
     const { actions } = this.props;
     if (actions) {
       delete query.category;
       actions.removeHistoryItem(query);
-      removeHistoryData(query);
     }
   }
 

--- a/src/app/views/sidebar/history/History.tsx
+++ b/src/app/views/sidebar/history/History.tsx
@@ -225,6 +225,14 @@ export class History extends Component<IHistoryProps, any> {
 
   public renderGroupHeader = (props: any): any => {
     const classes = classNames(this.props);
+    const {
+      intl: { messages },
+    }: any = this.props;
+
+    // tslint:disable
+    const expandText = messages['Expand'];
+    const collapseText = messages['Collapse'];
+    // tslint:enable
 
     return (
       <div aria-label={props.group!.name} style={
@@ -239,7 +247,7 @@ export class History extends Component<IHistoryProps, any> {
               className={`${classes.pullLeft} ${classes.groupHeaderRowIcon}`}
               iconProps={{ iconName: props.group!.isCollapsed ? 'ChevronRightSmall' : 'ChevronDownSmall' }}
               title={props.group!.isCollapsed ?
-                `Expand ${props.group!.name}` : `Collapse ${props.group!.name}`}
+                `${expandText} ${props.group!.name}` : `${collapseText} ${props.group!.name}`}
               ariaLabel='expand collapse group'
               onClick={() => this.onToggleCollapse(props)}
             />
@@ -253,7 +261,7 @@ export class History extends Component<IHistoryProps, any> {
           <IconButton
             className={`${classes.pullRight} ${classes.groupHeaderRowIcon}`}
             iconProps={{ iconName: 'Delete' }}
-            title={`Delete requests in ${props.group!.name}`}
+            title={`${messages['Delete requests']} : ${props.group!.name}`}
             ariaLabel='delete group'
             onClick={() => this.deleteCategoryHistory(props.group!.name)}
           />

--- a/src/app/views/sidebar/history/history-utils.ts
+++ b/src/app/views/sidebar/history/history-utils.ts
@@ -5,8 +5,8 @@ const historyStorage = localforage.createInstance({
   name: 'GE_V4'
 });
 
-export async function writeHistoryData(data: IHistoryItem) {
-  historyStorage.setItem(data.createdAt, data);
+export async function writeHistoryData(historyItem: IHistoryItem) {
+  historyStorage.setItem(historyItem.createdAt, historyItem);
 }
 
 export async function readHistoryData(): Promise<IHistoryItem[]> {
@@ -19,8 +19,8 @@ export async function readHistoryData(): Promise<IHistoryItem[]> {
   return historyData;
 }
 
-export const removeHistoryData = async (data: IHistoryItem) => {
-  await historyStorage.removeItem(data.createdAt);
+export const removeHistoryData = async (historyItem: IHistoryItem) => {
+  await historyStorage.removeItem(historyItem.createdAt);
   return true;
 };
 

--- a/src/app/views/sidebar/history/history-utils.ts
+++ b/src/app/views/sidebar/history/history-utils.ts
@@ -1,27 +1,28 @@
 import localforage from 'localforage';
 import { IHistoryItem } from '../../../../types/history';
-
-const key = 'history';
+const historyStorage = localforage.createInstance({
+  storeName: 'history',
+  name: 'GE_V4'
+});
 
 export async function writeHistoryData(data: IHistoryItem) {
-  const historyItems: IHistoryItem[] = await readHistoryData();
-  const items = [...historyItems, data];
-  localforage.setItem(key, items);
+  historyStorage.setItem(data.createdAt, data);
 }
 
 export async function readHistoryData(): Promise<IHistoryItem[]> {
-  const data: IHistoryItem[] = await localforage.getItem(key);
-  return data || [];
+  let historyData: IHistoryItem[] = [];
+  const keys = await historyStorage.keys();
+  for (const element of keys) {
+    const historyItem: IHistoryItem = await historyStorage.getItem(element);
+    historyData = [...historyData, historyItem];
+  }
+  return historyData;
 }
 
 export const removeHistoryData = async (data: IHistoryItem) => {
-  const historyItems: IHistoryItem[] = await readHistoryData();
-  const items = historyItems.filter((history: IHistoryItem) => history.createdAt !== data.createdAt);
-  await localforage.setItem(key, items);
-  return items.length;
+  await historyStorage.removeItem(data.createdAt);
+  return true;
 };
-
-export function clear() { localforage.clear(); }
 
 export function dynamicSort(property: string) {
   const column = property;

--- a/src/app/views/sidebar/history/history-utils.ts
+++ b/src/app/views/sidebar/history/history-utils.ts
@@ -14,11 +14,12 @@ export async function readHistoryData(): Promise<IHistoryItem[]> {
   return data || [];
 }
 
-export async function removeHistoryData(data: IHistoryItem) {
+export const removeHistoryData = async (data: IHistoryItem) => {
   const historyItems: IHistoryItem[] = await readHistoryData();
-  const items = historyItems.filter(history => history !== data);
-  localforage.setItem(key, items);
-}
+  const items = historyItems.filter((history: IHistoryItem) => history.createdAt !== data.createdAt);
+  await localforage.setItem(key, items);
+  return items.length;
+};
 
 export function clear() { localforage.clear(); }
 

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -267,5 +267,8 @@
   "Dark": "Dark",
   "Light": "Light",
   "High Contrast": "High Contrast",
-  "Auth": "Auth"
+  "Auth": "Auth",
+  "Collapse": "Collapse",
+  "Expand": "Expand",
+  "Delete requests": "Delete requests"
 }


### PR DESCRIPTION
## Overview
Adds a delete button on each section (Today, Yesterday, Older) that allows a user to delete all messages in the particular section.

Fixes a previously unknown bug where the items were not permanently deleted and were repopulated on reload

Fixes #354 

### Demo

![image](https://user-images.githubusercontent.com/58787602/75327613-c790a580-588d-11ea-955c-be7d08afb322.png)

### Notes

Previously ran queries before this update will not be shown

## Testing Instructions

* Run a query
* View it in the history section
* Click the button on the right of the Today section and notice all queries in the section are deleted
