### PR TITLE
Feature: context switching

### DIFF
--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -25,6 +25,7 @@ import { substituteTokens } from '../utils/token-helpers';
 import { appStyles } from './App.styles';
 import { Authentication } from './authentication';
 import { classNames } from './classnames';
+import { createShareLink } from './common/share';
 import { Banner } from './opt-in-out-banner';
 import { QueryResponse } from './query-response';
 import { QueryRunner } from './query-runner';
@@ -41,6 +42,7 @@ interface IAppProps {
   termsOfUse: boolean;
   graphExplorerMode: Mode;
   sidebarProperties: ISidebarProps;
+  sampleQuery: IQuery;
   actions: {
     addRequestHeader: Function;
     clearQueryStatus: Function;
@@ -269,8 +271,9 @@ class App extends Component<IAppProps, IAppState> {
 
   public render() {
     const classes = classNames(this.props);
-    const { graphExplorerMode, queryState, minimised, termsOfUse,
+    const { graphExplorerMode, queryState, minimised, termsOfUse, sampleQuery,
       actions, sidebarProperties, intl: { messages } }: any = this.props;
+    const query = createShareLink(sampleQuery);
     const sampleHeaderText = messages['Sample Queries'];
     // tslint:disable-next-line:no-string-literal
     const historyHeaderText = messages['History'];
@@ -384,7 +387,7 @@ class App extends Component<IAppProps, IAppState> {
                         <FormattedMessage id='To try the full features' />,
                         <a className={classes.links}
                           tabIndex={0}
-                          href='https://developer.microsoft.com/en-us/graph/graph-explorer' target='_blank'>
+                          href={query} target='_blank'>
                           <FormattedMessage id='full Graph Explorer' />.
                       </a>
                       </p>
@@ -401,7 +404,7 @@ class App extends Component<IAppProps, IAppState> {
 
                       <a className={classes.links}
                         tabIndex={0}
-                        href='https://developer.microsoft.com/en-us/graph/graph-explorer' target='_blank'>
+                        href={query} target='_blank'>
                         <FormattedMessage id='sign in' />.
                       </a>
                     </p>
@@ -473,7 +476,8 @@ const mapStateToProps = (state: any) => {
     receivedSampleQuery: state.sampleQuery,
     sidebarProperties: state.sidebarProperties,
     termsOfUse: state.termsOfUse,
-    minimised: !mobileScreen && !showSidebar
+    minimised: !mobileScreen && !showSidebar,
+    sampleQuery: state.sampleQuery,
   };
 };
 

--- a/src/app/views/common/share.ts
+++ b/src/app/views/common/share.ts
@@ -1,17 +1,17 @@
 import { IQuery } from '../../../types/query-runner';
 
 export const createShareLink = (sampleQuery: IQuery): string => {
-  const { origin, pathname } = window.location;
   const { sampleUrl, sampleBody, selectedVerb, selectedVersion } = sampleQuery;
   const url = new URL(sampleUrl);
   const graphUrl = url.origin;
+  const appUrl = 'https://developer.microsoft.com/graph/graph-explorer/preview';
   /**
    * To ensure backward compatibility the version is removed from the pathname.
    * V3 expects the request query param to not have the version number.
    */
   const graphUrlRequest = url.pathname.substr(6) + url.search;
   const requestBody = hashEncode(JSON.stringify(sampleBody));
-  return origin + pathname
+  return appUrl
     + '?request=' + graphUrlRequest
     + '&method=' + selectedVerb
     + '&version=' + selectedVersion

--- a/src/app/views/common/share.ts
+++ b/src/app/views/common/share.ts
@@ -1,0 +1,24 @@
+import { IQuery } from '../../../types/query-runner';
+
+export const createShareLink = (sampleQuery: IQuery): string => {
+  const { origin, pathname } = window.location;
+  const { sampleUrl, sampleBody, selectedVerb, selectedVersion } = sampleQuery;
+  const url = new URL(sampleUrl);
+  const graphUrl = url.origin;
+  /**
+   * To ensure backward compatibility the version is removed from the pathname.
+   * V3 expects the request query param to not have the version number.
+   */
+  const graphUrlRequest = url.pathname.substr(6) + url.search;
+  const requestBody = hashEncode(JSON.stringify(sampleBody));
+  return origin + pathname
+    + '?request=' + graphUrlRequest
+    + '&method=' + selectedVerb
+    + '&version=' + selectedVersion
+    + '&GraphUrl=' + graphUrl
+    + '&requestBody=' + requestBody;
+};
+
+const hashEncode = (requestBody: string): string => {
+  return btoa(requestBody);
+};

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -1,4 +1,4 @@
-import { DefaultButton, FontSizes, IconButton, Modal, Pivot, PivotItem, PrimaryButton } from 'office-ui-fabric-react';
+import { DefaultButton, FontSizes, IconButton, Modal, Pivot, PrimaryButton } from 'office-ui-fabric-react';
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
 import React, { Component } from 'react';
 import { injectIntl } from 'react-intl';
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 
 import { IQueryResponseProps, IQueryResponseState } from '../../../types/query-response';
 import { copy } from '../common/copy';
+import { createShareLink } from '../common/share';
 import { getPivotItems } from './pivot-items/pivot-items';
 import './query-response.scss';
 
@@ -19,8 +20,8 @@ class QueryResponse extends Component<IQueryResponseProps, IQueryResponseState> 
     };
   }
 
-  public shouldComponentUpdate(nextProps: IQueryResponseProps) {
-    return nextProps.graphResponse !== this.props.graphResponse;
+  public shouldComponentUpdate(nextProps: IQueryResponseProps, nextState: IQueryResponseState) {
+    return nextProps.graphResponse !== this.props.graphResponse || nextState !== this.state;
   }
 
   public handleCopy = () => {
@@ -29,7 +30,8 @@ class QueryResponse extends Component<IQueryResponseProps, IQueryResponseState> 
   }
 
   public handleShareQuery = () => {
-    const query = this.generateShareQueryParams();
+    const { sampleQuery } = this.props;
+    const query = createShareLink(sampleQuery);
     this.setState({ query });
     this.toggleShareQueryDialogState();
   }
@@ -40,30 +42,6 @@ class QueryResponse extends Component<IQueryResponseProps, IQueryResponseState> 
 
   public toggleModal = () => {
     this.setState({ showModal: !this.state.showModal });
-  }
-
-  private generateShareQueryParams = (): string => {
-    const { sampleQuery: { sampleBody, sampleUrl, selectedVerb, selectedVersion } } = this.props;
-    const { origin, pathname } = window.location;
-    const url = new URL(sampleUrl);
-    const graphUrl = url.origin;
-    /**
-     * To ensure backward compatibility the version is removed from the pathname.
-     * V3 expects the request query param to not have the version number.
-     */
-    const graphUrlRequest = url.pathname.substr(6) + url.search;
-    const requestBody = this.hashEncode(JSON.stringify(sampleBody));
-
-    return origin + pathname
-      + '?request=' + graphUrlRequest
-      + '&method=' + selectedVerb
-      + '&version=' + selectedVersion
-      + '&GraphUrl=' + graphUrl
-      + '&requestBody=' + requestBody;
-  }
-
-  private hashEncode(requestBody: string): string {
-    return btoa(requestBody);
   }
 
   public render() {

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -32,8 +32,8 @@ class QueryResponse extends Component<IQueryResponseProps, IQueryResponseState> 
 
   public handleShareQuery = () => {
     const { sampleQuery } = this.props;
-    const query = createShareLink(sampleQuery);
-    this.setState({ query });
+    const shareableLink = createShareLink(sampleQuery);
+    this.setState({ query: shareableLink });
     this.toggleShareQueryDialogState();
   }
 


### PR DESCRIPTION
## Overview

Carries over the context of the query from the try-it experience to the full GE experience.
Fixes #356 

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Does not consider whether someone is logged in or not

## Testing Instructions

* Open GE in try it mode
* Create a request
* click on the link in the banner
* Notice the request you ran is opened in the full experience