### PR TITLE
Fix: stops showing authentication text when minimised

### DIFF
--- a/src/app/views/authentication/Authentication.tsx
+++ b/src/app/views/authentication/Authentication.tsx
@@ -49,7 +49,7 @@ export class Authentication extends Component<IAuthenticationProps, { loginInPro
           :
           mobileScreen ? showSignInButtonOrProfile(tokenPresent, mobileScreen, this.signIn, minimised) :
             <>
-              {!tokenPresent && graphExplorerMode === Mode.Complete && showUnAuthenticatedText(classes)}
+              {!tokenPresent && graphExplorerMode === Mode.Complete && !minimised && showUnAuthenticatedText(classes)}
               <span><br />{showSignInButtonOrProfile(tokenPresent, mobileScreen, this.signIn, minimised)}<br /> </span>
             </>}
       </>


### PR DESCRIPTION
## Overview

Authentication text was showing when the minimise menu was hit.