### PR TITLE
Feature: Filter categories

### DIFF
--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -52,7 +52,8 @@ export class SampleQueries extends Component<ISampleQueriesProps, any> {
 
     const filteredSamples = queries.filter((sample: any) => {
       const name = sample.humanName.toLowerCase();
-      return name.toLowerCase().includes(keyword);
+      const category = sample.category.toLowerCase();
+      return name.includes(keyword) || category.includes(keyword);
     });
 
     this.generateSamples(filteredSamples);


### PR DESCRIPTION
## Overview
Added the category to the items to help filter requests in the sidebar.
We will now be able to filter the requests in a category.

Fixed #434 

### Demo

![image](https://user-images.githubusercontent.com/58787602/76541171-3841df80-6494-11ea-83b4-7def88b1a2d9.png)

### Notes

N/A

## Testing Instructions

* Search a category like one drive
* Notice all the onedrive items are displayed