### PR TITLE
Get instrumentation key from window object

### DIFF
--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -57,7 +57,7 @@ class Telemetry implements ITelemetry {
   }
 
   private getInstrumentationKey() {
-    return process.env.REACT_APP_INSTRUMENTATION_KEY || '';
+    return (window as any)['InstrumentationKey'] || '';
   }
 }
 

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -57,7 +57,7 @@ class Telemetry implements ITelemetry {
   }
 
   private getInstrumentationKey() {
-    return (window as any)['InstrumentationKey'] || '';
+    return (window as any).InstrumentationKey || '';
   }
 }
 


### PR DESCRIPTION
## Overview

Gets the AI/AM instrumentation key from the window object.

## Notes
Getting the instrumentation key is useful for automatic builds and we are building releases manually on the dev's machine.The build process will pick up the env variable and use it in the release. This has the unintended consequence of having wrong variables in the release. This PR, gets the InstrumentationKey variable from window object.