### PR TITLE
Fix: profile misaligned

### DIFF
--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -380,6 +380,7 @@ class App extends Component<IAppProps, IAppState> {
                     <span style={{
                       position: 'absolute',
                       marginLeft: '70%',
+                      marginTop: '2.5%'
                     }}>
 
                       <Authentication />

--- a/src/app/views/authentication/profile/Profile.tsx
+++ b/src/app/views/authentication/profile/Profile.tsx
@@ -146,7 +146,7 @@ export class Profile extends Component<IProfileProps, IProfileState> {
       },
     };
 
-    const defaultSize = minimised ? PersonaSize.size32 : PersonaSize.size72;
+    const defaultSize = minimised ? PersonaSize.size32 : PersonaSize.size48;
 
     const profileProperties = {
       persona,
@@ -163,20 +163,26 @@ export class Profile extends Component<IProfileProps, IProfileState> {
           </ActionButton>
         }
 
-        {!mobileScreen && graphExplorerMode === Mode.TryIt ?
-          <ActionButton ariaLabel='profile' role='button' menuProps={menuProperties}>
-            {this.showProfileComponent(profileProperties)}
-          </ActionButton> : this.showProfileComponent(profileProperties)}
+        {!mobileScreen && this.showProfileComponent(profileProperties, graphExplorerMode, menuProperties)}
       </div>
     );
   }
 
-  private showProfileComponent(profileProperties: any): React.ReactNode {
-    return <Persona
+  private showProfileComponent(profileProperties: any, graphExplorerMode: Mode, menuProperties: any): React.ReactNode {
+
+    const persona = <Persona
       {...profileProperties.persona}
       size={profileProperties.size}
       styles={profileProperties.styles}
       hidePersonaDetails={profileProperties.hidePersonaDetails} />;
+
+      if (graphExplorerMode === Mode.TryIt) {
+        return <ActionButton ariaLabel='profile' role='button' menuProps={menuProperties}>
+            {persona}
+          </ActionButton>;
+      }
+
+      return persona;
   }
 }
 


### PR DESCRIPTION
## Overview

Removes duplicate profiles displayed when the viewport is reduced.

Fixes #438 

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Log in to graph explorer
* Resize the browser till it gets to mobile view, 
* Notice there is only one profile picture present