### PR TITLE
Task: fix faulty url encoding in the url

### DIFF
--- a/src/app/views/common/share.ts
+++ b/src/app/views/common/share.ts
@@ -26,12 +26,9 @@ export const createShareLink = (sampleQuery: IQuery, authenticated?: boolean): s
   const graphUrlRequest = requestUrl + search;
   const requestBody = hashEncode(JSON.stringify(sampleBody));
 
-  let shareLink = `${appUrl}
-    ?request=${graphUrlRequest}
-    &method=${selectedVerb}
-    &version=${queryVersion}
-    &GraphUrl=${graphUrl}
-    &requestBody=${requestBody}`;
+  let shareLink =
+  // tslint:disable-next-line:max-line-length
+  `${appUrl}?request=${graphUrlRequest}&method=${selectedVerb}&version=${queryVersion}&GraphUrl=${graphUrl}&requestBody=${requestBody}`;
 
   if (authenticated) {
     const sessionId = getSessionId();

--- a/src/app/views/query-runner/QueryInput.tsx
+++ b/src/app/views/query-runner/QueryInput.tsx
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 
+import { Mode } from '../../../types/enums';
 import { IQueryInputProps } from '../../../types/query-runner';
 import { getStyleFor } from '../../utils/badge-color';
 import SubmitButton from '../common/submit-button/SubmitButton';
@@ -45,6 +46,8 @@ export class QueryInput extends Component<IQueryInputProps, any> {
       selectedVersion,
       sampleUrl,
       submitting,
+      mode,
+      authenticated
     } = this.props;
 
     const {
@@ -57,6 +60,8 @@ export class QueryInput extends Component<IQueryInputProps, any> {
       background: getStyleFor(selectedVerb),
     };
 
+    const httpMethodsToDisplay = (mode === Mode.TryIt && !authenticated ) ? [httpMethods[0]] : httpMethods;
+
     return (
       <div className='row'>
         <div className='col-sm-3 col-md-2'>
@@ -64,7 +69,7 @@ export class QueryInput extends Component<IQueryInputProps, any> {
             ariaLabel='Query sample option'
             role='listbox'
             selectedKey={selectedVerb}
-            options={httpMethods}
+            options={httpMethodsToDisplay}
             styles={verbSelector}
             onChange={(event, method) => handleOnMethodChange(method)}
           />
@@ -111,6 +116,8 @@ function mapStateToProps(state: any) {
     selectedVersion: state.sampleQuery.selectedVersion,
     submitting: state.isLoadingData,
     theme: state.theme,
+    mode: state.graphExplorerMode,
+    authenticated: !!state.authToken
   };
 }
 

--- a/src/types/query-runner.ts
+++ b/src/types/query-runner.ts
@@ -37,6 +37,8 @@ export interface IQueryInputProps {
   selectedVersion: string;
   sampleUrl: string;
   submitting: boolean;
+  authenticated: boolean;
+  mode: Mode;
   intl: {
     message: object;
   };


### PR DESCRIPTION
## Overview

The url generated had spaces inside it and thus producing a faulty url.

e.g.
`https://developer.microsoft.com/en-GB/graph/graph-explorer/preview%20%20%20%20?request=users%20%20%20%20&method=GET%20%20%20%20&version=v1.0%20%20%20%20&GraphUrl=https://graph.microsoft.com%20%20%20%20&requestBody=IiI=`
