### PR TITLE
Fix: responsive pivot items

### DIFF
--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -27,6 +27,7 @@ class QueryResponse extends Component<IQueryResponseProps, IQueryResponseState> 
 
   public shouldComponentUpdate(nextProps: IQueryResponseProps, nextState: IQueryResponseState) {
     return nextProps.graphResponse !== this.props.graphResponse
+      || nextProps.mobileScreen !== this.props.mobileScreen
       || nextState !== this.state
       || nextProps.theme !== this.props.theme;
   }
@@ -60,14 +61,18 @@ class QueryResponse extends Component<IQueryResponseProps, IQueryResponseState> 
     }: any = this.props;
 
     const { showShareQueryDialog, query, showModal } = this.state;
-    const { graphResponse, mode } = this.props;
+    const { graphResponse, mode, mobileScreen } = this.props;
 
     if (graphResponse) {
       body = graphResponse.body;
       headers = graphResponse.headers;
     }
 
-    const pivotItems = getPivotItems(messages, body, verb, mode, headers);
+    const pivotProperties = {
+      messages, body, verb, mode, headers, mobileScreen
+    };
+
+    const pivotItems = getPivotItems(pivotProperties);
 
     return (
       <div>
@@ -174,7 +179,8 @@ function mapStateToProps(state: any) {
     theme: state.theme,
     mode: state.graphExplorerMode,
     scopes: state.scopes.data,
-    sampleQuery: state.sampleQuery
+    sampleQuery: state.sampleQuery,
+    mobileScreen: !!state.sidebarProperties.mobileScreen
   };
 }
 

--- a/src/app/views/query-response/pivot-items/pivot-items.tsx
+++ b/src/app/views/query-response/pivot-items/pivot-items.tsx
@@ -10,12 +10,9 @@ import AdaptiveCard from '../adaptive-cards/AdaptiveCard';
 import { darkThemeHostConfig, lightThemeHostConfig } from '../adaptive-cards/AdaptiveHostConfig';
 import { Snippets } from '../snippets';
 
-export const getPivotItems = (messages: any,
-  body: any,
-  verb: string,
-  mode: Mode,
-  headers: any) => {
+export const getPivotItems = (properties: any) => {
 
+  const { headers, body, verb, messages, mobileScreen, mode } = properties;
   const resultComponent = displayResultComponent(headers, body, verb);
 
   const pivotItems = [
@@ -23,14 +20,14 @@ export const getPivotItems = (messages: any,
       key='response-preview'
       ariaLabel='Response Preview'
       itemIcon='Reply'
-      headerText={messages['Response Preview']}
+      headerText={(mobileScreen) ? '' : messages['Response Preview']}
     >
       {resultComponent}
     </PivotItem>,
     <PivotItem
       key='response-headers'
       ariaLabel='Response Headers'
-      headerText={messages['Response Headers']}
+      headerText={(mobileScreen) ? '' : messages['Response Headers']}
       itemIcon='FileComment'
     >
       {headers && <div><IconButton style={{ float: 'right', zIndex: 1 }} iconProps={{
@@ -45,7 +42,7 @@ export const getPivotItems = (messages: any,
       <PivotItem
         key='adaptive-cards'
         ariaLabel='Adaptive Cards'
-        headerText={messages['Adaptive Cards']}
+        headerText={(mobileScreen) ? '' : messages['Adaptive Cards']}
         itemIcon='ContactCard'
       >
         <ThemeContext.Consumer >
@@ -63,7 +60,7 @@ export const getPivotItems = (messages: any,
       <PivotItem
         key='code-snippets'
         ariaLabel='Code Snippets'
-        headerText={messages.Snippets}
+        headerText={(mobileScreen) ? '' : messages.Snippets}
         itemIcon='PasteAsCode'
       >
         <Snippets />

--- a/src/app/views/query-response/pivot-items/pivot-items.tsx
+++ b/src/app/views/query-response/pivot-items/pivot-items.tsx
@@ -22,6 +22,7 @@ export const getPivotItems = (messages: any,
     <PivotItem
       key='response-preview'
       ariaLabel='Response Preview'
+      itemIcon='Reply'
       headerText={messages['Response Preview']}
     >
       {resultComponent}
@@ -30,6 +31,7 @@ export const getPivotItems = (messages: any,
       key='response-headers'
       ariaLabel='Response Headers'
       headerText={messages['Response Headers']}
+      itemIcon='FileComment'
     >
       {headers && <div><IconButton style={{ float: 'right', zIndex: 1 }} iconProps={{
         iconName: 'copy',
@@ -44,6 +46,7 @@ export const getPivotItems = (messages: any,
         key='adaptive-cards'
         ariaLabel='Adaptive Cards'
         headerText={messages['Adaptive Cards']}
+        itemIcon='ContactCard'
       >
         <ThemeContext.Consumer >
           {(theme) => (
@@ -61,6 +64,7 @@ export const getPivotItems = (messages: any,
         key='code-snippets'
         ariaLabel='Code Snippets'
         headerText={messages.Snippets}
+        itemIcon='PasteAsCode'
       >
         <Snippets />
       </PivotItem>

--- a/src/app/views/query-runner/request/Request.tsx
+++ b/src/app/views/query-runner/request/Request.tsx
@@ -22,6 +22,7 @@ export class Request extends Component<IRequestComponent, any> {
       handleOnEditorChange,
       sampleBody,
       mode,
+      mobileScreen,
       intl: { messages },
     }: any = this.props;
 
@@ -29,7 +30,7 @@ export class Request extends Component<IRequestComponent, any> {
       <PivotItem
         key='request-body'
         itemIcon='Send'
-        headerText={messages['request body']}>
+        headerText={(mobileScreen) ? '' : messages['request body']}>
         <Monaco
           body={sampleBody}
           onChange={(value) => handleOnEditorChange(value)} />
@@ -37,13 +38,13 @@ export class Request extends Component<IRequestComponent, any> {
       <PivotItem
         key='request-header'
         itemIcon='FileComment'
-        headerText={messages['request header']}>
+        headerText={(mobileScreen) ? '' : messages['request header']}>
         <RequestHeaders />
       </PivotItem>,
       <PivotItem
         key='permissions'
         itemIcon='AzureKeyVault'
-        headerText={messages['modify permissions']}>
+        headerText={(mobileScreen) ? '' : messages['modify permissions']}>
         <Permission />
       </PivotItem>
     ];
@@ -53,7 +54,7 @@ export class Request extends Component<IRequestComponent, any> {
         <PivotItem
           key='auth'
           itemIcon='AuthenticatorApp'
-          headerText={messages['Access Token']}>
+          headerText={(mobileScreen) ? '' : messages['Access Token']}>
           <Auth />
         </PivotItem>
       );
@@ -82,6 +83,7 @@ function mapStateToProps(state: any) {
     mode: state.graphExplorerMode,
     sampleBody: state.sampleQuery.sampleBody,
     theme: state.theme,
+    mobileScreen: !!state.sidebarProperties.mobileScreen
   };
 }
 

--- a/src/app/views/query-runner/request/Request.tsx
+++ b/src/app/views/query-runner/request/Request.tsx
@@ -28,6 +28,7 @@ export class Request extends Component<IRequestComponent, any> {
     const pivotItems = [
       <PivotItem
         key='request-body'
+        itemIcon='Send'
         headerText={messages['request body']}>
         <Monaco
           body={sampleBody}
@@ -35,11 +36,13 @@ export class Request extends Component<IRequestComponent, any> {
       </PivotItem>,
       <PivotItem
         key='request-header'
+        itemIcon='FileComment'
         headerText={messages['request header']}>
         <RequestHeaders />
       </PivotItem>,
       <PivotItem
         key='permissions'
+        itemIcon='AzureKeyVault'
         headerText={messages['modify permissions']}>
         <Permission />
       </PivotItem>
@@ -49,6 +52,7 @@ export class Request extends Component<IRequestComponent, any> {
       pivotItems.push(
         <PivotItem
           key='auth'
+          itemIcon='AuthenticatorApp'
           headerText={messages['Access Token']}>
           <Auth />
         </PivotItem>

--- a/src/types/query-response.ts
+++ b/src/types/query-response.ts
@@ -18,6 +18,7 @@ export interface IQueryResponseProps {
   actions: {
     getConsent: Function;
   };
+  mobileScreen: boolean;
 }
 
 export interface IQueryResponseState {


### PR DESCRIPTION
## Overview

On smaller screens, the view of the components (request/response) is altered.

Fixes #450 

### Demo
Desktop:
![image](https://user-images.githubusercontent.com/58787602/77627939-bacca380-6f58-11ea-8462-b21bd77103cf.png)

Mobile:
![image](https://user-images.githubusercontent.com/58787602/77628175-d9cb3580-6f58-11ea-9a56-470cc7ff054b.png)




### Notes

There is currently an open issue on the [fluent ui repository](https://github.com/microsoft/fluentui/issues/4066) to help users sort this out. Hence scrolling horizontally or having a behaviour similar to an [overflowing command bar](https://developer.microsoft.com/en-us/fabric#/controls/web/commandbar) is not feasible at the moment. 

This current implementation utilises an easier idea that the user will have interacted with the desktop version of GE before going mobile and so the icons will make things easier to find and remember.

## Testing Instructions

* Minimise your screen to mobile size
* Notice the display changes to icons only