### PR TITLE
Feature: Add icon on auth-required queries

### DIFF
--- a/src/app/views/sidebar/Sidebar.styles.ts
+++ b/src/app/views/sidebar/Sidebar.styles.ts
@@ -73,7 +73,6 @@ export const sidebarStyles = (theme: ITheme) => {
     queryRow: {
       background: 'inherit',
       lineHeight: '100%',
-      width: '80%',
       fontSize: FontSizes.medium,
       borderBottom: '1px solid ' + theme.palette.neutralLight,
       color: theme.palette.black,
@@ -82,9 +81,9 @@ export const sidebarStyles = (theme: ITheme) => {
           background: theme.palette.neutralLight,
         },
       },
+      marginLeft: '-5%',
     },
     queryContent: {
-      display: 'table-cell',
       float: 'left',
       textAlign: 'left',
     },
@@ -107,7 +106,6 @@ export const sidebarStyles = (theme: ITheme) => {
       minWidth: '55px'
     },
     docLink: {
-      display: 'table-cell',
       float: 'right',
       verticalAlign: 'center',
       marginTop: '-7.5%',

--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -102,50 +102,55 @@ export class SampleQueries extends Component<ISampleQueriesProps, any> {
 
   public renderItemColumn = (item: any, index: number | undefined, column: IColumn | undefined) => {
     const classes = classNames(this.props);
+    const {
+      tokenPresent,
+      intl: { messages },
+    }: any = this.props;
 
     if (column) {
       const queryContent = item[column.fieldName as keyof any] as string;
 
       switch (column.key) {
         case 'authRequiredIcon':
-          if (item.method !== 'GET') {
+          if (item.method !== 'GET' && !tokenPresent) {
+            const signInText = messages['Sign In to try this sample'];
             return <TooltipHost
+              tooltipProps={{
+                onRenderContent: () => <div style={{ paddingBottom: 3 }}>
+                  <FormattedMessage id={'Sign In to try this sample'} /></div>
+              }}
+              id={getId()}
+              calloutProps={{ gapSpace: 0 }}
+              styles={{ root: { display: 'inline-block' } }}
+            >
+              <IconButton
+                className={classes.docLink}
+                iconProps={{ iconName: 'Lock' }}
+                title={signInText}
+                ariaLabel={signInText}
+              />
+            </TooltipHost>;
+          }
+          return null;
+
+        case 'button':
+          return <TooltipHost
             tooltipProps={{
               onRenderContent: () => <div style={{ paddingBottom: 3 }}>
-                <FormattedMessage id={'Sign In to try this sample'} /></div>
+                {item.docLink}</div>
             }}
             id={getId()}
             calloutProps={{ gapSpace: 0 }}
             styles={{ root: { display: 'inline-block' } }}
           >
             <IconButton
-              className={classes.docLink}
-              iconProps={{ iconName: 'Lock' }}
-              title='Sign In to try this sample'
-              ariaLabel='Sign In to try this sample'
+              style={{ marginTop: '-7.5%' }}
+              iconProps={{ iconName: 'NavigateExternalInline' }}
+              title={item.docLink}
+              ariaLabel={item.docLink}
+              onClick={(event) => this.onDocumentationLinkClicked(event, item)}
             />
           </TooltipHost>;
-          }
-          return null;
-
-        case 'button':
-          return <TooltipHost
-          tooltipProps={{
-            onRenderContent: () => <div style={{ paddingBottom: 3 }}>
-              {item.docLink}</div>
-          }}
-          id={getId()}
-          calloutProps={{ gapSpace: 0 }}
-          styles={{ root: { display: 'inline-block' } }}
-        >
-          <IconButton
-            style={{marginTop: '-7.5%'}}
-            iconProps={{ iconName: 'NavigateExternalInline' }}
-            title={item.docLink}
-            ariaLabel={item.docLink}
-            onClick={(event) => this.onDocumentationLinkClicked(event, item)}
-          />
-        </TooltipHost>;
 
         case 'method':
           return <TooltipHost

--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -100,41 +100,60 @@ export class SampleQueries extends Component<ISampleQueriesProps, any> {
     });
   }
 
-  public getToolTipContent(item: any, queryContent: any) {
-    let selectionDisabled = false;
-
-    if (!this.props.tokenPresent && item.method !== 'GET') {
-      selectionDisabled = true;
-    }
-
-    return selectionDisabled ? <FormattedMessage id={'Sign In to try this sample'} /> : queryContent;
-
-  }
-
   public renderItemColumn = (item: any, index: number | undefined, column: IColumn | undefined) => {
     const classes = classNames(this.props);
-    const hostId: string = getId('tooltipHost');
 
     if (column) {
       const queryContent = item[column.fieldName as keyof any] as string;
 
-      const toolTipContent = this.getToolTipContent(item, queryContent);
-
       switch (column.key) {
+        case 'authRequiredIcon':
+          if (item.method !== 'GET') {
+            return <TooltipHost
+            tooltipProps={{
+              onRenderContent: () => <div style={{ paddingBottom: 3 }}>
+                <FormattedMessage id={'Sign In to try this sample'} /></div>
+            }}
+            id={getId()}
+            calloutProps={{ gapSpace: 0 }}
+            styles={{ root: { display: 'inline-block' } }}
+          >
+            <IconButton
+              className={classes.docLink}
+              iconProps={{ iconName: 'Lock' }}
+              title='Sign In to try this sample'
+              ariaLabel='Sign In to try this sample'
+            />
+          </TooltipHost>;
+          }
+          return null;
 
         case 'button':
-          return <IconButton
-            className={classes.docLink}
+          return <TooltipHost
+          tooltipProps={{
+            onRenderContent: () => <div style={{ paddingBottom: 3 }}>
+              {item.docLink}</div>
+          }}
+          id={getId()}
+          calloutProps={{ gapSpace: 0 }}
+          styles={{ root: { display: 'inline-block' } }}
+        >
+          <IconButton
+            style={{marginTop: '-7.5%'}}
             iconProps={{ iconName: 'NavigateExternalInline' }}
             title={item.docLink}
             ariaLabel={item.docLink}
             onClick={(event) => this.onDocumentationLinkClicked(event, item)}
-          />;
+          />
+        </TooltipHost>;
 
         case 'method':
           return <TooltipHost
-            tooltipProps={{ onRenderContent: () => <div style={{ paddingBottom: 3 }}>{toolTipContent}</div> }}
-            id={hostId}
+            tooltipProps={{
+              onRenderContent: () => <div style={{ paddingBottom: 3 }}>
+                {queryContent}</div>
+            }}
+            id={getId()}
             calloutProps={{ gapSpace: 0 }}
             styles={{ root: { display: 'inline-block' } }}
           >
@@ -146,8 +165,11 @@ export class SampleQueries extends Component<ISampleQueriesProps, any> {
         default:
           return <span aria-label={queryContent}>
             <TooltipHost
-              tooltipProps={{ onRenderContent: () => <div style={{ paddingBottom: 3 }}>{toolTipContent}</div> }}
-              id={hostId}
+              tooltipProps={{
+                onRenderContent: () => <div style={{ paddingBottom: 3 }}>
+                  {item.method} <FormattedMessage id={queryContent} /></div>
+              }}
+              id={getId()}
               calloutProps={{ gapSpace: 0 }}
               styles={{ root: { display: 'inline-block' } }}
             >
@@ -238,6 +260,7 @@ export class SampleQueries extends Component<ISampleQueriesProps, any> {
 
     const { groupedList } = this.state;
     const columns = [
+      { key: 'authRequiredIcon', name: '', fieldName: 'authRequiredIcon', minWidth: 14, maxWidth: 15 },
       { key: 'method', name: '', fieldName: 'method', minWidth: 20, maxWidth: 50 },
       { key: 'category', name: '', fieldName: 'humanName', minWidth: 105, maxWidth: 205 },
       { key: 'button', name: '', fieldName: 'button', minWidth: 15, maxWidth: 15, },


### PR DESCRIPTION
## Overview
Fixes #406 

- [x] Add the key icon next to all samples queries that require login before a user can run them

- [x] When you hover over the key icon, the tooltip should be "Login to run this request"

- [x] When you hover over the sample query, the name of the sample query should be shown in full in the tooltip and the request option e.g. "GET My Profile"

- [x] When you hover over the Documentation link the tooltip should be the documentation link.

### Demo

![image](https://user-images.githubusercontent.com/58787602/77639639-19e6e400-6f6a-11ea-82a5-2d8bb4439ccc.png)


### Notes

"Login to run this request" changes to the already localized "Sign In to try this sample"
A key icon is not available in [the list of fabric icons](https://developer.microsoft.com/en-us/fabric#/styles/web/icons) however a Lock icon makes a lot of sense in its place

## Testing Instructions

* Hover over previously mentioned elements to see the tooltips