### PR TITLE
Feature: add permission consent tip

### DIFF
--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -481,7 +481,13 @@ class App extends Component<IAppProps, IAppState> {
                       {`- ${queryState.duration}`}<FormattedMessage id='milliseconds' />
                     </>}
 
-                    {queryState.status === 403 && <>. <FormattedMessage id='consent to scopes' /> </>}
+                    {queryState.status === 403 && <>.
+                      <FormattedMessage id='consent to scopes' />
+                      <span style={{ fontWeight: 600 }}>
+                        <FormattedMessage id='modify permissions' />
+                      </span>
+                      <FormattedMessage id='tab' />
+                    </>}
 
                   </MessageBar>
                 )}

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -481,6 +481,8 @@ class App extends Component<IAppProps, IAppState> {
                       {`- ${queryState.duration}`}<FormattedMessage id='milliseconds' />
                     </>}
 
+                    {queryState.status === 403 && <>. <FormattedMessage id='consent to scopes' /> </>}
+
                   </MessageBar>
                 )}
                 {termsOfUse && (

--- a/src/app/views/query-runner/request/permissions/Permission.styles.ts
+++ b/src/app/views/query-runner/request/permissions/Permission.styles.ts
@@ -17,6 +17,10 @@ export const permissionStyles = (theme: ITheme) => {
       fontWeight: 'bold',
       marginBottom: 5
     },
+    permissionText: {
+      fontSize: FontSizes.small,
+      marginBottom: 5
+    },
     toolTipHost: {
       root: {
         display:

--- a/src/app/views/query-runner/request/permissions/Permission.tsx
+++ b/src/app/views/query-runner/request/permissions/Permission.tsx
@@ -11,7 +11,7 @@ import {
   TooltipHost
 } from 'office-ui-fabric-react';
 import React, { useEffect, useState } from 'react';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, injectIntl } from 'react-intl';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { getAuthTokenSuccess, getConsentedScopesSuccess } from '../../../../services/actions/auth-action-creators';
 import { acquireNewAccessToken } from '../../../../services/graph-client/msal-service';
@@ -35,23 +35,46 @@ function Permission(props: any) {
   const consentedScopes: string[] = useSelector((state: any) => state.consentedScopes);
   const [permissions, setPermissions] = useState([]);
   const [loading, setLoading] = useState(false);
+  const {
+    intl: { messages },
+  }: any = props;
 
-  const columns = [
-    { key: 'value', name: 'Name', fieldName: 'value', minWidth: 100, maxWidth: 150 },
-    {
-      key: 'consentDisplayName', name: 'Function', fieldName: 'consentDisplayName', isResizable: true,
-      minWidth: 150, maxWidth: 200
-    },
-    {
-      key: 'consentDescription', name: 'Description', fieldName: 'consentDescription', isResizable: true,
-      minWidth: 200, maxWidth: 300
-    },
-    { key: 'isAdmin', name: 'Admin Consent', fieldName: 'isAdmin', minWidth: 100, maxWidth: 200 }
-  ];
+  const columns = [{
+    key: 'value',
+    name: messages.Permission,
+    fieldName: 'value',
+    minWidth: 100,
+    maxWidth: 150,
+    isResizable: true
+  },
+  {
+    key: 'consentDisplayName',
+    name: messages['Display string'],
+    fieldName: 'consentDisplayName',
+    isResizable: true,
+    minWidth: 150,
+    maxWidth: 200
+  },
+  {
+    key: 'consentDescription',
+    name: messages.Description,
+    fieldName: 'consentDescription',
+    isResizable: true,
+    minWidth: 200,
+    maxWidth: 300
+  },
+  {
+    key: 'isAdmin',
+    name: messages['Admin consent required'],
+    fieldName: 'isAdmin',
+    minWidth: 100,
+    maxWidth: 200
+  }
+];
 
   if (accessToken) {
     columns.push(
-      { key: 'consented', name: 'Status', fieldName: 'consented', minWidth: 100, maxWidth: 200 }
+      { key: 'consented', name: messages.Status, fieldName: 'consented', minWidth: 100, maxWidth: 200 }
     );
   }
 
@@ -96,9 +119,13 @@ function Permission(props: any) {
 
         case 'isAdmin':
           if (item.isAdmin) {
-            return <Icon iconName='checkmark' className={classes.checkIcon} />;
+            return <div style={{ textAlign: 'center'}}>
+              <Icon iconName='checkmark' className={classes.checkIcon} />
+            </div>;
           } else {
-            return '';
+            return <div style={{ textAlign: 'center'}}>
+            <Icon iconName='StatusCircleErrorX' className={classes.checkIcon} />
+          </div>;
           }
 
         case 'consented':
@@ -154,4 +181,5 @@ function Permission(props: any) {
   );
 }
 
-export default styled(Permission, permissionStyles as any);
+const IntlPermission = injectIntl(Permission);
+export default styled(IntlPermission, permissionStyles as any);

--- a/src/app/views/query-runner/request/permissions/Permission.tsx
+++ b/src/app/views/query-runner/request/permissions/Permission.tsx
@@ -168,6 +168,9 @@ function Permission(props: any) {
           <Label className={classes.permissionLength}>
             <FormattedMessage id='Permissions' />&nbsp;({permissions.length})
           </Label>
+          <Label className={classes.permissionText}>
+            <FormattedMessage id='permissions required to run the query' />
+          </Label>
           <DetailsList
             items={permissions}
             columns={columns}

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -287,5 +287,6 @@
   "Description": "Description",
   "Status": "Status",
   "Admin consent required": "Admin consent required",
-  "Consent": "Consent"
+  "Consent": "Consent",
+  "permissions required to run the query": "The following permissions are required to run the query. To consent to the permissions, click Consent."
 }

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -280,5 +280,6 @@
   "running the query": "When you sign in, running the query will affect the data in your tenant.",
   "We did not find any history items": "We did not find any history items",
   "Expand response": "Expand response",
-  "Access Token": "Access token"
+  "Access Token": "Access token",
+  "consent to scopes": "Go to the Modify permissions tab and consent to scopes"
 }

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -281,12 +281,13 @@
   "We did not find any history items": "We did not find any history items",
   "Expand response": "Expand response",
   "Access Token": "Access token",
-  "consent to scopes": "Go to the Modify permissions tab and consent to scopes",
+  "consent to scopes": " You need to consent to the permissions on the ",
   "Permission": "Permission",
   "Display string": "Display string",
   "Description": "Description",
   "Status": "Status",
   "Admin consent required": "Admin consent required",
   "Consent": "Consent",
-  "permissions required to run the query": "The following permissions are required to run the query. To consent to the permissions, click Consent."
+  "permissions required to run the query": "The following permissions are required to run the query. To consent to the permissions, click Consent.",
+  "tab": " tab"
 }

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -281,5 +281,11 @@
   "We did not find any history items": "We did not find any history items",
   "Expand response": "Expand response",
   "Access Token": "Access token",
-  "consent to scopes": "Go to the Modify permissions tab and consent to scopes"
+  "consent to scopes": "Go to the Modify permissions tab and consent to scopes",
+  "Permission": "Permission",
+  "Display string": "Display string",
+  "Description": "Description",
+  "Status": "Status",
+  "Admin consent required": "Admin consent required",
+  "Consent": "Consent"
 }


### PR DESCRIPTION
## Overview

Fixes #447 
Fixes #456 
Fixes #448 

Also:

- [x] Add permission table column names to localization

- [x] Add Consent to localization

- [x] Make the permission name column resizable to improve visibility of long permission names

- [x] Add an icon to show permissions that do not need admin consent

### Demo

Consent tip
![image](https://user-images.githubusercontent.com/58787602/77746442-fedda800-702d-11ea-907e-784256bc3300.png)


Permissions table columns
![image](https://user-images.githubusercontent.com/58787602/77644533-2e2edf00-6f72-11ea-9d40-6c83f577df0f.png)


### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Run a query you do not have permissions for
* Notice the message