### PR TITLE
Hotfix: fix try it not loading error

### DIFF
--- a/src/app/views/common/share.ts
+++ b/src/app/views/common/share.ts
@@ -30,7 +30,7 @@ export const createShareLink = (sampleQuery: IQuery, authenticated?: boolean): s
     // tslint:disable-next-line:max-line-length
     `${appUrl}?request=${graphUrlRequest}&method=${selectedVerb}&version=${queryVersion}&GraphUrl=${graphUrl}&requestBody=${requestBody}`;
 
-  if (sampleHeaders.length > 0) {
+  if (sampleHeaders && sampleHeaders.length > 0) {
     const headers = hashEncode(JSON.stringify(sampleHeaders));
     shareLink = `${shareLink}&headers=${headers}`;
   }


### PR DESCRIPTION
## Overview

Trying to open this link loads the try-it experience for a flash then it breaks.

The screenshot shows the console error
![image](https://user-images.githubusercontent.com/58787602/80134412-65130780-85a7-11ea-8579-e6bbaa4f8d58.png)

Conclusion:

The sample headers are undefined from the query that is passed in to GE from the docs. 
Adding a null check on the sample headers ensures the code doesn't break