### PR TITLE
Fix: Share query errors

### DIFF
--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -18,7 +18,7 @@ import { clearQueryStatus } from '../services/actions/query-status-action-creato
 import { clearTermsOfUse } from '../services/actions/terms-of-use-action-creator';
 import { changeThemeSuccess } from '../services/actions/theme-action-creator';
 import { toggleSidebar } from '../services/actions/toggle-sidebar-action-creator';
-import { getLoginType, logIn } from '../services/graph-client/msal-service';
+import { logIn } from '../services/graph-client/msal-service';
 import { parseSampleUrl } from '../utils/sample-url-generation';
 import { substituteTokens } from '../utils/token-helpers';
 import { appTitleDisplayOnFullScreen, appTitleDisplayOnMobileScreen } from './app-sections/AppTitle';
@@ -324,7 +324,6 @@ class App extends Component<IAppProps, IAppState> {
     const historyHeaderText = messages['History'];
     const { mobileScreen, showSidebar } = sidebarProperties;
     const language = navigator.language || 'en-US';
-    const loginType = getLoginType();
 
     let displayContent = true;
     if (graphExplorerMode === Mode.Complete) {
@@ -391,7 +390,7 @@ class App extends Component<IAppProps, IAppState> {
               </div>
             )}
             <div className={layout}>
-              {graphExplorerMode.TryIt && headerMessaging(loginType, classes, query)}
+              {graphExplorerMode === Mode.TryIt && headerMessaging(classes, query)}
 
               {displayContent && <>
                 <div style={{ marginBottom: 8 }}>

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -155,7 +155,7 @@ class App extends Component<IAppProps, IAppState> {
       selectedVerb: method,
       selectedVersion: version,
       sampleBody: this.hashDecode(requestBody),
-      sampleHeaders: JSON.parse(this.hashDecode(headers)),
+      sampleHeaders: (headers) ? JSON.parse(this.hashDecode(headers)) : [],
     };
   }
 
@@ -245,25 +245,6 @@ class App extends Component<IAppProps, IAppState> {
       selectedVerb: verb
     });
   };
-
-  public promptNewLogin = async () => {
-    this.closeDialog();
-    localStorage.clear();
-    const { mscc } = (window as any);
-
-    if (mscc) {
-      mscc.setConsent();
-    }
-
-    setTimeout(async () => {
-      const authResponse = await logIn();
-      if (authResponse) {
-        this.props.actions!.signIn(authResponse.accessToken);
-        this.props.actions!.storeScopes(authResponse.scopes);
-      }
-    }, 700);
-
-  }
 
   public toggleSidebar = (): void => {
     const { sidebarProperties } = this.props;

--- a/src/app/views/app-sections/HeaderMessaging.tsx
+++ b/src/app/views/app-sections/HeaderMessaging.tsx
@@ -1,9 +1,14 @@
 import { MessageBar, MessageBarType } from 'office-ui-fabric-react';
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
+
 import { LoginType } from '../../../types/enums';
+import { getLoginType } from '../../services/graph-client/msal-service';
 import { Authentication } from '../authentication';
-export function headerMessaging(loginType: LoginType, classes: any, query: string): React.ReactNode {
+
+export function headerMessaging(classes: any, query: string): React.ReactNode {
+  const loginType = getLoginType();
+
   return (
   <div style={{ marginBottom: 8 }}>
     {loginType === LoginType.Popup && <>

--- a/src/app/views/common/share.ts
+++ b/src/app/views/common/share.ts
@@ -30,7 +30,7 @@ export const createShareLink = (sampleQuery: IQuery, authenticated?: boolean): s
     // tslint:disable-next-line:max-line-length
     `${appUrl}?request=${graphUrlRequest}&method=${selectedVerb}&version=${queryVersion}&GraphUrl=${graphUrl}&requestBody=${requestBody}`;
 
-  if (sampleHeaders.length > 0) {
+  if (sampleHeaders && sampleHeaders.length > 0) {
     const headers = hashEncode(JSON.stringify(sampleHeaders));
     shareLink = `${shareLink}&headers=${headers}`;
   }


### PR DESCRIPTION
## Overview

When a query was passed on to try it and it lacked headers, the share link utility was unable to generate a share-able query link.

Now it does.

A similar action has happened on the master branch, This action is intended to bring it over to dev

Adds null check on headers that have been passed in through the url ti fix the shared query not populating the UI

Fixes #482 