### PR TITLE
Fix: sidebar http methods

### DIFF
--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -67,7 +67,7 @@ interface IAppState {
 
 class App extends Component<IAppProps, IAppState> {
 
-  private mediaQueryList = window.matchMedia('(max-width: 1260px)');
+  private mediaQueryList = window.matchMedia('(max-width: 992px)');
 
   constructor(props: IAppProps) {
     super(props);

--- a/src/app/views/sidebar/Sidebar.styles.ts
+++ b/src/app/views/sidebar/Sidebar.styles.ts
@@ -22,7 +22,7 @@ export const sidebarStyles = (theme: ITheme) => {
       maxHeight: pageHeight,
       minHeight: pageHeight,
       overflowY: 'auto',
-      overflowX: 'hidden',
+      overflowX: 'auto',
       fontSize: FontSizes.medium,
       background: 'inherit'
     },

--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -328,6 +328,11 @@ export class SampleQueries extends Component<ISampleQueriesProps, any> {
           </a>
         </MessageBar>
         <DetailsList className={classes.queryList}
+         cellStyleProps={{
+          cellRightPadding: 0,
+          cellExtraRightPadding: 0,
+          cellLeftPadding: 0,
+        }}
           layoutMode={DetailsListLayoutMode.justified}
           onRenderItemColumn={this.renderItemColumn}
           items={groupedList.samples}


### PR DESCRIPTION
## Overview

Works off changes made in PR #525 by @jobala 
Reverts breakpoint to 992
Adds horizontal scrolling in the sidebar when screen size is small
Fixes #523 

### Demo

![image](https://user-images.githubusercontent.com/58787602/81262161-f70a1e00-9045-11ea-8994-4e04cc6f8f33.png)

