### PR TITLE
Task: display settings icon mobile view

### DIFF
--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -272,13 +272,13 @@ class App extends Component<IAppProps, IAppState> {
   public displayAuthenticationSection = (minimised: boolean) => {
     return <div style={{
       display: minimised ? 'block' : 'flex',
-      justifyContent: 'center',
-      alignItems: 'center'
+      justifyContent: minimised ? '' : 'center',
+      alignItems: minimised ? '' : 'center',
     }}>
-      <div className={minimised ? '' : 'col-md-10'}>
+      <div className={minimised ? '' : 'col-10'}>
         <Authentication />
       </div>
-      <div className={minimised ? '' : 'col-md-2'}>
+      <div className={minimised ? '' : 'col-2'}>
         <Settings />
       </div>
     </div>;
@@ -345,12 +345,9 @@ class App extends Component<IAppProps, IAppState> {
                 )}
 
                 <hr className={classes.separator} />
-                {!mobileScreen &&
-                  <>
-                    {this.displayAuthenticationSection(minimised)}
-                    <hr className={classes.separator} />
-                  </>
-                }
+
+                {this.displayAuthenticationSection(minimised)}
+                <hr className={classes.separator} />
 
                 {showSidebar && <>
                   <Sidebar sampleHeaderText={sampleHeaderText} historyHeaderText={historyHeaderText} />

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -274,6 +274,7 @@ class App extends Component<IAppProps, IAppState> {
       display: minimised ? 'block' : 'flex',
       justifyContent: minimised ? '' : 'center',
       alignItems: minimised ? '' : 'center',
+      marginLeft: minimised ? '' : '-0.9em',
     }}>
       <div className={minimised ? '' : 'col-10'}>
         <Authentication />

--- a/src/app/views/app-sections/AppTitle.tsx
+++ b/src/app/views/app-sections/AppTitle.tsx
@@ -45,13 +45,6 @@ export function appTitleDisplayOnFullScreen(
             Graph Explorer
           </Label>
         </div>
-        <span style={{
-          position: 'absolute',
-          marginLeft: '70%',
-          marginTop: '2.5%'
-        }}>
-          <Authentication />
-        </span>
       </>
     </Stack>;
   }

--- a/src/app/views/authentication/Authentication.tsx
+++ b/src/app/views/authentication/Authentication.tsx
@@ -64,7 +64,7 @@ export class Authentication extends Component<IAuthenticationProps, { loginInPro
           mobileScreen ? showSignInButtonOrProfile(tokenPresent, mobileScreen, this.signIn, minimised) :
             <>
               {!tokenPresent && graphExplorerMode === Mode.Complete && !minimised && showUnAuthenticatedText(classes)}
-              <span><br />{showSignInButtonOrProfile(tokenPresent, mobileScreen, this.signIn, minimised)}<br /> </span>
+              <br />{showSignInButtonOrProfile(tokenPresent, mobileScreen, this.signIn, minimised)}<br />
             </>}
       </>
     );

--- a/src/app/views/authentication/auth-util-components/UtilComponents.tsx
+++ b/src/app/views/authentication/auth-util-components/UtilComponents.tsx
@@ -25,11 +25,9 @@ export function showSignInButtonOrProfile(
     </PrimaryButton>;
 
   return (
-    <Stack>
-      <Stack.Item align='start'>
-        {!tokenPresent && signInButton}
-      </Stack.Item>
+    <div>
+      {!tokenPresent && signInButton}
       {tokenPresent && <Profile />}
-    </Stack>
+    </div>
   );
 }

--- a/src/app/views/authentication/profile/Profile.tsx
+++ b/src/app/views/authentication/profile/Profile.tsx
@@ -159,9 +159,7 @@ export class Profile extends Component<IProfileProps, IProfileState> {
     return (
       <div className={classes.profile}>
         {mobileScreen &&
-          <ActionButton ariaLabel='profile' role='button' menuProps={menuProperties}>
-            <Persona {...persona} size={PersonaSize.size40} hidePersonaDetails={true} />
-          </ActionButton>
+          <Persona {...persona} size={PersonaSize.size40}  />
         }
 
         {!mobileScreen && this.showProfileComponent(profileProperties, graphExplorerMode, menuProperties)}

--- a/src/app/views/query-response/pivot-items/pivot-items.tsx
+++ b/src/app/views/query-response/pivot-items/pivot-items.tsx
@@ -52,7 +52,7 @@ export const getPivotItems = (properties: any) => {
         headerText={(mobileScreen) ? '' : messages['Adaptive Cards']}
         title={messages['Adaptive Cards']}
         itemIcon='ContactCard'
-        resource={sampleQuery}
+        resource={(!!body) ? sampleQuery : null}
         onRenderItemLink={getTooltipDisplay}
       >
         <ThemeContext.Consumer >
@@ -89,7 +89,7 @@ function getTooltipDisplay(link: any) {
       <Icon iconName={link.itemIcon} style={{ paddingRight: 5 }} />
       {link.headerText}
 
-      {link.ariaLabel === 'Adaptive Cards' && adaptiveCardPresentDot(link.resource)}
+      {link.ariaLabel === 'Adaptive Cards' && link.resource && adaptiveCardPresentDot(link.resource)}
     </TooltipHost>
   );
 }


### PR DESCRIPTION
## Overview

Adds the setting icon into the mobile view so that a user has the chance to interact with the options available
Aligns the authentication to the left instead of centered

Extra: Fix useability inconsistency brought by showing the adaptive cards dot before a query is made. Making it appear once a query is ran shows that the response is available an adaptive card / not .

## Demo

Anonymous 
![image](https://user-images.githubusercontent.com/58787602/81442438-45213d80-917c-11ea-9b36-5857bef204d4.png)

Authenticated
![image](https://user-images.githubusercontent.com/58787602/81442519-6a15b080-917c-11ea-8bc9-1581b1796f52.png)

