### PR TITLE
Fix: remove duplicate content type header

### DIFF
--- a/src/app/services/actions/query-action-creator-util.ts
+++ b/src/app/services/actions/query-action-creator-util.ts
@@ -24,12 +24,9 @@ export async function anonymousRequest(dispatch: Function, query: IQuery) {
   const escapedUrl = encodeURIComponent(query.sampleUrl);
   const graphUrl = `https://proxy.apisandbox.msdn.microsoft.com/svc?url=${escapedUrl}`;
   const sampleHeaders: any = {};
-
-  if (query.sampleHeaders) {
+  if (query.sampleHeaders && query.sampleHeaders.length > 0) {
     query.sampleHeaders.forEach(header => {
-      if (header.name !== '' && header.value !== '') {
-        sampleHeaders[header.name] = header.value;
-      }
+      sampleHeaders[header.name] = header.value;
     });
   }
 
@@ -101,12 +98,11 @@ const makeRequest = (httpVerb: string, scopes: string[]): Function => {
     const sampleHeaders: any = {};
     sampleHeaders.SdkVersion = 'GraphExplorer/4.0';
 
-    if (query.sampleHeaders) {
+    if (query.sampleHeaders && query.sampleHeaders.length > 0) {
       query.sampleHeaders.forEach(header => {
+
+        // We are relying on the graph client to set the content type header.
         if (header.name.toLowerCase() === 'content-type') {
-          return;
-        }
-        if (header.name === '' && header.value === '') {
           return;
         }
         sampleHeaders[header.name] = header.value;

--- a/src/app/services/actions/query-action-creator-util.ts
+++ b/src/app/services/actions/query-action-creator-util.ts
@@ -103,9 +103,13 @@ const makeRequest = (httpVerb: string, scopes: string[]): Function => {
 
     if (query.sampleHeaders) {
       query.sampleHeaders.forEach(header => {
-        if (header.name !== '' && header.value !== '') {
-          sampleHeaders[header.name] = header.value;
+        if (header.name.toLowerCase() === 'content-type') {
+          return;
         }
+        if (header.name === '' && header.value === '') {
+          return;
+        }
+        sampleHeaders[header.name] = header.value;
       });
     }
 

--- a/src/app/services/actions/samples-action-creators.ts
+++ b/src/app/services/actions/samples-action-creators.ts
@@ -45,8 +45,7 @@ export function fetchSamples(): Function {
       const res = await response.json();
       return dispatch(fetchSamplesSuccess(res.sampleQueries));
     } catch (error) {
-      const errorCode = await error.text();
-      return  dispatch(fetchSamplesError({ error: errorCode }));
+      return dispatch(fetchSamplesError({ error }));
     }
   };
 }


### PR DESCRIPTION
## Overview

Removes duplicate content-type headers passed in from the sample queries

### Demo

![image](https://user-images.githubusercontent.com/58787602/81552865-e7b00b00-938c-11ea-86ba-f50fc96ddce8.png)

## Testing Instructions

* Select send an email from the sidebar
* Click run query
* Message will be sent