### PR TITLE
Fix: lowercase locales

### DIFF
--- a/src/app/services/graph-client/msal-service.ts
+++ b/src/app/services/graph-client/msal-service.ts
@@ -20,6 +20,7 @@ export async function logIn(sessionId = ''): Promise<any> {
   const loginRequest: AuthenticationParameters = {
     scopes: defaultUserScopes,
     prompt: 'select_account',
+    redirectUri: window.location.href.toLowerCase(),
     extraQueryParameters: { mkt: geLocale }
   };
 
@@ -82,8 +83,8 @@ export function logOutPopUp() {
   // @ts-ignore
   msalApplication.authorityInstance.resolveEndpointsAsync().then(authority => {
     const urlNavigate = authority.EndSessionEndpoint
-        ? authority.EndSessionEndpoint
-        : `${msalApplication.authority}oauth2/v2.0/logout`;
+      ? authority.EndSessionEndpoint
+      : `${msalApplication.authority}oauth2/v2.0/logout`;
     (msalApplication as any).openPopup(urlNavigate, 'msal', 400, 600);
   });
 }

--- a/src/app/views/common/share.ts
+++ b/src/app/views/common/share.ts
@@ -18,7 +18,7 @@ export const createShareLink = (sampleQuery: IQuery, authenticated?: boolean): s
 
   const url = new URL(sampleUrl);
   const graphUrl = url.origin;
-  const appUrl = 'https://developer.microsoft.com/' + geLocale + '/graph/graph-explorer'.toLowerCase();
+  const appUrl = 'https://developer.microsoft.com/' + geLocale.toLowerCase() + '/graph/graph-explorer';
   /**
    * To ensure backward compatibility the version is removed from the pathname.
    * V3 expects the request query param to not have the version number.

--- a/src/app/views/common/share.ts
+++ b/src/app/views/common/share.ts
@@ -18,7 +18,7 @@ export const createShareLink = (sampleQuery: IQuery, authenticated?: boolean): s
 
   const url = new URL(sampleUrl);
   const graphUrl = url.origin;
-  const appUrl = 'https://developer.microsoft.com/' + geLocale + '/graph/graph-explorer/preview';
+  const appUrl = 'https://developer.microsoft.com/' + geLocale + '/graph/graph-explorer'.toLowerCase();
   /**
    * To ensure backward compatibility the version is removed from the pathname.
    * V3 expects the request query param to not have the version number.


### PR DESCRIPTION
## Overview

Adds a lower-cased redirect url to the authentication request
Removes preview from the share query link and localizes it

Partially fixes missing url in the client id error in when there is a capitalised locale as mentioned in #540 

### Demo

```
https://developer.microsoft.com/es-es/graph/graph-explorer?request=me&method=GET&version=v1.0&GraphUrl=https://graph.microsoft.com&requestBody=dW5kZWZpbmVk
```
