### PR TITLE
Fix: select permissions pop up

### DIFF
--- a/src/app/views/settings/Settings.tsx
+++ b/src/app/views/settings/Settings.tsx
@@ -58,7 +58,7 @@ function Settings(props: ISettingsProps) {
       }
     ];
 
-    if (!authenticated) {
+    if (authenticated) {
       menuItems.push(
         {
           key: 'change-theme',

--- a/src/app/views/settings/Settings.tsx
+++ b/src/app/views/settings/Settings.tsx
@@ -25,10 +25,10 @@ import { Permission } from '../query-runner/request/permissions';
 function Settings(props: ISettingsProps) {
   const dispatch = useDispatch();
 
-  const [ themeChooserDialogHidden, hideThemeChooserDialog] = useState(true);
-  const [ items, setItems] = useState([]);
-  const [ selectedPermissions, setSelectedPermissions] = useState([]);
-  const [ panelIsOpen, setPanelState] = useState(false);
+  const [themeChooserDialogHidden, hideThemeChooserDialog] = useState(true);
+  const [items, setItems] = useState([]);
+  const [selectedPermissions, setSelectedPermissions] = useState([]);
+  const [panelIsOpen, setPanelState] = useState(false);
 
   const {
     intl: { messages }
@@ -58,7 +58,7 @@ function Settings(props: ISettingsProps) {
       }
     ];
 
-    if (authenticated) {
+    if (!authenticated) {
       menuItems.push(
         {
           key: 'change-theme',
@@ -194,7 +194,7 @@ function Settings(props: ISettingsProps) {
 
         <Panel
           isOpen={panelIsOpen}
-          onDismiss={() => togglePermissionsPanel}
+          onDismiss={() => togglePermissionsPanel()}
           type={PanelType.medium}
           hasCloseButton={true}
           headerText={messages.Permissions}


### PR DESCRIPTION
## Overview

Fixes #547 

## Testing Instructions

* Log in to graph explorer
* Click the gear icon and select 'Select permissions'
* Click the close button and close the panel
* Click the version dropdown and notice the panel does not open