### PR TITLE
Support for tenanted endpoint in Graph explorer.

### DIFF
--- a/src/app/services/graph-client/msal-service.ts
+++ b/src/app/services/graph-client/msal-service.ts
@@ -17,23 +17,23 @@ export function getSessionId() {
 }
 
 export async function logIn(sessionId = ''): Promise<any> {
-
+ 
   // support for tenanted endpoint
-  let params = new URLSearchParams(location.search);
-  let tenantId = params.get('tenantId');
+  const urlParams = new URLSearchParams(location.search);
+  let tenant = urlParams.get('tenant');
 
-  if (tenantId == null) {
-    tenantId = 'common';
+  if (tenant === null) {
+    tenant = 'common';
   }
 
   const loginRequest: AuthenticationParameters = {
     scopes: defaultUserScopes,
-    authority: `https://login.microsoftonline.com/${tenantId}/`,
+    authority: `https://login.microsoftonline.com/${tenant}/`,
     prompt: 'select_account',
     redirectUri: window.location.href.toLowerCase(),
     extraQueryParameters: { mkt: geLocale }
   };
-
+  
   if (sessionId !== '') {
     loginRequest.sid = sessionId;
 

--- a/src/app/services/graph-client/msal-service.ts
+++ b/src/app/services/graph-client/msal-service.ts
@@ -16,6 +16,12 @@ export function getSessionId() {
   }
 }
 
+// get current uri for redirect uri purpose
+// ref - https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/9274fac6d100a6300eb2faa4c94aa2431b1ca4b0/lib/msal-browser/src/utils/BrowserUtils.ts#L49
+function getCurrentUri(): string {
+  return window.location.href.split("?")[0].split("#")[0];
+}
+
 function getAuthority(): string {
     // support for tenanted endpoint
     const urlParams = new URLSearchParams(location.search);
@@ -34,6 +40,7 @@ export async function logIn(sessionId = ''): Promise<any> {
     scopes: defaultUserScopes,
     authority: getAuthority(),
     prompt: 'select_account',
+    redirectUri: getCurrentUri().toLowerCase(),
     extraQueryParameters: { mkt: geLocale }
   };
 

--- a/src/app/services/graph-client/msal-service.ts
+++ b/src/app/services/graph-client/msal-service.ts
@@ -17,9 +17,10 @@ export function getSessionId() {
 }
 
 // get current uri for redirect uri purpose
-// ref - https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/9274fac6d100a6300eb2faa4c94aa2431b1ca4b0/lib/msal-browser/src/utils/BrowserUtils.ts#L49
+// ref - https://github.com/AzureAD/microsoft-authentication-library-for
+//  -js/blob/9274fac6d100a6300eb2faa4c94aa2431b1ca4b0/lib/msal-browser/src/utils/BrowserUtils.ts#L49
 function getCurrentUri(): string {
-  return window.location.href.split("?")[0].split("#")[0];
+  return window.location.href.split('?')[0].split('#')[0];
 }
 
 function getAuthority(): string {

--- a/src/app/services/graph-client/msal-service.ts
+++ b/src/app/services/graph-client/msal-service.ts
@@ -16,7 +16,7 @@ export function getSessionId() {
   }
 }
 
-function getAuthority() : string {
+function getAuthority(): string {
     // support for tenanted endpoint
     const urlParams = new URLSearchParams(location.search);
     let tenant = urlParams.get('tenant');

--- a/src/app/services/graph-client/msal-service.ts
+++ b/src/app/services/graph-client/msal-service.ts
@@ -16,24 +16,27 @@ export function getSessionId() {
   }
 }
 
-export async function logIn(sessionId = ''): Promise<any> {
- 
-  // support for tenanted endpoint
-  const urlParams = new URLSearchParams(location.search);
-  let tenant = urlParams.get('tenant');
+function getAuthority() : string {
+    // support for tenanted endpoint
+    const urlParams = new URLSearchParams(location.search);
+    let tenant = urlParams.get('tenant');
 
-  if (tenant === null) {
-    tenant = 'common';
+    if (tenant === null) {
+      tenant = 'common';
   }
+
+  return `https://login.microsoftonline.com/${tenant}/`;
+}
+
+export async function logIn(sessionId = ''): Promise<any> {
 
   const loginRequest: AuthenticationParameters = {
     scopes: defaultUserScopes,
-    authority: `https://login.microsoftonline.com/${tenant}/`,
+    authority: getAuthority(),
     prompt: 'select_account',
-    redirectUri: window.location.href.toLowerCase(),
     extraQueryParameters: { mkt: geLocale }
   };
-  
+
   if (sessionId !== '') {
     loginRequest.sid = sessionId;
 
@@ -107,6 +110,7 @@ export function logOutPopUp() {
 export async function acquireNewAccessToken(scopes: string[] = []): Promise<any> {
   const loginRequest: AuthenticationParameters = {
     scopes,
+    authority: getAuthority(),
   };
   if (loginType === LoginType.Popup) {
     try {

--- a/src/app/services/graph-client/msal-service.ts
+++ b/src/app/services/graph-client/msal-service.ts
@@ -17,8 +17,18 @@ export function getSessionId() {
 }
 
 export async function logIn(sessionId = ''): Promise<any> {
+
+  // support for tenanted endpoint
+  let params = new URLSearchParams(location.search);
+  let tenantId = params.get('tenantId');
+
+  if (tenantId == null) {
+    tenantId = 'common';
+  }
+
   const loginRequest: AuthenticationParameters = {
     scopes: defaultUserScopes,
+    authority: `https://login.microsoftonline.com/${tenantId}/`,
     prompt: 'select_account',
     redirectUri: window.location.href.toLowerCase(),
     extraQueryParameters: { mkt: geLocale }


### PR DESCRIPTION
## Overview

Currently to go a tenant in Graph Explorer, we need to create a local account in tenant. After this change a `tenant` queryString parameter can be passed and then all idtoken and access token requests will go to that tenant.

Tenant parameter can be guid or the domain name for the tenant.

**sample request** 
https://developer.microsoft.com/en-us/graph/graph-explorer?tenant=abc.onmicrosoft.com
if no tenant is specified, the request goes to common endpoint. 

## RedirectUri notes
MSAL.JS documentation says that default redirect uri is window.location.href but taking a look at 
[this](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/d259ebab2ebc441a0eecce88381d932664c97fa1/lib/msal-browser/src/config/Configuration.ts#L65) and [this](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/9274fac6d100a6300eb2faa4c94aa2431b1ca4b0/lib/msal-browser/src/utils/BrowserUtils.ts#L49) shows that its not complete location but only host part of it. 

So I had to modify the change which specifies the redirect url explicitly since the auth requests fail because of that. the redirect uri will come from MSAL like function now. This change was made by @thewahome in https://github.com/microsoftgraph/microsoft-graph-explorer-v4/pull/551 

## Test cases
1. SIgn in with and without tenant query string.
2. Consent to permissions works with and without tenant query string.

## Testing Instructions
If tenant is specified, user can login to their desired tenant
https://developer.microsoft.com/en-us/graph/graph-explorer?tenant=abc.onmicrosoft.com

