### PR TITLE
Fix: Show log-out on try it on mobile screens

### DIFF
--- a/src/app/views/authentication/profile/Profile.tsx
+++ b/src/app/views/authentication/profile/Profile.tsx
@@ -98,7 +98,6 @@ export class Profile extends Component<IProfileProps, IProfileState> {
     const { user } = this.state;
     const {
       intl: { messages },
-      mobileScreen,
       minimised,
       graphExplorerMode,
     }: any = this.props;
@@ -158,11 +157,7 @@ export class Profile extends Component<IProfileProps, IProfileState> {
 
     return (
       <div className={classes.profile}>
-        {mobileScreen &&
-          <Persona {...persona} size={PersonaSize.size40}  />
-        }
-
-        {!mobileScreen && this.showProfileComponent(profileProperties, graphExplorerMode, menuProperties)}
+        {this.showProfileComponent(profileProperties, graphExplorerMode, menuProperties)}
       </div>
     );
   }
@@ -175,13 +170,13 @@ export class Profile extends Component<IProfileProps, IProfileState> {
       styles={profileProperties.styles}
       hidePersonaDetails={profileProperties.hidePersonaDetails} />;
 
-      if (graphExplorerMode === Mode.TryIt) {
-        return <ActionButton ariaLabel='profile' role='button' menuProps={menuProperties}>
-            {persona}
-          </ActionButton>;
-      }
+    if (graphExplorerMode === Mode.TryIt) {
+      return <ActionButton ariaLabel='profile' role='button' menuProps={menuProperties}>
+        {persona}
+      </ActionButton>;
+    }
 
-      return persona;
+    return persona;
   }
 }
 


### PR DESCRIPTION
## Overview
Displays the login screen in mobile views

Fixes #561 

### Demo

![image](https://user-images.githubusercontent.com/58787602/83413553-b030fd80-a424-11ea-8bd9-ed7d29519e61.png)


### Notes

N/A

## Testing Instructions

* Load GE in try it mode
* Minimise screen till it hits the mobile view
* Notice you can still see the dropdown