### PR TITLE
Fix: sample queries documentation link

### DIFF
--- a/src/app/views/sidebar/Sidebar.styles.ts
+++ b/src/app/views/sidebar/Sidebar.styles.ts
@@ -111,6 +111,8 @@ export const sidebarStyles = (theme: ITheme) => {
       marginTop: '-7.5%',
       marginRight: theme.spacing.s1,
     },
-
+    links: {
+      color: `${theme.palette.blueMid} !important`,
+    },
   };
 };

--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -170,18 +170,18 @@ export class SampleQueries extends Component<ISampleQueriesProps, any> {
 
         default:
           return <TooltipHost
-              tooltipProps={{
-                onRenderContent: () => <div style={{ paddingBottom: 3 }}>
-                  {item.method} {queryContent} </div>
-              }}
-              id={getId()}
-              calloutProps={{ gapSpace: 0 }}
-              styles={{ root: { display: 'inline-block' } }}
-            >
-              <span aria-label={queryContent} className={classes.queryContent}>
-                {queryContent}
-              </span>
-            </TooltipHost>;
+            tooltipProps={{
+              onRenderContent: () => <div style={{ paddingBottom: 3 }}>
+                {item.method} {queryContent} </div>
+            }}
+            id={getId()}
+            calloutProps={{ gapSpace: 0 }}
+            styles={{ root: { display: 'inline-block' } }}
+          >
+            <span aria-label={queryContent} className={classes.queryContent}>
+              {queryContent}
+            </span>
+          </TooltipHost>;
       }
     }
   };
@@ -218,11 +218,11 @@ export class SampleQueries extends Component<ISampleQueriesProps, any> {
         styles={{
           check: { display: 'none' },
           title: {
-          fontSize: FontSizes.medium,
-          fontWeight: FontWeights.semibold
-        },
-        expand: {
-          fontSize: FontSizes.small,
+            fontSize: FontSizes.medium,
+            fontWeight: FontWeights.semibold
+          },
+          expand: {
+            fontSize: FontSizes.small,
           }
         }}
         {...props}
@@ -318,20 +318,20 @@ export class SampleQueries extends Component<ISampleQueriesProps, any> {
           <FormattedMessage id='viewing a cached set' />
         </MessageBar>}
         <MessageBar messageBarType={MessageBarType.info}
-          isMultiline={false}
+          isMultiline={true}
           dismissButtonAriaLabel='Close'>
           <FormattedMessage id='see more queries' />
-          <a target='_blank'
+          <a target='_blank' className={classes.links}
             href={`https://docs.microsoft.com/${geLocale}/graph/api/overview?view=graph-rest-1.0`}>
             <FormattedMessage id='Microsoft Graph API Reference docs' />
           </a>
         </MessageBar>
         <DetailsList className={classes.queryList}
-         cellStyleProps={{
-          cellRightPadding: 0,
-          cellExtraRightPadding: 0,
-          cellLeftPadding: 0,
-        }}
+          cellStyleProps={{
+            cellRightPadding: 0,
+            cellExtraRightPadding: 0,
+            cellLeftPadding: 0,
+          }}
           layoutMode={DetailsListLayoutMode.justified}
           onRenderItemColumn={this.renderItemColumn}
           items={groupedList.samples}

--- a/src/app/views/sidebar/sample-queries/tokens.ts
+++ b/src/app/views/sidebar/sample-queries/tokens.ts
@@ -99,6 +99,10 @@ export function getTokens(user?: any) {
       demoTenantValue: '1.2.3.5',
     },
     {
+      placeholder: 'user-id',
+      demoTenantValue: 'd4957c9d-869e-4364-830c-d0c95be72738',
+    },
+    {
       placeholder: 'today',
       defaultValueFn: () => {
         return (new Date()).toISOString();


### PR DESCRIPTION
## Overview

Makes the documentation link multiline
Changes the link colour to reflect that it is a link

Adds a placeholder token for the user-id in the presence api call

Fixes #556 
Fixes #563 

### Demo

![image](https://user-images.githubusercontent.com/58787602/83415386-aeb50480-a427-11ea-90f9-a39b0ffdd49c.png)



### Notes

N/A
