### PR TITLE
Fix: History item click action

### DIFF
--- a/src/app/views/sidebar/history/History.tsx
+++ b/src/app/views/sidebar/history/History.tsx
@@ -136,7 +136,8 @@ export class History extends Component<IHistoryProps, any> {
     const classes = classNames(this.props);
     return (
       <div className={classes.groupHeader}>
-        <DetailsRow {...props} className={classes.queryRow} />
+        <DetailsRow {...props} className={classes.queryRow}
+          onClick={() => this.onViewQuery(props.item)} />
       </div>
     );
   };


### PR DESCRIPTION
## Overview

User can view a query when history item is clicked
Fixes #541 

### Demo

N/A

### Notes

N/A

## Testing Instructions

* Head over to history on the sidebar
* Click on a history item
* Notice the results appear