### PR TITLE
Fix: Post request hangs waiting for response

### DIFF
--- a/src/app/services/actions/query-action-creators.ts
+++ b/src/app/services/actions/query-action-creators.ts
@@ -16,6 +16,17 @@ export function runQuery(query: IQuery): Function {
     if (tokenPresent) {
       return authenticatedRequest(dispatch, query).then(async (response: Response) => {
         await processResponse(response, respHeaders, dispatch, createdAt);
+      }).catch(async (error: any) => {
+        dispatch(queryResponse({
+          body: error,
+          headers: null
+        }));
+        return dispatch(setQueryResponseStatus({
+          messageType: MessageBarType.error,
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request'
+        }));
       });
     }
 


### PR DESCRIPTION
## Overview

Handles errors from the sdk making the request to hang.
Fixes #555 

### Demo

N/A

### Notes

Errors from the sdk were not being handled. We added a default error 400 and display the actual error in the editor.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output