### PR TITLE
Fix: hostname missing

### DIFF
--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -5,6 +5,7 @@ import React, { Component } from 'react';
 import { InjectedIntl, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
+
 import { geLocale } from '../../appLocale';
 import { loadGETheme } from '../../themes';
 import { ThemeContext } from '../../themes/theme-context';
@@ -20,6 +21,7 @@ import { clearTermsOfUse } from '../services/actions/terms-of-use-action-creator
 import { changeThemeSuccess } from '../services/actions/theme-action-creator';
 import { toggleSidebar } from '../services/actions/toggle-sidebar-action-creator';
 import { logIn } from '../services/graph-client/msal-service';
+import { GRAPH_URL } from '../services/graph-constants';
 import { parseSampleUrl } from '../utils/sample-url-generation';
 import { substituteTokens } from '../utils/token-helpers';
 import { appTitleDisplayOnFullScreen, appTitleDisplayOnMobileScreen } from './app-sections/AppTitle';
@@ -137,7 +139,7 @@ class App extends Component<IAppProps, IAppState> {
     const request = urlParams.get('request');
     const method = urlParams.get('method');
     const version = urlParams.get('version');
-    const graphUrl = urlParams.get('GraphUrl');
+    const graphUrl = urlParams.get('GraphUrl') || GRAPH_URL;
     const requestBody = urlParams.get('requestBody');
     const headers = urlParams.get('headers');
 

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -157,7 +157,7 @@ class App extends Component<IAppProps, IAppState> {
       sampleUrl: `${graphUrl}/${version}/${request}`,
       selectedVerb: method,
       selectedVersion: version,
-      sampleBody: this.hashDecode(requestBody),
+      sampleBody: requestBody ? this.hashDecode(requestBody) : null,
       sampleHeaders: (headers) ? JSON.parse(this.hashDecode(headers)) : [],
     };
   }

--- a/src/app/views/common/share.ts
+++ b/src/app/views/common/share.ts
@@ -19,16 +19,16 @@ export const createShareLink = (sampleQuery: IQuery, authenticated?: boolean): s
   const url = new URL(sampleUrl);
   const graphUrl = url.origin;
   const appUrl = 'https://developer.microsoft.com/' + geLocale.toLowerCase() + '/graph/graph-explorer';
-  /**
-   * To ensure backward compatibility the version is removed from the pathname.
-   * V3 expects the request query param to not have the version number.
-   */
-  const graphUrlRequest = requestUrl + search;
-  const requestBody = hashEncode(JSON.stringify(sampleBody));
 
+  const graphUrlRequest = encodeURIComponent(requestUrl + search);
   let shareLink =
     // tslint:disable-next-line:max-line-length
-    `${appUrl}?request=${graphUrlRequest}&method=${selectedVerb}&version=${queryVersion}&GraphUrl=${graphUrl}&requestBody=${requestBody}`;
+    `${appUrl}?request=${graphUrlRequest}&method=${selectedVerb}&version=${queryVersion}&GraphUrl=${graphUrl}`;
+
+  if (sampleBody && Object.keys(sampleBody).length > 0) {
+    const requestBody = hashEncode(JSON.stringify(sampleBody));
+    shareLink = `&requestBody=${requestBody}`;
+  }
 
   if (sampleHeaders && sampleHeaders.length > 0) {
     const headers = hashEncode(JSON.stringify(sampleHeaders));
@@ -41,7 +41,6 @@ export const createShareLink = (sampleQuery: IQuery, authenticated?: boolean): s
       shareLink = `${shareLink}&sid=${sessionId}`;
     }
   }
-
   return shareLink;
 };
 


### PR DESCRIPTION
## Overview

Makes the graph url an optional parameter so that shared queries from documentation do not fail.
Fixes #571 

URL encodes the url to maintain all parts of the shared query
Only shares a hashed request body when a request body exists
Fixes #567 

### Demo

N/A

### Notes

N/A

## Testing Instructions

* Run a complex query
* Click share query
* Notice that the query is encoded