### PR TITLE
Fix: failing create teams request

### DIFF
--- a/src/app/views/common/share.ts
+++ b/src/app/views/common/share.ts
@@ -27,23 +27,23 @@ export const createShareLink = (sampleQuery: IQuery, authenticated?: boolean): s
 
   if (sampleBody && Object.keys(sampleBody).length > 0) {
     const requestBody = hashEncode(JSON.stringify(sampleBody));
-    shareLink = `&requestBody=${requestBody}`;
+    shareLink += `&requestBody=${requestBody}`;
   }
 
   if (sampleHeaders && sampleHeaders.length > 0) {
     const headers = hashEncode(JSON.stringify(sampleHeaders));
-    shareLink = `${shareLink}&headers=${headers}`;
+    shareLink += `${shareLink}&headers=${headers}`;
   }
 
   if (authenticated) {
     const sessionId = getSessionId();
     if (sessionId) {
-      shareLink = `${shareLink}&sid=${sessionId}`;
+      shareLink += `${shareLink}&sid=${sessionId}`;
     }
   }
   return shareLink;
 };
 
 const hashEncode = (requestBody: string): string => {
-  return btoa(requestBody);
+  return btoa(unescape(encodeURIComponent(requestBody)));
 };

--- a/src/app/views/common/share.ts
+++ b/src/app/views/common/share.ts
@@ -27,18 +27,18 @@ export const createShareLink = (sampleQuery: IQuery, authenticated?: boolean): s
 
   if (sampleBody && Object.keys(sampleBody).length > 0) {
     const requestBody = hashEncode(JSON.stringify(sampleBody));
-    shareLink += `&requestBody=${requestBody}`;
+    shareLink = `&requestBody=${requestBody}`;
   }
 
   if (sampleHeaders && sampleHeaders.length > 0) {
     const headers = hashEncode(JSON.stringify(sampleHeaders));
-    shareLink += `${shareLink}&headers=${headers}`;
+    shareLink = `${shareLink}&headers=${headers}`;
   }
 
   if (authenticated) {
     const sessionId = getSessionId();
     if (sessionId) {
-      shareLink += `${shareLink}&sid=${sessionId}`;
+      shareLink = `${shareLink}&sid=${sessionId}`;
     }
   }
   return shareLink;

--- a/src/app/views/common/share.ts
+++ b/src/app/views/common/share.ts
@@ -27,7 +27,7 @@ export const createShareLink = (sampleQuery: IQuery, authenticated?: boolean): s
 
   if (sampleBody && Object.keys(sampleBody).length > 0) {
     const requestBody = hashEncode(JSON.stringify(sampleBody));
-    shareLink = `&requestBody=${requestBody}`;
+    shareLink = `${shareLink}&requestBody=${requestBody}`;
   }
 
   if (sampleHeaders && sampleHeaders.length > 0) {

--- a/src/app/views/query-runner/QueryInput.tsx
+++ b/src/app/views/query-runner/QueryInput.tsx
@@ -66,7 +66,7 @@ export class QueryInput extends Component<IQueryInputProps, any> {
       background: getStyleFor(selectedVerb),
     };
 
-    const httpMethodsToDisplay = (mode === Mode.TryIt || !authenticated) ? [httpMethods[0]] : httpMethods;
+    const httpMethodsToDisplay = (!authenticated) ? [httpMethods[0]] : httpMethods;
 
     return (
       <div className='row'>

--- a/src/app/views/query-runner/QueryInput.tsx
+++ b/src/app/views/query-runner/QueryInput.tsx
@@ -66,7 +66,7 @@ export class QueryInput extends Component<IQueryInputProps, any> {
       background: getStyleFor(selectedVerb),
     };
 
-    const httpMethodsToDisplay = (mode === Mode.TryIt && !authenticated ) ? [httpMethods[0]] : httpMethods;
+    const httpMethodsToDisplay = (mode === Mode.TryIt || !authenticated) ? [httpMethods[0]] : httpMethods;
 
     return (
       <div className='row'>


### PR DESCRIPTION
## Overview

Running the ```create a team``` query breaks the app like so
![image](https://user-images.githubusercontent.com/58787602/87342961-c9b18300-c554-11ea-82b9-7311b99d9601.png)

The characters previously unsupported when hashEncoding are now supported.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Log in
* Set to POST and run ``` https://graph.microsoft.com/beta/teams ``` adding the request body described in the [docs here](https://docs.microsoft.com/en-us/graph/api/team-post?view=graph-rest-beta&tabs=http#example-6-create-a-team-with-a-non-standard-base-template-type)
* Notice the browser does not break 💯 