### PR TITLE
Fix: image content types

### DIFF
--- a/src/app/services/actions/query-action-creator-util.ts
+++ b/src/app/services/actions/query-action-creator-util.ts
@@ -53,7 +53,7 @@ export function isImageResponse(contentType: string) {
   if (!contentType) { return false; }
   return (
     contentType === 'application/octet-stream' ||
-    contentType.substr(0, 6) === 'image/'
+    contentType.includes('image/')
   );
 }
 

--- a/src/app/services/actions/query-action-creators.ts
+++ b/src/app/services/actions/query-action-creators.ts
@@ -1,9 +1,13 @@
 import { MessageBarType } from 'office-ui-fabric-react';
+
 import { ContentType } from '../../../types/enums';
 import { IHistoryItem } from '../../../types/history';
 import { IQuery } from '../../../types/query-runner';
 import { writeHistoryData } from '../../views/sidebar/history/history-utils';
-import { anonymousRequest, authenticatedRequest, parseResponse, queryResponse, isImageResponse } from './query-action-creator-util';
+import {
+  anonymousRequest, authenticatedRequest,
+  isImageResponse, parseResponse, queryResponse
+} from './query-action-creator-util';
 import { setQueryResponseStatus } from './query-status-action-creator';
 import { addHistoryItem } from './request-history-action-creators';
 

--- a/src/app/services/actions/query-action-creators.ts
+++ b/src/app/services/actions/query-action-creators.ts
@@ -3,7 +3,7 @@ import { ContentType } from '../../../types/enums';
 import { IHistoryItem } from '../../../types/history';
 import { IQuery } from '../../../types/query-runner';
 import { writeHistoryData } from '../../views/sidebar/history/history-utils';
-import { anonymousRequest, authenticatedRequest, parseResponse, queryResponse } from './query-action-creator-util';
+import { anonymousRequest, authenticatedRequest, parseResponse, queryResponse, isImageResponse } from './query-action-creator-util';
 import { setQueryResponseStatus } from './query-status-action-creator';
 import { addHistoryItem } from './request-history-action-creators';
 
@@ -83,7 +83,7 @@ async function createHistory(response: Response, respHeaders: any, query: IQuery
   const responseHeaders = { ...respHeaders };
   const contentType = respHeaders['content-type'];
 
-  if (contentType === ContentType.Image) {
+  if (isImageResponse(contentType)) {
     result = {
       message: 'Run the query to view the image'
     };

--- a/src/app/views/query-response/pivot-items/pivot-items.tsx
+++ b/src/app/views/query-response/pivot-items/pivot-items.tsx
@@ -12,6 +12,7 @@ import AdaptiveCard from '../adaptive-cards/AdaptiveCard';
 import { darkThemeHostConfig, lightThemeHostConfig } from '../adaptive-cards/AdaptiveHostConfig';
 import { queryResponseStyles } from '../queryResponse.styles';
 import { Snippets } from '../snippets';
+import { isImageResponse } from '../../../services/actions/query-action-creator-util';
 
 export const getPivotItems = (properties: any) => {
 
@@ -112,14 +113,14 @@ function displayResultComponent(headers: any, body: any, verb: string) {
       case ContentType.XML:
         return <Monaco body={formatXml(body)} verb={verb} language='xml' />;
 
-      case ContentType.Image:
-        return <Image
-          styles={{ padding: '10px' }}
-          body={body}
-          alt='profile image'
-        />;
-
       default:
+        if (isImageResponse(contentType)) {
+          return <Image
+            styles={{ padding: '10px' }}
+            body={body}
+            alt='profile image'
+          />;
+        }
         return <Monaco body={body} verb={verb} language={language} />;
     }
   }

--- a/src/app/views/query-response/pivot-items/pivot-items.tsx
+++ b/src/app/views/query-response/pivot-items/pivot-items.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { ThemeContext } from '../../../../themes/theme-context';
 import { ContentType, Mode } from '../../../../types/enums';
 import { IQuery } from '../../../../types/query-runner';
+import { isImageResponse } from '../../../services/actions/query-action-creator-util';
 import { lookupTemplate } from '../../../utils/adaptive-cards-lookup';
 import { Image, Monaco } from '../../common';
 import { genericCopy } from '../../common/copy';
@@ -12,7 +13,6 @@ import AdaptiveCard from '../adaptive-cards/AdaptiveCard';
 import { darkThemeHostConfig, lightThemeHostConfig } from '../adaptive-cards/AdaptiveHostConfig';
 import { queryResponseStyles } from '../queryResponse.styles';
 import { Snippets } from '../snippets';
-import { isImageResponse } from '../../../services/actions/query-action-creator-util';
 
 export const getPivotItems = (properties: any) => {
 


### PR DESCRIPTION
## Overview

Fixes #634 

### Demo

![image](https://user-images.githubusercontent.com/58787602/87500286-c4dbf480-c664-11ea-82f4-c011fbefcfcf.png)


### Notes

Creates an image url from all responses with a content type that includes images

## Testing Instructions

* Log in to GE
* Run `https://graph.microsoft.com/beta/me/photo/$value`
* Notice your image is presented