### PR TITLE
Fix: Add aria-labels and correct colour contrast

### DIFF
--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -91,9 +91,12 @@ class QueryResponse extends Component<IQueryResponseProps, IQueryResponseState> 
                 calloutProps={{ gapSpace: 0 }}
                 styles={{ root: { display: 'inline-block' } }}
               >
-                <IconButton onClick={this.handleShareQuery} className='share-query-btn' iconProps={{
-                  iconName: 'Share'
-                }} />
+                <IconButton
+                  onClick={this.handleShareQuery}
+                  className='share-query-btn'
+                  iconProps={{ iconName: 'Share'}}
+                  aria-label={'Share'}
+                />
               </TooltipHost>
             </div>
 
@@ -108,9 +111,12 @@ class QueryResponse extends Component<IQueryResponseProps, IQueryResponseState> 
                 calloutProps={{ gapSpace: 0 }}
                 styles={{ root: { display: 'inline-block' } }}
               >
-                <IconButton onClick={this.toggleModal} className='share-query-btn' iconProps={{
-                  iconName: 'MiniExpandMirrored'
-                }} />
+                <IconButton
+                  onClick={this.toggleModal}
+                  className='share-query-btn'
+                  iconProps={{ iconName: 'MiniExpandMirrored'}}
+                  aria-label={'Expand response'}
+                />
               </TooltipHost>
             </div>
           </>}

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -95,7 +95,7 @@ class QueryResponse extends Component<IQueryResponseProps, IQueryResponseState> 
                   onClick={this.handleShareQuery}
                   className='share-query-btn'
                   iconProps={{ iconName: 'Share'}}
-                  aria-label={'Share'}
+                  aria-label={'Share query message'}
                 />
               </TooltipHost>
             </div>

--- a/src/app/views/query-runner/request/permissions/PanelList.tsx
+++ b/src/app/views/query-runner/request/permissions/PanelList.tsx
@@ -1,6 +1,11 @@
 import {
-  Announced, DetailsList, DetailsListLayoutMode, IColumn,
-  Label, SearchBox, SelectionMode
+  Announced,
+  DetailsList,
+  DetailsListLayoutMode,
+  IColumn,
+  Label,
+  SearchBox,
+  SelectionMode
 } from 'office-ui-fabric-react';
 import React from 'react';
 import { FormattedMessage } from 'react-intl';

--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -330,7 +330,7 @@ export class SampleQueries extends Component<ISampleQueriesProps, any> {
           placeholder={messages['Search sample queries']}
           onChange={this.searchValueChanged}
           styles={{ field: { paddingLeft: 10 } }}
-          ariaLabel={'Search'}
+          aria-label={'Search'}
         />
         <hr />
         {error && <MessageBar messageBarType={MessageBarType.warning}

--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -1,8 +1,21 @@
 import {
-  Announced, DetailsList, DetailsRow,
-  FontSizes, FontWeights, getId, GroupHeader, IColumn,
-  Icon, MessageBar, MessageBarType,
-  SearchBox, SelectionMode, Spinner, SpinnerSize, styled, TooltipHost
+  Announced,
+  DetailsList,
+  DetailsRow,
+  FontSizes,
+  FontWeights,
+  getId,
+  GroupHeader,
+  IColumn,
+  Icon,
+  MessageBar,
+  MessageBarType,
+  SearchBox,
+  SelectionMode,
+  Spinner,
+  SpinnerSize,
+  styled,
+  TooltipHost
 } from 'office-ui-fabric-react';
 import React, { ChangeEvent, Component } from 'react';
 import { FormattedMessage, injectIntl } from 'react-intl';

--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -330,6 +330,7 @@ export class SampleQueries extends Component<ISampleQueriesProps, any> {
           placeholder={messages['Search sample queries']}
           onChange={this.searchValueChanged}
           styles={{ field: { paddingLeft: 10 } }}
+          ariaLabel={'Search'}
         />
         <hr />
         {error && <MessageBar messageBarType={MessageBarType.warning}

--- a/src/themes/light.ts
+++ b/src/themes/light.ts
@@ -18,7 +18,7 @@ export const light = {
     neutralQuaternary: '#d0d0d0',
     neutralTertiaryAlt: '#c8c8c8',
     neutralTertiary: '#c2c2c2',
-    neutralSecondary: '#858585',
+    neutralSecondary: '#535353',
     neutralPrimaryAlt: '#4b4b4b',
     neutralPrimary: '#333333',
     neutralDark: '#272727',


### PR DESCRIPTION
## Overview

- Add aria-labels for screen reader support.
- Altering the secondary text color on the persona card's tooltip to fit the acceptable color contrast ratio


Fixes #495 