### PR TITLE
Fix: copy paste query address bar

### DIFF
--- a/src/app/views/query-runner/QueryRunner.tsx
+++ b/src/app/views/query-runner/QueryRunner.tsx
@@ -117,8 +117,9 @@ export class QueryRunner extends Component<
 
     if (newQueryVersion !== oldQueryVersion) {
       if (newQueryVersion === 'v1.0' || newQueryVersion === 'beta') {
-        const sampleQuery = { ...this.props.sampleQuery };
+        const sampleQuery = { ...query };
         sampleQuery.selectedVersion = newQueryVersion;
+        sampleQuery.sampleUrl = newUrl;
         this.props.actions!.setSampleQuery(sampleQuery);
       }
     }


### PR DESCRIPTION
## Overview

Fixes #655 

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Selecting all and pasting the url over the previous content was also working. To fully fail copy pasting the url bar has to be empty

## Testing Instructions

* Clear everything on the url bar
* Copy `https://graph.microsoft.com/v1.0/me/messages`
* Paste it on the url bar
* You can choose to write it down manually