### PR TITLE
task:enhance sanitise query function

### DIFF
--- a/src/app/utils/query-url-sanitization.ts
+++ b/src/app/utils/query-url-sanitization.ts
@@ -1,21 +1,10 @@
 import { GRAPH_URL } from '../services/graph-constants';
 import { parseSampleUrl } from './sample-url-generation';
 
-// Matches patterns like "('<1f7ff346-c174-45e5-af38-294e51d9969a>')" or "('<key>')"
-const keyIdRegex = /\(\'\<?\{?[ ?0-9a-zA-Z-]*\}?\>?\'\)/g;
-
-// Matches patterns like "(query=<key>)" or "(itemat=<key>,mode=<mode>)"
-const functionParamInitialRegex = /(?<=\=).*?(?=,)/g;
-const functionParamFinalRegex = /(?<=\=).[^,]*(?=\))/g;
-
 // Matches pattterns within quotes e.g "displayName: Gupta"
 const quotedTextRegex = /"([^"]*)"/g;
 
-// Matches PII patterns
-const numberRegex =  /(?<=\/)\d+\b/g; // number between forward slashes
-const emailRegex = /([a-z0-9_\-.+]+)@\w+(\.\w+)*/gi;
-const guidRegex =
- /(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}/gi;
+const alphaNumericRegex = /[^a-z0-9]/g;
 
 
 export function sanitizeQueryUrl(url: string): string {
@@ -40,31 +29,11 @@ export function sanitizeQueryUrl(url: string): string {
     if (hasSpecialCharacters(sec)) {
       const index = sections.indexOf(sec);
       const replacementItemWithPrefix = `{${sections[index - 1]}-id}`;
-      sanitizedUrl = replaceWithRegexValues(sanitizedUrl, replacementItemWithPrefix);
-
-      // if pattern was not replaced by the regex values
-      if (!sanitizedUrl.includes('{')) {
-        sanitizedUrl = sanitizedUrl.replace(sec, replacementItemWithPrefix);
-      }
+      sanitizedUrl = sanitizedUrl.replace(sec, replacementItemWithPrefix);
     }
   });
 
   return `${urlPrefix}${sanitizedUrl}${queryString}` ;
-}
-
-function replaceWithRegexValues(sanitizedUrl: string, replacementItem: string) {
-
-  // Normalize parameters in param=<arbitraryKey> format with param={value} format
-  sanitizedUrl = sanitizedUrl.replace(functionParamInitialRegex, replacementItem);
-  sanitizedUrl = sanitizedUrl.replace(functionParamFinalRegex, replacementItem);
-
-  // Replace IDs and ID placeholders with generic {id}
-  sanitizedUrl = sanitizedUrl.replace(keyIdRegex, `/${replacementItem}`);
-  sanitizedUrl = sanitizedUrl.replace(guidRegex, replacementItem);
-  sanitizedUrl = sanitizedUrl.replace(numberRegex, replacementItem);
-  // Redact PII
-  sanitizedUrl = sanitizedUrl.replace(emailRegex, replacementItem);
-  return sanitizedUrl;
 }
 
 function sanitizeQueryParameters(queryString: string): string {
@@ -86,7 +55,7 @@ function sanitizeQueryParameters(queryString: string): string {
 */
 function hasSpecialCharacters(segment: string) {
   const specialCharacters = ['.', '=', '@', '-'];
-  return specialCharacters.some((character) =>  segment.includes(character));
+  return specialCharacters.some((character) =>  segment.includes(character) || segment.match(alphaNumericRegex));
 }
 
 function sanitizeQueryParameterValue(param: string) {

--- a/src/app/utils/query-url-sanitization.ts
+++ b/src/app/utils/query-url-sanitization.ts
@@ -4,6 +4,7 @@ import { parseSampleUrl } from './sample-url-generation';
 // Matches pattterns within quotes e.g "displayName: Gupta"
 const quotedTextRegex = /"([^"]*)"/g;
 
+// Matches patterns with alphanumeric characters e.g <CONGZUWfGUu4msTgNP66e2UAAySi>
 const alphaNumericRegex = /[^a-z0-9]/g;
 
 

--- a/src/app/utils/query-url-sanitization.ts
+++ b/src/app/utils/query-url-sanitization.ts
@@ -7,6 +7,9 @@ const quotedTextRegex = /"([^"]*)"/g;
 // matches strings that are all alphabets
 const allAlphaRegex = /^[A-Za-z]+$/;
 
+// matches strings with depracation identifier
+const depracationRegex = /_v2/gi;
+
 export function sanitizeQueryUrl(url: string): string {
   url = decodeURIComponent(url);
 
@@ -16,13 +19,14 @@ export function sanitizeQueryUrl(url: string): string {
 
   let resourceUrl = requestUrl;
   const sections = requestUrl.split('/');
-  sections.forEach(sec => {
-    if (isAllAlpha(sec)) {
+  sections.forEach(segment => {
+    if (isAllAlpha(segment) || isDeprecation(segment)) {
       return;
     }
-    const index = sections.indexOf(sec);
+
+    const index = sections.indexOf(segment);
     const replacementItemWithPrefix = `{${sections[index - 1]}-id}`;
-    resourceUrl = resourceUrl.replace(sec, replacementItemWithPrefix);
+    resourceUrl = resourceUrl.replace(segment, replacementItemWithPrefix);
 });
 
   return `${GRAPH_URL}/${queryVersion}/${resourceUrl}${queryString}`;
@@ -47,6 +51,15 @@ function sanitizeQueryParameters(queryString: string): string {
  */
 export function isAllAlpha(segment: string): boolean {
   return !!segment.match(allAlphaRegex);
+}
+
+/**
+ * @param segment part of the url string to test
+ * depracated resources may have `_v2` temporarily
+ * @returns boolean
+ */
+export function isDeprecation(segment: string): boolean {
+  return !!segment.match(depracationRegex);
 }
 
 function sanitizeQueryParameterValue(param: string) {

--- a/src/app/utils/query-url-sanitization.ts
+++ b/src/app/utils/query-url-sanitization.ts
@@ -56,7 +56,7 @@ function sanitizeQueryParameters(queryString: string): string {
 */
 function hasSpecialCharacters(segment: string): boolean {
   const specialCharacters = ['.', '=', '@', '-'];
-  return !!specialCharacters.some((character) =>  segment.includes(character) || segment.match(alphaNumericRegex));
+  return specialCharacters.some((character) =>  segment.includes(character) || !!segment.match(alphaNumericRegex));
 }
 
 function sanitizeQueryParameterValue(param: string) {

--- a/src/app/utils/query-url-sanitization.ts
+++ b/src/app/utils/query-url-sanitization.ts
@@ -44,12 +44,19 @@ function sanitizeQueryParameters(queryString: string): string {
 *   2. special characters are present
 */
 export function containsIdentifier(segment: string): boolean {
-  return isAlphaNumericString(segment) || hasSpecialCharacters(segment);
+  return isAlphaNumericString(segment)
+  || isNumericString(segment)
+  || hasSpecialCharacters(segment);
 }
 
 export function hasSpecialCharacters(segment: string): boolean {
   const specialCharacters = ['.', '=', '@', '-'];
   return specialCharacters.some((character) => segment.includes(character));
+}
+
+export function isNumericString(segment: string): boolean {
+  const numberRegex = /^[0-9]*$/;
+  return !!segment.match(numberRegex);
 }
 
 export function isAlphaNumericString(str: string): boolean {

--- a/src/app/utils/query-url-sanitization.ts
+++ b/src/app/utils/query-url-sanitization.ts
@@ -11,19 +11,17 @@ export function sanitizeQueryUrl(url: string): string {
   const { search, queryVersion, requestUrl } = parseSampleUrl(url);
   const queryString: string = sanitizeQueryParameters(search);
 
-  // Drop query string
-  let sanitizedUrl = requestUrl;
-
-  const sections = requestUrl.split('/');
+  let resourceUrl = requestUrl;
+  const sections = resourceUrl.split('/');
   sections.forEach(sec => {
     if (containsIdentifier(sec)) {
       const index = sections.indexOf(sec);
       const replacementItemWithPrefix = `{${sections[index - 1]}-id}`;
-      sanitizedUrl = sanitizedUrl.replace(sec, replacementItemWithPrefix);
+      resourceUrl = resourceUrl.replace(sec, replacementItemWithPrefix);
     }
   });
 
-  return `${GRAPH_URL}/${queryVersion}/${sanitizedUrl}${queryString}`;
+  return `${GRAPH_URL}/${queryVersion}/${resourceUrl}${queryString}`;
 }
 
 function sanitizeQueryParameters(queryString: string): string {

--- a/src/app/utils/query-url-sanitization.ts
+++ b/src/app/utils/query-url-sanitization.ts
@@ -54,9 +54,9 @@ function sanitizeQueryParameters(queryString: string): string {
 * Special characters present in the url show that the
 * segment contains an identifier
 */
-function hasSpecialCharacters(segment: string) {
+function hasSpecialCharacters(segment: string): boolean {
   const specialCharacters = ['.', '=', '@', '-'];
-  return specialCharacters.some((character) =>  segment.includes(character) || segment.match(alphaNumericRegex));
+  return !!specialCharacters.some((character) =>  segment.includes(character) || segment.match(alphaNumericRegex));
 }
 
 function sanitizeQueryParameterValue(param: string) {

--- a/src/app/utils/query-url-sanitization.ts
+++ b/src/app/utils/query-url-sanitization.ts
@@ -12,7 +12,7 @@ export function sanitizeQueryUrl(url: string): string {
   const queryString: string = sanitizeQueryParameters(search);
 
   let resourceUrl = requestUrl;
-  const sections = resourceUrl.split('/');
+  const sections = requestUrl.split('/');
   sections.forEach(sec => {
     if (containsIdentifier(sec)) {
       const index = sections.indexOf(sec);

--- a/src/app/utils/query-url-sanitization.ts
+++ b/src/app/utils/query-url-sanitization.ts
@@ -60,12 +60,12 @@ export function hasSpecialCharacters(segment: string): boolean {
 }
 
 export function isAlphaNumericString(str: string): boolean {
-  let code, i, len;
+  let code = 0;
   let isNumeric = false;
   let isAlpha = false;
 
-  for (i = 0, len = str.length; i < len; i++) {
-    code = str.charCodeAt(i);
+  for (let index = 0; index < str.length; index++) {
+    code = str.charCodeAt(index);
 
     switch (true) {
       // check if all values are 0-9

--- a/src/app/utils/query-url-sanitization.ts
+++ b/src/app/utils/query-url-sanitization.ts
@@ -8,18 +8,11 @@ export function sanitizeQueryUrl(url: string): string {
   url = decodeURIComponent(url);
 
   // Extract query string
-  const { search, queryVersion } = parseSampleUrl(url);
+  const { search, queryVersion, requestUrl } = parseSampleUrl(url);
   const queryString: string = sanitizeQueryParameters(search);
 
   // Drop query string
-  let sanitizedUrl = url.split('?')[0];
-
-  /*
-  * Remove url prefix and query version.
-  * They have special characters used in the check that follows
-  */
-  const urlPrefix = `${GRAPH_URL}/${queryVersion}`;
-  sanitizedUrl = sanitizedUrl.replace(urlPrefix, '');
+  let sanitizedUrl = requestUrl;
 
   const sections = sanitizedUrl.split('/');
   sections.forEach(sec => {
@@ -30,7 +23,7 @@ export function sanitizeQueryUrl(url: string): string {
     }
   });
 
-  return `${urlPrefix}${sanitizedUrl}${queryString}`;
+  return `${GRAPH_URL}/${queryVersion}/${sanitizedUrl}${queryString}`;
 }
 
 function sanitizeQueryParameters(queryString: string): string {

--- a/src/app/utils/query-url-sanitization.ts
+++ b/src/app/utils/query-url-sanitization.ts
@@ -12,7 +12,7 @@ export function sanitizeQueryUrl(url: string): string {
   const queryString: string = sanitizeQueryParameters(search);
 
   // Drop query string
-  let sanitizedUrl = '';
+  let sanitizedUrl = requestUrl;
 
   const sections = requestUrl.split('/');
   sections.forEach(sec => {

--- a/src/app/utils/query-url-sanitization.ts
+++ b/src/app/utils/query-url-sanitization.ts
@@ -5,7 +5,7 @@ import { parseSampleUrl } from './sample-url-generation';
 const quotedTextRegex = /"([^"]*)"/g;
 
 // Matches patterns with alphanumeric characters e.g <CONGZUWfGUu4msTgNP66e2UAAySi>
-const alphaNumericRegex = /[^a-z0-9]/g;
+const alphaNumericRegex = /^[a-z0-9]+$/i;
 
 
 export function sanitizeQueryUrl(url: string): string {
@@ -27,7 +27,7 @@ export function sanitizeQueryUrl(url: string): string {
 
   const sections = sanitizedUrl.split('/');
   sections.forEach(sec => {
-    if (hasSpecialCharacters(sec)) {
+    if (containsIdentifier(sec)) {
       const index = sections.indexOf(sec);
       const replacementItemWithPrefix = `{${sections[index - 1]}-id}`;
       sanitizedUrl = sanitizedUrl.replace(sec, replacementItemWithPrefix);
@@ -51,12 +51,21 @@ function sanitizeQueryParameters(queryString: string): string {
 }
 
 /*
-* Special characters present in the url show that the
-* segment contains an identifier
+* A string contains an identifier if:
+*   1. is an alphanumeric string
+*   2. special characters are present
 */
+function containsIdentifier(segment: string): boolean {
+  return isAlphaNumericString(segment) || hasSpecialCharacters(segment);
+}
+
 function hasSpecialCharacters(segment: string): boolean {
   const specialCharacters = ['.', '=', '@', '-'];
-  return specialCharacters.some((character) =>  segment.includes(character) || !!segment.match(alphaNumericRegex));
+  return specialCharacters.some((character) =>  segment.includes(character));
+}
+
+function isAlphaNumericString(segment: string): boolean {
+  return !!segment.match(alphaNumericRegex);
 }
 
 function sanitizeQueryParameterValue(param: string) {

--- a/src/tests/utils/sanitize-url.spec.tsx
+++ b/src/tests/utils/sanitize-url.spec.tsx
@@ -1,5 +1,5 @@
 import {
-  isAllAlpha, sanitizeQueryUrl
+  isAllAlpha, isDeprecation, sanitizeQueryUrl
 } from '../../app/utils/query-url-sanitization';
 
 
@@ -15,6 +15,22 @@ describe('isAllAlpha should ', () => {
     it(`return ${element.isAllAlphabetic} for ${element.key}`, () => {
       const key = isAllAlpha(element.key);
       expect(key).toBe(element.isAllAlphabetic);
+    });
+  });
+});
+
+describe('isDepraction should ', () => {
+  const list = [
+    { key: 'messages_V2', depracated: true },
+    { key: 'messages', depracated: false },
+    { key: 'users_v2', depracated: true },
+    { key: 'users', depracated: false }
+  ];
+
+  list.forEach(element => {
+    it(`return ${element.depracated} for ${element.key}`, () => {
+      const key = isDeprecation(element.key);
+      expect(key).toBe(element.depracated);
     });
   });
 });
@@ -57,6 +73,11 @@ describe('Sanitize Query Url should', () => {
       // tslint:disable-next-line: max-line-length
       url: 'https://graph.microsoft.com/v1.0/teams/02bd9fd6-8f93-4758-87c3-1fb73740a315/channels/19:09fc54a3141a45d0bc769cf506d2e079@thread.skype',
       sanitized: 'https://graph.microsoft.com/v1.0/teams/{teams-id}/channels/{channels-id}'
+    },
+    {
+      check: 'with depracated resource and without id',
+      url: 'https://graph.microsoft.com/v1.0/applications_v2/02bd9fd6-8f93-4758-87c3-1fb73740a315',
+      sanitized: 'https://graph.microsoft.com/v1.0/applications_v2/{applications_v2-id}'
     }
   ];
 

--- a/src/tests/utils/sanitize-url.spec.tsx
+++ b/src/tests/utils/sanitize-url.spec.tsx
@@ -1,4 +1,33 @@
-import { sanitizeQueryUrl } from '../../app/utils/query-url-sanitization';
+import { containsIdentifier, isAlphaNumericString, sanitizeQueryUrl } from '../../app/utils/query-url-sanitization';
+
+describe('containsIdentifier should ', () => {
+  const list = [
+    { key: 'oIx3zN98jEmVOM', contains: true },
+    { key: 'oIx3zN98jEmVOM-4mUJzSGUANeje', contains: true },
+    { key: 'planner', contains: false }
+  ];
+  list.forEach(element => {
+    it(`return ${element.contains} for ${element.key}`, () => {
+      const isIdentifier = containsIdentifier(element.key);
+      expect(isIdentifier).toBe(element.contains);
+    });
+  });
+});
+
+describe('isAlphaNumericString should ', () => {
+  const list = [
+    { key: 'aaa', isAlphaNumeric: false },
+    { key: '111', isAlphaNumeric: false },
+    { key: '1a1', isAlphaNumeric: true }
+  ];
+  list.forEach(element => {
+    it(`return ${element.isAlphaNumeric} for ${element.key}`, () => {
+      const isIdentifier = isAlphaNumericString(element.key);
+      expect(isIdentifier).toBe(element.isAlphaNumeric);
+    });
+  });
+});
+
 
 describe('Sanitize Query Url should', () => {
   const list = [

--- a/src/tests/utils/sanitize-url.spec.tsx
+++ b/src/tests/utils/sanitize-url.spec.tsx
@@ -1,32 +1,40 @@
-import { sanitizeQueryUrl } from "../../app/utils/query-url-sanitization";
+import { sanitizeQueryUrl } from '../../app/utils/query-url-sanitization';
 
 describe('Sanitize Query Url should', () => {
   const list = [
     {
       check: 'without task id',
       url: 'https://graph.microsoft.com/v1.0/planner/tasks/oIx3zN98jEmVOM-4mUJzSGUANeje',
-      sanitized: 'https://graph.microsoft.com/v1.0/planner/tasks/<id>',
+      sanitized: 'https://graph.microsoft.com/v1.0/planner/tasks/{tasks-id}',
     },
     {
       check: 'without email',
       url: 'https://graph.microsoft.com/v1.0/users/MiriamG@M365x214355.onmicrosoft.com',
-      sanitized: 'https://graph.microsoft.com/v1.0/users/<email>',
+      sanitized: 'https://graph.microsoft.com/v1.0/users/{users-id}',
     },
     {
       check: 'without message id',
+      // tslint:disable-next-line: max-line-length
       url: 'https://graph.microsoft.com/v1.0/me/messages/AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hMDZiLTU1OGY5OTZhYmY4OABGAAAAAAAiQ8W967B7TKBjgx9rVEURBwAiIsqMbYjsT5e-T7KzowPTAAAAAAEMAAAiIsqMbYjsT5e-T7KzowPTAAMCzwJpAAA=',
-      sanitized: 'https://graph.microsoft.com/v1.0/me/messages/<id>'
+      sanitized: 'https://graph.microsoft.com/v1.0/me/messages/{messages-id}'
+    },
+    {
+      check: 'without extension id',
+      url: 'https://graph.microsoft.com/v1.0/me/extensions/com.contoso.roamingSettings',
+      sanitized: 'https://graph.microsoft.com/v1.0/me/extensions/{extensions-id}'
+    },
+    {
+      check: 'without plan id',
+      url: 'https://graph.microsoft.com/v1.0/planner/plans/CONGZUWfGUu4msTgNP66e2UAAySi',
+      sanitized: 'https://graph.microsoft.com/v1.0/planner/plans/CONGZUWfGUu4msTgNP66e2UAAySi'
     }
   ];
 
-  for (let index = 0; index < list.length; index++) {
-    const element = list[index];
-
+  list.forEach(element => {
     it(`return url ${element.check}`, () => {
       const normalizedUrl = sanitizeQueryUrl(element.url);
       expect(normalizedUrl).toEqual(element.sanitized);
     });
-
-  }
+  });
 
 });

--- a/src/tests/utils/sanitize-url.spec.tsx
+++ b/src/tests/utils/sanitize-url.spec.tsx
@@ -1,4 +1,7 @@
-import { containsIdentifier, isAlphaNumericString, sanitizeQueryUrl } from '../../app/utils/query-url-sanitization';
+import {
+  containsIdentifier, isAlphaNumericString,
+  isNumericString, sanitizeQueryUrl
+} from '../../app/utils/query-url-sanitization';
 
 describe('containsIdentifier should ', () => {
   const list = [
@@ -24,6 +27,20 @@ describe('isAlphaNumericString should ', () => {
     it(`return ${element.isAlphaNumeric} for ${element.key}`, () => {
       const isIdentifier = isAlphaNumericString(element.key);
       expect(isIdentifier).toBe(element.isAlphaNumeric);
+    });
+  });
+});
+
+describe('isNumericString should ', () => {
+  const list = [
+    { key: 'aaa', isNumeric: false },
+    { key: '111', isNumeric: true },
+    { key: '1a1', isNumeric: false }
+  ];
+  list.forEach(element => {
+    it(`return ${element.isNumeric} for ${element.key}`, () => {
+      const isIdentifier = isNumericString(element.key);
+      expect(isIdentifier).toBe(element.isNumeric);
     });
   });
 });

--- a/src/tests/utils/sanitize-url.spec.tsx
+++ b/src/tests/utils/sanitize-url.spec.tsx
@@ -27,6 +27,11 @@ describe('Sanitize Query Url should', () => {
       check: 'without plan id',
       url: 'https://graph.microsoft.com/v1.0/planner/plans/CONGZUWfGUu4msTgNP66e2UAAySi',
       sanitized: 'https://graph.microsoft.com/v1.0/planner/plans/CONGZUWfGUu4msTgNP66e2UAAySi'
+    },
+    {
+      check: 'without section id',
+      url: 'https://graph.microsoft.com/v1.0/me/onenote/sections/1f7ff346-c174-45e5-af38-294e51d9969a/pages',
+      sanitized: 'https://graph.microsoft.com/v1.0/me/onenote/sections/{sections-id}/pages'
     }
   ];
 

--- a/src/tests/utils/sanitize-url.spec.tsx
+++ b/src/tests/utils/sanitize-url.spec.tsx
@@ -32,6 +32,12 @@ describe('Sanitize Query Url should', () => {
       check: 'without section id',
       url: 'https://graph.microsoft.com/v1.0/me/onenote/sections/1f7ff346-c174-45e5-af38-294e51d9969a/pages',
       sanitized: 'https://graph.microsoft.com/v1.0/me/onenote/sections/{sections-id}/pages'
+    },
+    {
+      check: 'with all parameters replaced',
+      // tslint:disable-next-line: max-line-length
+      url: 'https://graph.microsoft.com/v1.0/teams/02bd9fd6-8f93-4758-87c3-1fb73740a315/channels/19:09fc54a3141a45d0bc769cf506d2e079@thread.skype',
+      sanitized: 'https://graph.microsoft.com/v1.0/teams/{teams-id}/channels/{channels-id}'
     }
   ];
 

--- a/src/tests/utils/sanitize-url.spec.tsx
+++ b/src/tests/utils/sanitize-url.spec.tsx
@@ -83,8 +83,8 @@ describe('Sanitize Query Url should', () => {
 
   list.forEach(element => {
     it(`return url ${element.check}`, () => {
-      const normalizedUrl = sanitizeQueryUrl(element.url);
-      expect(normalizedUrl).toEqual(element.sanitized);
+      const sanitizedUrl = sanitizeQueryUrl(element.url);
+      expect(sanitizedUrl).toEqual(element.sanitized);
     });
   });
 

--- a/src/tests/utils/sanitize-url.spec.tsx
+++ b/src/tests/utils/sanitize-url.spec.tsx
@@ -26,7 +26,7 @@ describe('Sanitize Query Url should', () => {
     {
       check: 'without plan id',
       url: 'https://graph.microsoft.com/v1.0/planner/plans/CONGZUWfGUu4msTgNP66e2UAAySi',
-      sanitized: 'https://graph.microsoft.com/v1.0/planner/plans/CONGZUWfGUu4msTgNP66e2UAAySi'
+      sanitized: 'https://graph.microsoft.com/v1.0/planner/plans/{plans-id}'
     },
     {
       check: 'without section id',

--- a/src/tests/utils/sanitize-url.spec.tsx
+++ b/src/tests/utils/sanitize-url.spec.tsx
@@ -1,50 +1,23 @@
 import {
-  containsIdentifier, isAlphaNumericString,
-  isNumericString, sanitizeQueryUrl
+  isAllAlpha, sanitizeQueryUrl
 } from '../../app/utils/query-url-sanitization';
 
-describe('containsIdentifier should ', () => {
+
+describe('isAllAlpha should ', () => {
   const list = [
-    { key: 'oIx3zN98jEmVOM', contains: true },
-    { key: 'oIx3zN98jEmVOM-4mUJzSGUANeje', contains: true },
-    { key: 'planner', contains: false }
+    { key: 'aaa', isAllAlphabetic: true },
+    { key: 'aZa', isAllAlphabetic: true },
+    { key: '111', isAllAlphabetic: false },
+    { key: '1a1', isAllAlphabetic: false }
   ];
+
   list.forEach(element => {
-    it(`return ${element.contains} for ${element.key}`, () => {
-      const isIdentifier = containsIdentifier(element.key);
-      expect(isIdentifier).toBe(element.contains);
+    it(`return ${element.isAllAlphabetic} for ${element.key}`, () => {
+      const key = isAllAlpha(element.key);
+      expect(key).toBe(element.isAllAlphabetic);
     });
   });
 });
-
-describe('isAlphaNumericString should ', () => {
-  const list = [
-    { key: 'aaa', isAlphaNumeric: false },
-    { key: '111', isAlphaNumeric: false },
-    { key: '1a1', isAlphaNumeric: true }
-  ];
-  list.forEach(element => {
-    it(`return ${element.isAlphaNumeric} for ${element.key}`, () => {
-      const isIdentifier = isAlphaNumericString(element.key);
-      expect(isIdentifier).toBe(element.isAlphaNumeric);
-    });
-  });
-});
-
-describe('isNumericString should ', () => {
-  const list = [
-    { key: 'aaa', isNumeric: false },
-    { key: '111', isNumeric: true },
-    { key: '1a1', isNumeric: false }
-  ];
-  list.forEach(element => {
-    it(`return ${element.isNumeric} for ${element.key}`, () => {
-      const isIdentifier = isNumericString(element.key);
-      expect(isIdentifier).toBe(element.isNumeric);
-    });
-  });
-});
-
 
 describe('Sanitize Query Url should', () => {
   const list = [


### PR DESCRIPTION
## Overview

This work enhances the work done by @millicentachieng in #734 to redact PII from the query url.

## Notes
Assumptions made are that URL segments with identifiers are never full alphabetic strings. They will be strings with numbers / special characters. 

## Tasks
- [x] Checks the URL segments for identifier characters 

- [x] Replaces the id with the resource name e.g. `messages-id` / `tasks-id`

- [x] Adds tests to validate scenarios