### PR TITLE
remove window instrumentation key

### DIFF
--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -65,7 +65,7 @@ class Telemetry implements ITelemetry {
   }
 
   private getInstrumentationKey() {
-    return (window as any).InstrumentationKey || process.env.REACT_APP_INSTRUMENTATION_KEY || '';
+    return process.env.REACT_APP_INSTRUMENTATION_KEY || '';
   }
 }
 


### PR DESCRIPTION
## Overview

We have our instrumentation key that is unreachable by the function because the window instrumentation key is never empty.
We need to change it so that the staging environment can point to its own staging key