### PR TITLE
Adding JWT.ms support in the Access Token view

### DIFF
--- a/src/app/views/query-runner/request/auth/Auth.styles.ts
+++ b/src/app/views/query-runner/request/auth/Auth.styles.ts
@@ -6,7 +6,7 @@ export const authStyles = (theme: ITheme) => {
       padding: 10
     },
     accessTokenContainer: {
-      width: 120,
+      width: 160,
       display: 'flex',
       flexDirection: 'row',
       justifyContent: 'space-between',

--- a/src/app/views/query-runner/request/auth/Auth.tsx
+++ b/src/app/views/query-runner/request/auth/Auth.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useSelector } from 'react-redux';
 import { telemetry } from '../../../../../telemetry';
+import { translateMessage } from '../../../../utils/translate-messages';
 import { classNames } from '../../../classnames';
 import { genericCopy } from '../../../common/copy';
 import { authStyles } from './Auth.styles';
@@ -30,7 +31,7 @@ export function Auth(props: any) {
         <div className={classes.accessTokenContainer}>
           <Label className={classes.accessTokenLabel}><FormattedMessage id='Access Token' /></Label>
           <IconButton onClick={handleCopy} iconProps={copyIcon} title='Copy' ariaLabel='Copy' />
-          <IconButton iconProps={tokenDetailsIcon} title='Get token details (Powered by jwt.ms)' ariaLabel='Get token details (Powered by jwt.ms)' href={`https://jwt.ms#access_token=${accessToken}`} target="_blank" />
+          <IconButton iconProps={tokenDetailsIcon} title={translateMessage('Get token details (Powered by jwt.ms)')} ariaLabel={translateMessage('Get token details (Powered by jwt.ms)')} href={`https://jwt.ms#access_token=${accessToken}`} target="_blank" />
         </div>
         <Label className={classes.accessToken} >{accessToken}</Label>
       </div>

--- a/src/app/views/query-runner/request/auth/Auth.tsx
+++ b/src/app/views/query-runner/request/auth/Auth.tsx
@@ -31,7 +31,11 @@ export function Auth(props: any) {
         <div className={classes.accessTokenContainer}>
           <Label className={classes.accessTokenLabel}><FormattedMessage id='Access Token' /></Label>
           <IconButton onClick={handleCopy} iconProps={copyIcon} title='Copy' ariaLabel='Copy' />
-          <IconButton iconProps={tokenDetailsIcon} title={translateMessage('Get token details (Powered by jwt.ms)')} ariaLabel={translateMessage('Get token details (Powered by jwt.ms)')} href={`https://jwt.ms#access_token=${accessToken}`} target="_blank" />
+          <IconButton iconProps={tokenDetailsIcon}
+            title={translateMessage('Get token details (Powered by jwt.ms)')}
+            ariaLabel={translateMessage('Get token details (Powered by jwt.ms)')}
+            href={`https://jwt.ms#access_token=${accessToken}`}
+            target='_blank' />
         </div>
         <Label className={classes.accessToken} >{accessToken}</Label>
       </div>

--- a/src/app/views/query-runner/request/auth/Auth.tsx
+++ b/src/app/views/query-runner/request/auth/Auth.tsx
@@ -20,12 +20,17 @@ export function Auth(props: any) {
     iconName: 'copy'
   };
 
+  const tokenDetailsIcon: IIconProps = {
+    iconName: 'code'
+  };
+
   return (<div className={classes.auth}>
     {accessToken ?
       <div>
         <div className={classes.accessTokenContainer}>
           <Label className={classes.accessTokenLabel}><FormattedMessage id='Access Token' /></Label>
           <IconButton onClick={handleCopy} iconProps={copyIcon} title='Copy' ariaLabel='Copy' />
+          <IconButton iconProps={tokenDetailsIcon} title='Get token details (Powered by jwt.ms)' ariaLabel='Get token details (Powered by jwt.ms)' href={`https://jwt.ms#access_token=${accessToken}`} target="_blank" />
         </div>
         <Label className={classes.accessToken} >{accessToken}</Label>
       </div>

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -319,5 +319,6 @@
   "Administrator permission": "Admin of the tenant needs to authorize first before you can consent to this permission",
   "Adaptive Cards designer": "Adaptive Cards designer.",
   "Click Run Query button above to fetch Adaptive Card": "Click Run Query button above to fetch Adaptive Card.",
-  "Your history includes queries made in the last 30 days": "Your history includes queries made in the last 30 days"
+  "Your history includes queries made in the last 30 days": "Your history includes queries made in the last 30 days",
+  "Get token details (Powered by jwt.ms)": "Get token details (Powered by jwt.ms)"
 }

--- a/src/messages/GE_fr-FR.json
+++ b/src/messages/GE_fr-FR.json
@@ -319,5 +319,6 @@
   "Administrator permission": "L'administration du locataire doit d'abord obtenir une autorisation avant que vous puissiez donner votre consentement",
   "Adaptive Cards designer": "Concepteur de cartes adaptatives.",
   "Click Run Query button above to fetch Adaptive Card": "Cliquez sur le bouton Exécuter la requête ci-dessus pour aller chercher la carte adaptative.",
-  "Your history includes queries made in the last 30 days": "Votre historique inclut les requêtes effectuées au cours des 30 derniers jours"
+  "Your history includes queries made in the last 30 days": "Votre historique inclut les requêtes effectuées au cours des 30 derniers jours",
+  "Get token details (Powered by jwt.ms)": "Obtenir les détails du jeton (Propulsé par jwt.ms)"
 }

--- a/src/messages/GE_fr-FR.json
+++ b/src/messages/GE_fr-FR.json
@@ -319,6 +319,5 @@
   "Administrator permission": "L'administration du locataire doit d'abord obtenir une autorisation avant que vous puissiez donner votre consentement",
   "Adaptive Cards designer": "Concepteur de cartes adaptatives.",
   "Click Run Query button above to fetch Adaptive Card": "Cliquez sur le bouton Exécuter la requête ci-dessus pour aller chercher la carte adaptative.",
-  "Your history includes queries made in the last 30 days": "Votre historique inclut les requêtes effectuées au cours des 30 derniers jours",
-  "Get token details (Powered by jwt.ms)": "Obtenir les détails du jeton (Propulsé par jwt.ms)"
+  "Your history includes queries made in the last 30 days": "Votre historique inclut les requêtes effectuées au cours des 30 derniers jours"
 }


### PR DESCRIPTION
## Overview

Based on a [Twitter discussion](https://twitter.com/sebastienlevert/status/1324336189151891458), this would be a great feature to inspect our Access Token when using the Graph Explorer

### Demo

![image](https://user-images.githubusercontent.com/7620955/98404566-d8a6ce80-2038-11eb-9032-8d9675394f72.png)

![image](https://user-images.githubusercontent.com/7620955/98404641-f70cca00-2038-11eb-82a2-de48d6e6b2dd.png)

## Testing Instructions

* Open the Graph Explorer
* Connect using a Microsoft Account
* Execute `/me`
* Navigate to the Access Token pivot item
* Click on the `{ }` icon