### PR TITLE
descriptive message after pop-up blocked in browser

### DIFF
--- a/src/app/views/authentication/Authentication.tsx
+++ b/src/app/views/authentication/Authentication.tsx
@@ -38,7 +38,7 @@ export class Authentication extends Component<IAuthenticationProps, { loginInPro
       this.props.actions!.setQueryResponseStatus({
         ok: false,
         statusText: messages['Authentication failed'],
-        status: errorCode.replace('_', ' '),
+        status: errorCode === 'popup_window_error' ? 'popup blocked, allow pop-up windows in your browser' : errorCode.replace('_', ' '),
         messageType: MessageBarType.error
       });
       this.setState({ loginInProgress: false });

--- a/src/app/views/authentication/Authentication.tsx
+++ b/src/app/views/authentication/Authentication.tsx
@@ -9,6 +9,7 @@ import { Mode } from '../../../types/enums';
 import * as authActionCreators from '../../services/actions/auth-action-creators';
 import * as queryStatusActionCreators from '../../services/actions/query-status-action-creator';
 import { logIn } from '../../services/graph-client/msal-service';
+import { translateMessage } from '../../utils/translate-messages';
 import { classNames } from '../classnames';
 import { showSignInButtonOrProfile } from './auth-util-components';
 import { authenticationStyles } from './Authentication.styles';
@@ -39,7 +40,7 @@ export class Authentication extends Component<IAuthenticationProps, { loginInPro
         ok: false,
         statusText: messages['Authentication failed'],
         status: errorCode === 'popup_window_error'
-          ? 'popup blocked, allow pop-up windows in your browser'
+          ? translateMessage('popup blocked, allow pop-up windows in your browser')
           : errorCode.replace('_', ' '),
         messageType: MessageBarType.error
       });

--- a/src/app/views/authentication/Authentication.tsx
+++ b/src/app/views/authentication/Authentication.tsx
@@ -38,7 +38,9 @@ export class Authentication extends Component<IAuthenticationProps, { loginInPro
       this.props.actions!.setQueryResponseStatus({
         ok: false,
         statusText: messages['Authentication failed'],
-        status: errorCode === 'popup_window_error' ? 'popup blocked, allow pop-up windows in your browser' : errorCode.replace('_', ' '),
+        status: errorCode === 'popup_window_error'
+          ? 'popup blocked, allow pop-up windows in your browser'
+          : errorCode.replace('_', ' '),
         messageType: MessageBarType.error
       });
       this.setState({ loginInProgress: false });

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -323,5 +323,6 @@
   "Get token details (Powered by jwt.ms)": "Get token details (Powered by jwt.ms)",
   "HTTP request method option": "HTTP request method option",
   "Microsoft Graph API Version option": "Microsoft Graph API Version option",
-  "Query Sample Input": "Query sample input"
+  "Query Sample Input": "Query sample input",
+  "popup blocked, allow pop-up windows in your browser": "popup blocked, allow pop-up windows in your browser"
 }


### PR DESCRIPTION
## Overview

According to issue #753, there are 2 options(solutions) to the issue. I worked on `adding a descriptive error message after the pop-up is blocked by browser windows.` 
### Demo

![Screenshot 2020-11-14 at 16 05 45](https://user-images.githubusercontent.com/48981919/99147590-4b482780-2693-11eb-9161-a25925b2571c.png)

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Checkout to the branch
* Try logging in to Safari or chrome(Ensure that browser blocks any popups)
* Try sign in and check the error message provided after login fails