### PR TITLE
Fix: focus order

### DIFF
--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -172,15 +172,6 @@ class QueryResponse extends Component<IQueryResponseProps, IQueryResponseState> 
       </div >
     );
   }
-
-  private showResponse(pivotItems: JSX.Element[]) {
-    return <Pivot className='pivot-response'
-      styles={{ root: { display: 'flex', flexWrap: 'wrap' } }}
-      onLinkClick={(pivotItem) => onPivotItemClick(pivotItem)}
-    >
-      {pivotItems}
-    </Pivot>;
-  }
 }
 
 function mapStateToProps(state: any) {

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -12,11 +12,11 @@ import React, { Component } from 'react';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 
-import { Mode } from '../../../types/enums';
 import { IQueryResponseProps, IQueryResponseState } from '../../../types/query-response';
+import { translateMessage } from '../../utils/translate-messages';
 import { copy } from '../common/copy';
 import { createShareLink } from '../common/share';
-import { getPivotItems, onPivotItemClick } from './pivot-items/pivot-items';
+import { getPivotItems } from './pivot-items/pivot-items';
 import './query-response.scss';
 
 class QueryResponse extends Component<IQueryResponseProps, IQueryResponseState> {
@@ -107,14 +107,14 @@ class QueryResponse extends Component<IQueryResponseProps, IQueryResponseState> 
             {pivotItems}
             <PivotItem headerText='Share' key='share'
               itemIcon='Share'
-              ariaLabel={`${messages['Share Query Message']}`}
-              title={`${messages['Share Query Message']}`}
+              ariaLabel={translateMessage('Share Query Message')}
+              title={translateMessage('Share Query Message')}
               onRenderItemLink={this.renderItemLink}
             />
             <PivotItem headerText='Expand' key='expand'
               itemIcon='MiniExpandMirrored'
-              ariaLabel={`${messages['Expand response']}`}
-              title={`${messages['Expand response']}`}
+              ariaLabel={translateMessage('Expand response')}
+              title={translateMessage('Expand response')}
               onRenderItemLink={this.renderItemLink}
             />
           </Pivot>

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -1,8 +1,11 @@
 import {
   DefaultButton, FontSizes,
+  getId,
+  Icon,
   IconButton, Modal, Pivot,
   PivotItem,
-  PrimaryButton
+  PrimaryButton,
+  TooltipHost
 } from 'office-ui-fabric-react';
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
 import React, { Component } from 'react';
@@ -63,6 +66,15 @@ class QueryResponse extends Component<IQueryResponseProps, IQueryResponseState> 
     }
   }
 
+  public renderItemLink(link: any) {
+    return (
+      <TooltipHost content={link.title} id={getId()} calloutProps={{ gapSpace: 0 }} >
+        <Icon iconName={link.itemIcon} style={{ paddingRight: 5 }} />
+        {link.headerText}
+      </TooltipHost>
+    );
+  }
+
   public render() {
     let body: any;
     let headers;
@@ -95,9 +107,15 @@ class QueryResponse extends Component<IQueryResponseProps, IQueryResponseState> 
             {pivotItems}
             <PivotItem headerText='Share' key='share'
               itemIcon='Share'
+              ariaLabel={`${messages['Share Query Message']}`}
+              title={`${messages['Share Query Message']}`}
+              onRenderItemLink={this.renderItemLink}
             />
             <PivotItem headerText='Expand' key='expand'
               itemIcon='MiniExpandMirrored'
+              ariaLabel={`${messages['Expand response']}`}
+              title={`${messages['Expand response']}`}
+              onRenderItemLink={this.renderItemLink}
             />
           </Pivot>
         </div>

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -1,8 +1,8 @@
 import {
   DefaultButton, FontSizes,
-  getId, IconButton, Modal, Pivot,
+  IconButton, Modal, Pivot,
   PivotItem,
-  PrimaryButton, TooltipHost
+  PrimaryButton
 } from 'office-ui-fabric-react';
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
 import React, { Component } from 'react';
@@ -89,14 +89,16 @@ class QueryResponse extends Component<IQueryResponseProps, IQueryResponseState> 
     return (
       <div >
         <div className='query-response'>
-          <Pivot styles={{ root: { float: 'right' } }}
-            onLinkClick={this.toggleModal}>
-            <PivotItem key='expand'
-              itemIcon='MiniExpandMirrored'
-            > {this.showResponse(pivotItems)}</PivotItem>
-            <PivotItem key='share'
+          <Pivot className='pivot-response'
+            onLinkClick={this.toggleModal}
+          >
+            {pivotItems}
+            <PivotItem headerText='Share' key='share'
               itemIcon='Share'
-            > {this.showResponse(pivotItems)} </PivotItem>
+            />
+            <PivotItem headerText='Expand' key='expand'
+              itemIcon='MiniExpandMirrored'
+            />
           </Pivot>
         </div>
 

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -1,6 +1,7 @@
 import {
   DefaultButton, FontSizes,
   getId, IconButton, Modal, Pivot,
+  PivotItem,
   PrimaryButton, TooltipHost
 } from 'office-ui-fabric-react';
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
@@ -48,8 +49,18 @@ class QueryResponse extends Component<IQueryResponseProps, IQueryResponseState> 
     this.setState({ showShareQueryDialog: !this.state.showShareQueryDialog });
   };
 
-  public toggleModal = () => {
+  public toggleExpandResponse = () => {
     this.setState({ showModal: !this.state.showModal });
+  }
+
+  public toggleModal = (event: any) => {
+    const { key } = event;
+    if (key && key.includes('expand')) {
+      this.toggleExpandResponse();
+    }
+    if (key && key.includes('share')) {
+      this.handleShareQuery();
+    }
   }
 
   public render() {
@@ -76,55 +87,16 @@ class QueryResponse extends Component<IQueryResponseProps, IQueryResponseState> 
     const pivotItems = getPivotItems(pivotProperties);
 
     return (
-      <div>
+      <div >
         <div className='query-response'>
-          {mode === Mode.Complete && <>
-            <div style={{
-              float: 'right',
-              padding: '0px',
-              zIndex: 1,
-            }}>
-
-              <TooltipHost
-                content={`${messages['Share Query Message']}`}
-                id={getId()}
-                calloutProps={{ gapSpace: 0 }}
-                styles={{ root: { display: 'inline-block' } }}
-              >
-                <IconButton
-                  onClick={this.handleShareQuery}
-                  className='share-query-btn'
-                  iconProps={{ iconName: 'Share'}}
-                  aria-label={'Share query message'}
-                />
-              </TooltipHost>
-            </div>
-
-            <div style={{
-              float: 'right',
-              padding: '0px',
-              zIndex: 1,
-            }}>
-              <TooltipHost
-                content={`${messages['Expand response']}`}
-                id={getId()}
-                calloutProps={{ gapSpace: 0 }}
-                styles={{ root: { display: 'inline-block' } }}
-              >
-                <IconButton
-                  onClick={this.toggleModal}
-                  className='share-query-btn'
-                  iconProps={{ iconName: 'MiniExpandMirrored'}}
-                  aria-label={'Expand response'}
-                />
-              </TooltipHost>
-            </div>
-          </>}
-          <Pivot className='pivot-response'
-            styles={{ root: { display: 'flex', flexWrap: 'wrap' } }}
-            onLinkClick={(pivotItem) => onPivotItemClick(pivotItem)}
-            >
-            {pivotItems}
+          <Pivot styles={{ root: { float: 'right' } }}
+            onLinkClick={this.toggleModal}>
+            <PivotItem key='expand'
+              itemIcon='MiniExpandMirrored'
+            > {this.showResponse(pivotItems)}</PivotItem>
+            <PivotItem key='share'
+              itemIcon='Share'
+            > {this.showResponse(pivotItems)} </PivotItem>
           </Pivot>
         </div>
 
@@ -132,7 +104,7 @@ class QueryResponse extends Component<IQueryResponseProps, IQueryResponseState> 
           // @ts-ignore
           <Modal
             isOpen={showModal}
-            onDismiss={this.toggleModal}
+            onDismiss={this.toggleExpandResponse}
             styles={{ main: { width: '80%', height: '90%' }, }}
           >
 
@@ -145,7 +117,7 @@ class QueryResponse extends Component<IQueryResponseProps, IQueryResponseState> 
               }}
               iconProps={{ iconName: 'Cancel' }}
               ariaLabel='Close popup modal'
-              onClick={this.toggleModal}
+              onClick={this.toggleExpandResponse}
             />
             <Pivot className='pivot-response'>
               {pivotItems}
@@ -180,6 +152,15 @@ class QueryResponse extends Component<IQueryResponseProps, IQueryResponseState> 
       </div >
     );
   }
+
+  private showResponse(pivotItems: JSX.Element[]) {
+    return <Pivot className='pivot-response'
+      styles={{ root: { display: 'flex', flexWrap: 'wrap' } }}
+      onLinkClick={(pivotItem) => onPivotItemClick(pivotItem)}
+    >
+      {pivotItems}
+    </Pivot>;
+  }
 }
 
 function mapStateToProps(state: any) {
@@ -196,4 +177,3 @@ function mapStateToProps(state: any) {
 // @ts-ignore
 const WithIntl = injectIntl(QueryResponse);
 export default connect(mapStateToProps)(WithIntl);
-

--- a/src/app/views/query-response/query-response.scss
+++ b/src/app/views/query-response/query-response.scss
@@ -14,6 +14,16 @@
     width: 100%;
   }
 
+  .pivot-response *[data-content='Expand xx']  {
+    float: right !important;
+    color: #0078d4;
+    }
+
+  .pivot-response *[data-content='Share xx']  {
+    float: right !important;
+    color: #0078d4;
+    }
+
   .default-text {
     display: flex;
     width: 100%;

--- a/src/app/views/query-response/query-response.scss
+++ b/src/app/views/query-response/query-response.scss
@@ -14,14 +14,12 @@
     width: 100%;
   }
 
-  .pivot-response *[data-content='Expand xx']  {
+  .pivot-response *[data-content='Expand xx'] {
     float: right !important;
-    color: #0078d4;
     }
 
-  .pivot-response *[data-content='Share xx']  {
+  .pivot-response *[data-content='Share xx'] {
     float: right !important;
-    color: #0078d4;
     }
 
   .default-text {


### PR DESCRIPTION
## Overview

Fixed the focus order after "Close" button by including the 'expand' and 'share' links as pivot items.
After "Close" button, focus will move to “Response preview” button instead of moving  “Share query” button.

Fixes #750 

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

Step 1: Open the above Graph Explorer URL in Edge browser.
Step 2: Navigate to "Close" button on Graph-Explorer page..
Step 3: Now press Tab key and Observe whether focus indicator moves to Response Preview

