### PR TITLE
Fix: stop display of options when fetching suggestions

### DIFF
--- a/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
+++ b/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
@@ -282,9 +282,12 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
       if (!requestUrl) {
         this.props.actions!.fetchAutoCompleteOptions('', queryVersion);
       } else {
-        this.props.actions!.fetchAutoCompleteOptions(requestUrl, queryVersion);
+        if (!this.props.autoCompleteOptions || `${requestUrl}` !== this.props.autoCompleteOptions.url) {
+          this.props.actions!.fetchAutoCompleteOptions(requestUrl, queryVersion);
+        } else {
+          this.performLocalSearch(url);
+        }
       }
-      this.performLocalSearch(url);
     }
   }
 


### PR DESCRIPTION
## Overview

Noticed that as the request for autocomplete options is running, the results of the previous run are displayed.
If the call is running, only the spinner should show until the content is found or not.