### PR TITLE
- replaces content-type header by accept to match HTTP and avoid CORS preflight

### DIFF
--- a/src/modules/suggestions/suggestions.ts
+++ b/src/modules/suggestions/suggestions.ts
@@ -21,7 +21,7 @@ class Suggestions implements ISuggestions {
   private async fetchSuggestionsFromNetwork(url: string, api: string, version: string):
     Promise<IParsedOpenApiResponse | null> {
     const headers = {
-      'Content-Type': 'application/json',
+      'Accept': 'application/json',
     };
     const openApiUrl = `${api}/openapi?url=/${url}&style=geautocomplete&graphVersion=${version}`;
     const options: IRequestOptions = { headers };


### PR DESCRIPTION
## Overview

The auto-complete feature is currently using the Content-Type request header.
Not only this is the wrong header to specify which format you want in return from the server, it also forces a CORS preflight which double the load per auto-complete "run" on the service, degrading the end user experience.
This pull request corrects the header usage.

### Demo
![image](https://user-images.githubusercontent.com/7905502/102090577-a2086480-3deb-11eb-98e3-59dc3e5ce17e.png)
![image](https://user-images.githubusercontent.com/7905502/102090629-af255380-3deb-11eb-8f98-d3e02ada344e.png)


Wrong:
```PowerShell
Invoke-WebRequest -Uri "https://graphexplorerapi.azurewebsites.net/openapi?url=/&style=geautocomplete&graphVersion=v1.0" `
-Headers @{
"method"="GET"
  "authority"="graphexplorerapi.azurewebsites.net"
  "scheme"="https"
  "path"="/openapi?url=/&style=geautocomplete&graphVersion=v1.0"
  "user-agent"="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36"
  "accept"="*/*"
  "origin"="https://developer.microsoft.com"
  "sec-fetch-site"="cross-site"
  "sec-fetch-mode"="cors"
  "sec-fetch-dest"="empty"
  "referer"="https://developer.microsoft.com/"
  "accept-encoding"="gzip, deflate, br"
  "accept-language"="en-US,en;q=0.9,fr;q=0.8"
} `
-ContentType "application/json"
```

Right:
```PowerShell
Invoke-WebRequest -Uri "https://graphexplorerapi.azurewebsites.net/openapi?url=/&style=geautocomplete&graphVersion=v1.0" `
-Headers @{
"method"="GET"
  "authority"="graphexplorerapi.azurewebsites.net"
  "scheme"="https"
  "path"="/openapi?url=/&style=geautocomplete&graphVersion=v1.0"
  "user-agent"="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36"
  "accept"="application/json"
  "origin"="https://developer.microsoft.com"
  "sec-fetch-site"="cross-site"
  "sec-fetch-mode"="cors"
  "sec-fetch-dest"="empty"
  "referer"="https://developer.microsoft.com/"
  "accept-encoding"="gzip, deflate, br"
  "accept-language"="en-US,en;q=0.9,fr;q=0.8"
} `
```

### Notes

https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Simple_requests

## Testing Instructions

Run GE, try the auto-complete feature.