### PR TITLE
Fix: sanitize url when fetching permissions

### DIFF
--- a/src/app/services/actions/permissions-action-creator.ts
+++ b/src/app/services/actions/permissions-action-creator.ts
@@ -6,6 +6,7 @@ import { NETWORK_ERROR } from '../../../telemetry/error-types';
 import { IAction } from '../../../types/action';
 import { IQuery } from '../../../types/query-runner';
 import { IRequestOptions } from '../../../types/request';
+import { sanitizeQueryUrl } from '../../utils/query-url-sanitization';
 import { parseSampleUrl } from '../../utils/sample-url-generation';
 import { acquireNewAccessToken } from '../graph-client/msal-service';
 import { FETCH_SCOPES_ERROR, FETCH_SCOPES_PENDING, FETCH_SCOPES_SUCCESS } from '../redux-constants';
@@ -38,7 +39,8 @@ export function fetchScopes(query?: IQuery): Function {
       let permissionsUrl = `${devxApi}/permissions`;
 
       if (query) {
-        const { requestUrl, sampleUrl } = parseSampleUrl(query.sampleUrl);
+        const signature = sanitizeQueryUrl(query.sampleUrl);
+        const { requestUrl, sampleUrl } = parseSampleUrl(signature);
 
         if (!sampleUrl) {
           throw new Error('url is invalid');
@@ -77,10 +79,10 @@ export function fetchScopes(query?: IQuery): Function {
 
 export function consentToScopes(scopes: string[]): Function {
   return async (dispatch: Function) => {
-      const authResponse = await acquireNewAccessToken(scopes);
-      if (authResponse && authResponse.accessToken) {
-        dispatch(getAuthTokenSuccess(authResponse.accessToken));
-        dispatch(getConsentedScopesSuccess(authResponse.scopes));
-      }
+    const authResponse = await acquireNewAccessToken(scopes);
+    if (authResponse && authResponse.accessToken) {
+      dispatch(getAuthTokenSuccess(authResponse.accessToken));
+      dispatch(getConsentedScopesSuccess(authResponse.scopes));
+    }
   };
 }


### PR DESCRIPTION
## Overview

Sanitises the URL before sending the request to the permissions endpoint
Fixes #793 

### Demo

N/A

### Notes

This would take us a step towards re-activating telemetry in the devx-api 

## Testing Instructions

* Add a URL with an ID/email within it
* Navigate to the modify permissions tab
* Open the network tab of the developer console to see the permission request
* Notice the id has been replaced