### PR TITLE
Fix: Sample Queries Keyboard accessibility

### DIFF
--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -450,6 +450,7 @@ export class SampleQueries extends Component<ISampleQueriesProps, any> {
           }}
           onRenderRow={this.renderRow}
           onRenderDetailsHeader={this.renderDetailsHeader}
+          onItemInvoked={this.querySelected}
         />
       </div>
     );


### PR DESCRIPTION
## Overview
This ensures using keyboard navigation to run a query from the list of given sample queries is successful.

Fixes #805 

## Testing Instructions

- Open the URL in Anaheim edge dev browser.
- Navigate (by Tab) to any List items say 'Get my profile' present under Expanded Getting Started button on the left side of the navigation pane and activate it using the Enter key.
- Observe the query is run.

