### PR TITLE
FIX: trim space in URL before executed

### DIFF
--- a/src/app/views/query-runner/QueryRunner.tsx
+++ b/src/app/views/query-runner/QueryRunner.tsx
@@ -87,6 +87,8 @@ export class QueryRunner extends Component<
     }
 
     if (actions) {
+      // remove whitespaces
+      sampleQuery.sampleUrl = sampleQuery.sampleUrl.replace(/\s+/g, '');
       actions.runQuery(sampleQuery);
       const sanitizedUrl = sanitizeQueryUrl(sampleQuery.sampleUrl);
       telemetry.trackEvent(eventTypes.BUTTON_CLICK_EVENT,

--- a/src/app/views/query-runner/QueryRunner.tsx
+++ b/src/app/views/query-runner/QueryRunner.tsx
@@ -88,7 +88,7 @@ export class QueryRunner extends Component<
 
     if (actions) {
       // remove whitespaces
-      sampleQuery.sampleUrl = sampleQuery.sampleUrl.replace(/\s+/g, '');
+      sampleQuery.sampleUrl = sampleQuery.sampleUrl.trim();
       actions.runQuery(sampleQuery);
       const sanitizedUrl = sanitizeQueryUrl(sampleQuery.sampleUrl);
       telemetry.trackEvent(eventTypes.BUTTON_CLICK_EVENT,

--- a/src/app/views/query-runner/QueryRunner.tsx
+++ b/src/app/views/query-runner/QueryRunner.tsx
@@ -87,7 +87,6 @@ export class QueryRunner extends Component<
     }
 
     if (actions) {
-      // remove whitespaces
       sampleQuery.sampleUrl = sampleQuery.sampleUrl.trim();
       actions.runQuery(sampleQuery);
       const sanitizedUrl = sanitizeQueryUrl(sampleQuery.sampleUrl);


### PR DESCRIPTION
- Fixes #788


## Overview

- GE to trim spaces on the URL so the request succeeds.

### Demo

![Screenshot 2021-02-02 185016](https://user-images.githubusercontent.com/48981919/106625215-86b60c00-6587-11eb-9128-312cfca846e8.png)


### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output