### PR TITLE
Fix: Add 'Maximize sidebar' aria-label

### DIFF
--- a/src/app/views/app-sections/AppTitle.tsx
+++ b/src/app/views/app-sections/AppTitle.tsx
@@ -10,22 +10,22 @@ export function appTitleDisplayOnFullScreen(
 
   return <div style={{ display: 'flex', width: '100%' }}>
     <TooltipHost
-      content='Minimize sidebar'
+      content={!minimised ? 'Minimize sidebar' : 'Maximize sidebar'}
       id={getId()}
       calloutProps={{ gapSpace: 0 }}
       tooltipProps={{
         onRenderContent: function renderContent() {
           return <div>
-            <FormattedMessage id={'Minimize sidebar'} /></div>
+            <FormattedMessage id={!minimised ? 'Minimize sidebar' : 'Maximize sidebar'} /></div>
         }
       }}>
       <IconButton
         iconProps={{ iconName: 'GlobalNavButton' }}
         className={classes.sidebarToggle}
-        ariaLabel='Minimize sidebar'
+        ariaLabel={!minimised ? 'Minimize sidebar' : 'Maximize sidebar'}
         onClick={() => toggleSidebar()} />
     </TooltipHost>
-      <div className={classes.graphExplorerLabelContainer} role={'heading'} aria-level={1}>
+    <div className={classes.graphExplorerLabelContainer} role={'heading'} aria-level={1}>
       {!minimised &&
         <>
           <Label className={classes.graphExplorerLabel}>
@@ -50,7 +50,7 @@ export function appTitleDisplayOnMobileScreen(
         ariaLabel='Remove sidebar'
         onClick={() => toggleSidebar()}
       />
-        <div style={{ padding: 10 }} role={'heading'} aria-level={1}>
+      <div style={{ padding: 10 }} role={'heading'} aria-level={1}>
         <Label className={classes.graphExplorerLabel}>
           Graph Explorer
           </Label>

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -344,5 +344,6 @@
   "Adaptive Cards Templating SDK": "Adaptive Cards Templating SDK",
   "card": "Card",
   "JSON Schema": "JSON Schema",
-  "Report an Issue": "Report an Issue"
+  "Report an Issue": "Report an Issue",
+  "Maximize sidebar": "Maximize sidebar"
 }


### PR DESCRIPTION
## Overview

This add's the maximize sidebar aria-label to ensure accurate information is read by the screen reader.
It also ensures the tooltip message is changed from "minimize sidebar' to 'maximize sidebar' when the sidebar is minimized and vice versa when the sidebar is maximized.

Fixes #841 

## Screenshots
_Tooltip view when sidebar is maximized_
![image](https://user-images.githubusercontent.com/18407044/107612722-eb442b80-6c57-11eb-8779-1a96ff2371dc.png)

_Tooltip view when sidebar is minimized_
![image](https://user-images.githubusercontent.com/18407044/107612943-66a5dd00-6c58-11eb-972e-8bdbdcf1e4a1.png)





