### PR TITLE
fix: autocomplete-onfocusout

### DIFF
--- a/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
+++ b/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
@@ -13,14 +13,12 @@ import { sanitizeQueryUrl } from '../../../../utils/query-url-sanitization';
 import { parseSampleUrl } from '../../../../utils/sample-url-generation';
 import { translateMessage } from '../../../../utils/translate-messages';
 import { queryInputStyles } from '../QueryInput.styles';
-
-
 import {
   cleanUpSelectedSuggestion, getLastCharacterOf,
+  getLastSymbolInUrl,
   getParametersWithVerb
 } from './auto-complete.util';
 import SuggestionsList from './SuggestionsList';
-
 
 class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
   private autoCompleteRef: React.RefObject<ITextField>;
@@ -53,7 +51,7 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
     }, 10);
   }
 
-  public onBlur = (e: any) => {
+  public updateUrlContent = (e: any) => {
     const userInput = e.target.value;
     this.props.contentChanged(userInput);
   };
@@ -73,7 +71,7 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
     this.initialiseAutoComplete(userInput);
   };
 
-  public onClick = (e: any) => {
+  public selectSuggestion = (e: any) => {
     const selected = e.currentTarget.innerText;
     this.appendSuggestionToUrl(selected);
   };
@@ -165,7 +163,7 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
     const controlPeriod = event.ctrlKey && event.keyCode === KeyCodes.period;
     if (controlSpace || controlPeriod) {
       const userInput = event.target.value;
-      const lastSymbol = this.getLastSymbolInUrl(userInput);
+      const lastSymbol = getLastSymbolInUrl(userInput);
       const previousUserInput = userInput.substring(0, lastSymbol.value + 1);
       if (lastSymbol.key === '/' || lastSymbol.key === '?') {
         const compare = userInput.replace(previousUserInput, '');
@@ -367,42 +365,7 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
     return null;
   }
 
-  private getLastSymbolInUrl(url: string) {
-    const availableSymbols = [
-      {
-        key: '/',
-        value: 0
-      },
-      {
-        key: ',',
-        value: 0
-      },
-      {
-        key: '$',
-        value: 0
-      },
-      {
-        key: '=',
-        value: 0
-      },
-      {
-        key: '&',
-        value: 0
-      },
-      {
-        key: '?',
-        value: 0
-      }
-    ];
-
-    availableSymbols.forEach(element => {
-      element.value = url.lastIndexOf(element.key);
-    });
-    const max = availableSymbols.reduce((prev, current) => (prev.value > current.value) ? prev : current);
-    return max;
-  }
-
-  onFocusOut = (event: any) => {
+  closeSuggestionDialog = (event: any) => {
     const { currentTarget, relatedTarget } = event;
     if (!currentTarget.contains(relatedTarget as Node) && this.state.showSuggestions) {
       this.setState({
@@ -426,13 +389,13 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
     }: any = queryInputStyles(currentTheme).autoComplete;
 
     return (
-      <div onBlur={this.onFocusOut}>
+      <div onBlur={this.closeSuggestionDialog}>
         <TextField
           className={autoInput}
           type='text'
           autoComplete='off'
           onChange={this.onChange}
-          onBlur={this.onBlur}
+          onBlur={this.updateUrlContent}
           onKeyDown={this.onKeyDown}
           value={queryUrl}
           componentRef={this.autoCompleteRef}
@@ -444,7 +407,7 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
           <SuggestionsList
             filteredSuggestions={filteredSuggestions}
             activeSuggestion={activeSuggestion}
-            onClick={(e: any) => this.onClick(e)} />}
+            onClick={(e: any) => this.selectSuggestion(e)} />}
       </div>
     );
   }

--- a/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
+++ b/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
@@ -426,7 +426,7 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
     }: any = queryInputStyles(currentTheme).autoComplete;
 
     return (
-      <div tabIndex={0} onBlur={this.onFocusOut}>
+      <div onBlur={this.onFocusOut}>
         <TextField
           className={autoInput}
           type='text'

--- a/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
+++ b/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
@@ -402,6 +402,14 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
     return max;
   }
 
+  onFocusOut = (event: any) => {
+    const { currentTarget, relatedTarget } = event;
+    if (!currentTarget.contains(relatedTarget as Node) && this.state.showSuggestions) {
+      this.setState({
+        showSuggestions: false
+      })
+    }
+  }
 
   public render() {
     const {
@@ -418,7 +426,7 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
     }: any = queryInputStyles(currentTheme).autoComplete;
 
     return (
-      <>
+      <div tabIndex={0} onBlur={this.onFocusOut}>
         <TextField
           className={autoInput}
           type='text'
@@ -437,7 +445,7 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
             filteredSuggestions={filteredSuggestions}
             activeSuggestion={activeSuggestion}
             onClick={(e: any) => this.onClick(e)} />}
-      </>
+      </div>
     );
   }
 }

--- a/src/app/views/query-runner/query-input/auto-complete/SuggestionsList.tsx
+++ b/src/app/views/query-runner/query-input/auto-complete/SuggestionsList.tsx
@@ -26,11 +26,10 @@ const SuggestionsList = (props: any) => {
   }, [activeSuggestion]);
 
   return (
-    <ul className={classes.suggestions} aria-haspopup='true'>
+    <ul className={classes.suggestions} tabIndex={-1}>
       {filteredSuggestions.map((suggestion: {} | null | undefined, index: number) => {
         return (
           <li
-            tabIndex={index}
             className={(index === activeSuggestion) ? classes.suggestionActive : classes.suggestionOption}
             key={index}
             ref={refs[index]}

--- a/src/app/views/query-runner/query-input/auto-complete/SuggestionsList.tsx
+++ b/src/app/views/query-runner/query-input/auto-complete/SuggestionsList.tsx
@@ -30,6 +30,7 @@ const SuggestionsList = (props: any) => {
       {filteredSuggestions.map((suggestion: {} | null | undefined, index: number) => {
         return (
           <li
+            tabIndex={index}
             className={(index === activeSuggestion) ? classes.suggestionActive : classes.suggestionOption}
             key={index}
             ref={refs[index]}

--- a/src/app/views/query-runner/query-input/auto-complete/auto-complete.util.ts
+++ b/src/app/views/query-runner/query-input/auto-complete/auto-complete.util.ts
@@ -28,3 +28,38 @@ export function getParametersWithVerb(properties: IAutoCompleteProps) {
 export function getLastCharacterOf(content: string) {
   return content.slice(-1);
 }
+
+export function getLastSymbolInUrl(url: string) {
+  const availableSymbols = [
+    {
+      key: '/',
+      value: 0
+    },
+    {
+      key: ',',
+      value: 0
+    },
+    {
+      key: '$',
+      value: 0
+    },
+    {
+      key: '=',
+      value: 0
+    },
+    {
+      key: '&',
+      value: 0
+    },
+    {
+      key: '?',
+      value: 0
+    }
+  ];
+
+  availableSymbols.forEach(element => {
+    element.value = url.lastIndexOf(element.key);
+  });
+  const max = availableSymbols.reduce((prev, current) => (prev.value > current.value) ? prev : current);
+  return max;
+}


### PR DESCRIPTION
## Overview
Autocomplete suggestions should collapse when the autocomplete component loses focus
Fixes #721 

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

OnFocusOut is not supported in React hence the use of onBlur. 


## Testing Instructions

* Trigger an autocomplete call
* Once the options show up click outside the component
* Notice that the suggestions close