### PR TITLE
Feature: make paging easier

### DIFF
--- a/src/app/views/query-response/response/Response.tsx
+++ b/src/app/views/query-response/response/Response.tsx
@@ -21,7 +21,7 @@ const Response = () => {
 
   const setQuery = () => {
     const query: IQuery = { ...sampleQuery };
-    query.sampleUrl = nextLink;
+    query.sampleUrl = nextLink!;
     dispatch(setSampleQuery(query));
     dispatch(runQuery(query));
   }
@@ -51,7 +51,7 @@ const Response = () => {
 
 function getNextLinkFromBody(body: any) {
   if (body && body['@odata.nextLink']) {
-    return body['@odata.nextLink'];
+    return decodeURIComponent(body['@odata.nextLink']);
   }
   return null;
 }

--- a/src/app/views/query-response/response/Response.tsx
+++ b/src/app/views/query-response/response/Response.tsx
@@ -1,15 +1,13 @@
 
+import { MessageBar, MessageBarType } from 'office-ui-fabric-react';
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import { useSelector } from 'react-redux';
 
-import { ContentType } from '../../../../types/enums';
-import { isImageResponse } from '../../../services/actions/query-action-creator-util';
-import { Image, Monaco } from '../../common';
 import { convertVhToPx, getResponseHeight } from '../../common/dimensions-adjustment';
-import { formatXml } from '../../common/monaco/util/format-xml';
+import ResponseDisplay from './ResponseDisplay';
 
 const Response = () => {
-  const language = 'json';
 
   const { dimensions: { response }, graphResponse, responseAreaExpanded } = useSelector((state: any) => state);
   const { body, headers } = graphResponse;
@@ -18,14 +16,25 @@ const Response = () => {
 
   if (headers) {
     const contentType = getContentType(headers);
-    return (<div style={{ display: 'block' }}>
-      {displayComponent({
-        contentType,
-        body,
-        height,
-        language
-      })}
-    </div>);
+    return (
+      <div style={{ display: 'block' }}>
+        <MessageBar messageBarType={MessageBarType.info}>
+          <FormattedMessage id='This response contains a next link property.' />
+          <a href={'https://docs.microsoft.com/en-us/adaptive-cards/templating/sdk'}
+            target='_blank'
+            rel='noopener noreferrer'
+            tabIndex={0}
+          >
+            <FormattedMessage id='Click here to go to the next page' />
+          </a>
+        </MessageBar>
+        <ResponseDisplay
+          contentType={contentType}
+          body={body}
+          height={height}
+        />
+      </div>
+    );
   }
   return <div />;
 };
@@ -44,28 +53,6 @@ function getContentType(headers: any) {
     }
   }
   return contentType;
-}
-
-function displayComponent(properties: any) {
-  const { contentType, body, height, language } = properties;
-
-  switch (contentType) {
-    case ContentType.XML:
-      return <Monaco body={formatXml(body)} language='xml' readOnly={true} height={height} />;
-
-    case ContentType.HTML:
-      return <Monaco body={body} language='html' readOnly={true} height={height} />;
-
-    default:
-      if (isImageResponse(contentType)) {
-        return <Image
-          styles={{ padding: '10px' }}
-          body={body}
-          alt='profile image'
-        />;
-      }
-      return <Monaco body={body} readOnly={true} language={language} height={height} />;
-  }
 }
 
 export default Response;

--- a/src/app/views/query-response/response/ResponseDisplay.tsx
+++ b/src/app/views/query-response/response/ResponseDisplay.tsx
@@ -4,7 +4,7 @@ import { isImageResponse } from '../../../services/actions/query-action-creator-
 import { Image, Monaco } from '../../common';
 import { formatXml } from '../../common/monaco/util/format-xml';
 
-const displayComponent = (properties: any) => {
+const ResponseDisplay = (properties: any) => {
   const { contentType, body, height } = properties;
 
   switch (contentType) {
@@ -25,4 +25,4 @@ const displayComponent = (properties: any) => {
   }
 }
 
-export default displayComponent;
+export default ResponseDisplay;

--- a/src/app/views/query-response/response/ResponseDisplay.tsx
+++ b/src/app/views/query-response/response/ResponseDisplay.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { ContentType } from '../../../../types/enums';
+import { isImageResponse } from '../../../services/actions/query-action-creator-util';
+import { Image, Monaco } from '../../common';
+import { formatXml } from '../../common/monaco/util/format-xml';
+
+const displayComponent = (properties: any) => {
+  const { contentType, body, height } = properties;
+
+  switch (contentType) {
+    case ContentType.XML:
+      return <Monaco body={formatXml(body)} language={ContentType.XML} readOnly={true} height={height} />;
+
+    case ContentType.HTML:
+      return <Monaco body={body} language={ContentType.HTML} readOnly={true} height={height} />;
+
+    default:
+      if (isImageResponse(contentType)) {
+        return <Image
+          styles={{ padding: '10px' }}
+          body={body}
+          alt='profile image' />;
+      }
+      return <Monaco body={body} readOnly={true} language={ContentType.Json} height={height} />;
+  }
+}
+
+export default displayComponent;

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -346,5 +346,7 @@
   "JSON Schema": "JSON Schema",
   "Report an Issue": "Report an Issue",
   "Maximize sidebar": "Maximize sidebar",
-  "Getting your access token": "Getting your access token"
+  "Getting your access token": "Getting your access token",
+  "This response contains a next link property.": "This response contains a next link property.",
+  "Click here to go to the next page": "Click here to go to the next page"
 }

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -347,6 +347,6 @@
   "Report an Issue": "Report an Issue",
   "Maximize sidebar": "Maximize sidebar",
   "Getting your access token": "Getting your access token",
-  "This response contains a next link property.": "This response contains a next link property.",
+  "This response contains an @odata.nextLink property.": "This response contains an @odata.nextLink property.",
   "Click here to go to the next page": "Click here to go to the next page"
 }


### PR DESCRIPTION
## Overview
Adds a message bar with a clickable link that executes the next link so that navigation is easy
Fixes #392 

### Demo

![image](https://user-images.githubusercontent.com/58787602/108871014-c497d480-7609-11eb-8bcb-41b1b1ae1558.png)

### Notes

Explicitly mentioned the `@odata.nextLink` property so that users can know which property is enabling this

## Testing Instructions

* Run this query `https://graph.microsoft.com/v1.0/me/messages?$select=subject`
* Notice a banner appears in the response area informing you of the ability to go to the next page
* Click the provided link and notice that the query runs the next url