### PR TITLE
Fix: metadata syntax highlighting

### DIFF
--- a/src/app/views/query-response/response/ResponseDisplay.tsx
+++ b/src/app/views/query-response/response/ResponseDisplay.tsx
@@ -9,7 +9,7 @@ const ResponseDisplay = (properties: any) => {
 
   switch (contentType) {
     case ContentType.XML:
-      return <Monaco body={formatXml(body)} language={ContentType.XML} readOnly={true} height={height} />;
+      return <Monaco body={formatXml(body)} language={ContentType.HTML} readOnly={true} height={height} />;
 
     case ContentType.HTML:
       return <Monaco body={body} language={ContentType.HTML} readOnly={true} height={height} />;


### PR DESCRIPTION
## Overview

Enables syntax highlighting on $metadata queries.
Fixes #858 

### Demo

Before
![image](https://user-images.githubusercontent.com/58787602/109129760-0cca0a80-7762-11eb-969b-b8db905fe5ea.png)

After
![image](https://user-images.githubusercontent.com/58787602/109129677-f4f28680-7761-11eb-9ec4-a4b8030ea354.png)

## Testing Instructions

* Run `https://graph.microsoft.com/v1.0/$metadata`
* See the tags in colour