### PR TITLE
Fix: snippets not available

### DIFF
--- a/src/app/services/actions/snippet-action-creator.ts
+++ b/src/app/services/actions/snippet-action-creator.ts
@@ -29,7 +29,7 @@ export function getSnippet(language: string): Function {
   return async (dispatch: Function, getState: Function) => {
     const { devxApi, sampleQuery } = getState();
     try {
-      let snippetsUrl = `${devxApi}/api/graphexplorersnippets`;
+      let snippetsUrl = `${devxApi.baseUrl}/api/graphexplorersnippets`;
 
       const { requestUrl, sampleUrl, queryVersion, search } = parseSampleUrl(sampleQuery.sampleUrl);
       if (!sampleUrl) {


### PR DESCRIPTION
## Overview

Fixes #876 

### Demo

![image](https://user-images.githubusercontent.com/58787602/109797297-54510a80-7c2a-11eb-8bb0-c10e9b61d291.png)


### Notes

N/A

## Testing Instructions
* Run any query
* Head over to code snippets
* Notice that the code snippet is displayed