### PR TITLE
Feature: Enhance 'More actions' icon appearance

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@
 
 name: $(date:yyyyMMdd)$(rev:.r)
 
-pool: MsGraphDevXAzureAgents
+pool: MsGraphBuildAgentsWindows
 
 pr:
   branches:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@
 
 name: $(date:yyyyMMdd)$(rev:.r)
 
-pool: MsGraphBuildAgentsWindows
+pool: MsGraphDevXAzureAgents
 
 pr:
   branches:

--- a/src/app/views/settings/Settings.tsx
+++ b/src/app/views/settings/Settings.tsx
@@ -205,13 +205,12 @@ function Settings(props: ISettingsProps) {
         content={messages['More actions']}
         id={getId()}
         calloutProps={{ gapSpace: 0 }}>
-        <DefaultButton
+        <IconButton
           ariaLabel={messages['More actions']}
           role='button'
           styles={{
             label: { marginBottom: -20 },
-            icon: { marginBottom: -20 },
-            root: { minWidth: '10px', paddingRight: '5px', paddingLeft: '5px' }
+            menuIcon: { fontSize: 20 },
           }}
           menuIconProps={{ iconName: 'More' }}
           menuProps={menuProperties} />

--- a/src/app/views/settings/Settings.tsx
+++ b/src/app/views/settings/Settings.tsx
@@ -205,15 +205,17 @@ function Settings(props: ISettingsProps) {
         content={messages['More actions']}
         id={getId()}
         calloutProps={{ gapSpace: 0 }}>
-        <IconButton
+        <DefaultButton
           ariaLabel={messages['More actions']}
           role='button'
           styles={{
             label: { marginBottom: -20 },
-            icon: { marginBottom: -20 }
+            icon: { marginBottom: -20 },
+            root: { minWidth: '10px', paddingRight: '5px', paddingLeft: '5px' }
           }}
-          menuIconProps={{ iconName: 'Settings' }}
+          menuIconProps={{ iconName: 'More' }}
           menuProps={menuProperties} />
+
       </TooltipHost>
       <div>
         <Dialog

--- a/src/app/views/settings/Settings.tsx
+++ b/src/app/views/settings/Settings.tsx
@@ -210,7 +210,7 @@ function Settings(props: ISettingsProps) {
           role='button'
           styles={{
             label: { marginBottom: -20 },
-            menuIcon: { fontSize: 20 },
+            menuIcon: { fontSize: 20 }
           }}
           menuIconProps={{ iconName: 'More' }}
           menuProps={menuProperties} />


### PR DESCRIPTION
## Overview

Changes the current 'more actions' icon from the settings gear to the ellipsis icon to indicate 'more'.
Fixes #882 

### Demo
_before_
![image](https://user-images.githubusercontent.com/18407044/112809062-4e601500-9082-11eb-8d99-32e56c2b9bcd.png)

_update_
![image](https://user-images.githubusercontent.com/18407044/112809007-40aa8f80-9082-11eb-8bba-3f0e396ef6bb.png)
