### PR TITLE
Set GET as default HTTP method if method specified in query params is invalid or missing 

### DIFF
--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -137,7 +137,7 @@ class App extends Component<IAppProps, IAppState> {
     const urlParams = new URLSearchParams(window.location.search);
 
     const request = urlParams.get('request');
-    const method = urlParams.get('method');
+    const method = this.validateHttpMethod(urlParams.get('method') || '');
     const version = urlParams.get('version');
     const graphUrl = urlParams.get('GraphUrl') || GRAPH_URL;
     const requestBody = urlParams.get('requestBody');
@@ -160,6 +160,15 @@ class App extends Component<IAppProps, IAppState> {
       sampleBody: requestBody ? this.hashDecode(requestBody) : null,
       sampleHeaders: (headers) ? JSON.parse(this.hashDecode(headers)) : [],
     };
+  }
+
+  private validateHttpMethod(method: string): string {
+    method = method.toUpperCase();
+    const validMethods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
+    if (!validMethods.includes(method)) {
+      method = 'GET';
+    }
+    return method;
   }
 
   private hashDecode(requestBody: string): string {


### PR DESCRIPTION
Problem: Graph explorer crashes if HTTP method is missing in query params

Fix: Default HTTP method to 'GET' if missing or invalid

Example link: 
https://developer.microsoft.com/en-us/graph/graph-explorer?request=me&version=v1.0

