### PR TITLE
Task/telemetry capture English theme names only

### DIFF
--- a/.github/workflows/azure-static-web-apps-jolly-sand-0ac78c710.yml
+++ b/.github/workflows/azure-static-web-apps-jolly-sand-0ac78c710.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Build And Deploy
         env:
           REACT_APP_CLIENT_ID: ${{ secrets.REACT_APP_CLIENT_ID }}
+          REACT_APP_INSTRUMENTATION_KEY: ${{ secrets.REACT_APP_STAGING_INSTRUMENTATION_KEY }}
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v0.0.1-preview
         with:

--- a/src/app/utils/string-operations.ts
+++ b/src/app/utils/string-operations.ts
@@ -1,0 +1,11 @@
+declare global {
+  interface String {
+    toSentenceCase(): String;
+  }
+}
+
+String.prototype.toSentenceCase = function () {
+  return `${this.charAt(0).toUpperCase()}${this.toLowerCase().slice(1)}`;
+};
+
+export {};

--- a/src/app/views/settings/Settings.tsx
+++ b/src/app/views/settings/Settings.tsx
@@ -17,6 +17,7 @@ import React, { useEffect, useState } from 'react';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 
+import  '../../utils/string-operations';
 import { geLocale } from '../../../appLocale';
 import { componentNames, eventTypes, telemetry } from '../../../telemetry';
 import { loadGETheme } from '../../../themes';
@@ -126,7 +127,7 @@ function Settings(props: ISettingsProps) {
       eventTypes.BUTTON_CLICK_EVENT,
       {
         ComponentName: componentNames.SELECT_THEME_BUTTON,
-        SelectedTheme: selectedTheme.text
+        SelectedTheme: selectedTheme.key.replace('-', ' ').toSentenceCase()
       });
   };
 

--- a/src/telemetry/ITelemetry.ts
+++ b/src/telemetry/ITelemetry.ts
@@ -1,13 +1,19 @@
 import { SeverityLevel } from '@microsoft/applicationinsights-web';
 import { ComponentType } from 'react';
 import { IQuery } from '../types/query-runner';
-import { IRequestOptions } from '../types/request';
 
 export default interface ITelemetry {
   initialize(): void;
   trackEvent(name: string, properties: {}): void;
-  trackReactComponent(Component: ComponentType, componentName?: string): ComponentType;
+  trackReactComponent(
+    Component: ComponentType,
+    componentName?: string
+  ): ComponentType;
   trackTabClickEvent(tabKey: string, sampleQuery?: IQuery): void;
   trackLinkClickEvent(url: string, componentName: string): void;
-  trackException(error: Error, severityLevel: SeverityLevel, properties: {}): void;
+  trackException(
+    error: Error,
+    severityLevel: SeverityLevel,
+    properties: {}
+  ): void;
 }

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -7,6 +7,8 @@ import {
   SeverityLevel,
 } from '@microsoft/applicationinsights-web';
 import { ComponentType } from 'react';
+
+import '../app/utils/string-operations';
 import { validateExternalLink } from '../app/utils/external-link-validation';
 import { sanitizeQueryUrl } from '../app/utils/query-url-sanitization';
 import { IQuery } from '../types/query-runner';
@@ -70,12 +72,9 @@ class Telemetry implements ITelemetry {
   }
 
   public trackTabClickEvent(tabKey: string, sampleQuery?: IQuery) {
-    let componentName = tabKey.replace('-', ' ');
-    componentName = `${componentName
-      .charAt(0)
-      .toUpperCase()}${componentName.slice(1)} tab`;
+    const componentName = tabKey.replace('-', ' ').toSentenceCase();
     const properties: { [key: string]: any } = {
-      ComponentName: componentName,
+      ComponentName: `${componentName} tab`,
     };
     if (sampleQuery) {
       const sanitizedUrl = sanitizeQueryUrl(sampleQuery.sampleUrl);


### PR DESCRIPTION
## Overview

We have been collecting telemetry for the themes that our users are opting to use. I have noticed that some them names are captured in other languages depending on the users locale.

### Fix
I am using the `selectedTheme.key` instead which is lower case and hyphenated. I'm replacing the hyphen with a space and capitalizing the first letter. e.g. `high-contrast` => `High contrast`


