### PR TITLE
Capture deployed version of GE for all telemetry data collected

### DIFF
--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -9,6 +9,7 @@ import {
 import { ComponentType } from 'react';
 
 import '../app/utils/string-operations';
+import { version } from '../../package.json';
 import { validateExternalLink } from '../app/utils/external-link-validation';
 import { sanitizeQueryUrl } from '../app/utils/query-url-sanitization';
 import { IQuery } from '../types/query-runner';
@@ -50,6 +51,7 @@ class Telemetry implements ITelemetry {
     this.appInsights.addTelemetryInitializer(filterRemoteDependencyData);
     this.appInsights.addTelemetryInitializer(sanitizeTelemetryItemUriProperty);
     this.appInsights.addTelemetryInitializer(addCommonTelemetryItemProperties);
+    this.appInsights.context.application.ver = version;
   }
 
   public trackEvent(name: string, properties: {}) {


### PR DESCRIPTION
## Overview

Include deployed version of GE in all telemetry data captured.


## Testing
1. Open developer tools
2. Go to Network tab
3. Trace `track` calls 
4. Application version should be captured with the tags property of response
![image](https://user-images.githubusercontent.com/25274795/119156346-d3512480-ba5c-11eb-9291-1c29d0dbb2c1.png)
