### PR TITLE
Fix: Concept try-it button

### DIFF
--- a/src/types/query-runner.ts
+++ b/src/types/query-runner.ts
@@ -61,7 +61,7 @@ export interface IInitMessage {
   /** The text within the Docs code block. */
   code: string;
   /** Data extracted from the permissions table. Will be null if Docs cannot locate the permissions table. */
-  permission: string[];
+  permission?: string[];
 }
 
 export interface IThemeChangedMessage {


### PR DESCRIPTION
## Overview

Fixes #843 

### Notes

The try-it experience fails to load if the concept page does not pass in a permission property. Making it optional should prevent the failure. 