### PR TITLE
Feature: send notification when release is created

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -12,7 +12,17 @@ jobs:
       - name: Send a message to Microsoft Teams
         uses: aliencube/microsoft-teams-actions@v0.8.0
         with:
-          webhook_uri: ${{ secrets.WEBHOOK_URL}}
+          webhook_uri: ${{ secrets.TEAMS_WEBHOOK_URL}}
+          title: New release ${{ github.event.release.name }} from ${{ github.event.repository.name }}
+          summary: A new release (${{ github.event.release.tag_name }}) has been created
+          text: ${{ github.event.release.body }}
+          theme_color: 0000FF
+          actions: '[{"@type": "OpenUri", "name": "View release", "targets": [{ "os": "default", "uri": "${{ github.event.release.html_url }}"}]}]'
+
+      - name: Send a message to Microsoft Outlook
+        uses: aliencube/microsoft-teams-actions@v0.8.0
+        with:
+          webhook_uri: ${{ secrets.OUTLOOK_WEBHOOK_URL}}
           title: New release ${{ github.event.release.name }} from ${{ github.event.repository.name }}
           summary: A new release (${{ github.event.release.tag_name }}) has been created
           text: ${{ github.event.release.body }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,20 @@
+name: Publish release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  send_message_job:
+    runs-on: ubuntu-latest
+    name: Publish release
+    steps:
+      - name: Send a message to Microsoft Teams
+        uses: aliencube/microsoft-teams-actions@v0.8.0
+        with:
+          webhook_uri: ${{ secrets.WEBHOOK_URL}}
+          title: New release ${{ github.event.release.name }} from ${{ github.event.repository.name }}
+          summary: A new release (${{ github.event.release.tag_name }}) has been created
+          text: ${{ github.event.release.body }}
+          theme_color: 0000FF
+          actions: '[{"@type": "OpenUri", "name": "View release", "targets": [{ "os": "default", "uri": "${{ github.event.release.html_url }}"}]}]'

--- a/src/types/query-runner.ts
+++ b/src/types/query-runner.ts
@@ -61,7 +61,7 @@ export interface IInitMessage {
   /** The text within the Docs code block. */
   code: string;
   /** Data extracted from the permissions table. Will be null if Docs cannot locate the permissions table. */
-  permission: string[];
+  permission?: string[];
 }
 
 export interface IThemeChangedMessage {

--- a/src/types/query-runner.ts
+++ b/src/types/query-runner.ts
@@ -61,7 +61,7 @@ export interface IInitMessage {
   /** The text within the Docs code block. */
   code: string;
   /** Data extracted from the permissions table. Will be null if Docs cannot locate the permissions table. */
-  permission?: string[];
+  permission: string[];
 }
 
 export interface IThemeChangedMessage {


### PR DESCRIPTION
## Overview

Automate message sending. Can be reused by multiple teams to send notifications to their deployment channels.

Closes #959 

### Demo

Sample Microsoft teams notification created in a channel with the change log and a link to the release
![image](https://user-images.githubusercontent.com/58787602/119696195-9c618100-be57-11eb-9d69-7b6250dcead2.png)


Sample Outlook email notification created in a group. Members of the group also get notified in their inbox
![image](https://user-images.githubusercontent.com/58787602/119769469-2c88e000-bec3-11eb-8c1c-78fe4d9764eb.png)


### Notes

#### Teams: 

- Add an incoming webhook connector to the chosen Microsoft Teams channel 
- Place the webhook URL into the repository secrets under **TEAMS_WEBHOOK_URL**

#### Outlook:
- Create a group and add all expected recipients
- Add an incoming webhook connector in the group settings
- Place the webhook URL into the repository secrets under **OUTLOOK_WEBHOOK_URL**