### PR TITLE
Fix: Accessibility bugs - June

### DIFF
--- a/src/app/views/authentication/auth-util-components/UtilComponents.tsx
+++ b/src/app/views/authentication/auth-util-components/UtilComponents.tsx
@@ -1,6 +1,7 @@
 import { IconButton, PrimaryButton } from 'office-ui-fabric-react';
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
+import { translateMessage } from '../../../utils/translate-messages';
 import Profile from '../profile/Profile';
 
 export function showSignInButtonOrProfile(
@@ -11,12 +12,12 @@ export function showSignInButtonOrProfile(
 ) {
 
   const signInButton = minimised ? <IconButton
-    ariaLabel='Sign-in button'
+    ariaLabel={translateMessage('sign in')}
     role='button'
     iconProps={{ iconName: 'Contact' }}
-    title='sign in'
+    title={translateMessage('sign in')}
     onClick={() => signIn()} /> : <PrimaryButton
-      ariaLabel='Sign-in button'
+      ariaLabel={translateMessage('sign in')}
       role='button'
       iconProps={{ iconName: 'Contact' }}
       onClick={() => signIn()}

--- a/src/app/views/query-runner/request/auth/Auth.tsx
+++ b/src/app/views/query-runner/request/auth/Auth.tsx
@@ -1,5 +1,5 @@
 import { AuthenticationResult } from '@azure/msal-browser';
-import { IconButton, IIconProps, Label, styled } from 'office-ui-fabric-react';
+import { IconButton, IIconProps, Label, MessageBar, MessageBarType, styled } from 'office-ui-fabric-react';
 import React, { useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useSelector } from 'react-redux';
@@ -44,9 +44,10 @@ export function Auth(props: any) {
   };
 
   if (!authToken.token) {
-    return <Label className={classes.emptyStateLabel}>
+    return <MessageBar className={classes.emptyStateLabel}
+      messageBarType={MessageBarType.blocked}>
       <FormattedMessage id='Sign In to see your access token.' />
-    </Label>;
+    </MessageBar>;
   }
 
   return (<div className={classes.auth} style={{ height: requestHeight }}>

--- a/src/app/views/query-runner/request/auth/Auth.tsx
+++ b/src/app/views/query-runner/request/auth/Auth.tsx
@@ -44,8 +44,7 @@ export function Auth(props: any) {
   };
 
   if (!authToken.token) {
-    return <MessageBar className={classes.emptyStateLabel}
-      messageBarType={MessageBarType.blocked}>
+    return <MessageBar messageBarType={MessageBarType.blocked}>
       <FormattedMessage id='Sign In to see your access token.' />
     </MessageBar>;
   }

--- a/src/app/views/query-runner/request/permissions/Permission.tsx
+++ b/src/app/views/query-runner/request/permissions/Permission.tsx
@@ -181,8 +181,8 @@ export class Permission extends Component<IPermissionProps, IPermissionState> {
           name: messages.Description,
           fieldName: 'consentDescription',
           isResizable: true,
-          minWidth: (tokenPresent) ? 400 : 700,
-          maxWidth: (tokenPresent) ? 700 : 1000,
+          minWidth: (tokenPresent) ? 400 : 600,
+          maxWidth: (tokenPresent) ? 600 : 1000,
           isMultiline: true
         }
       );
@@ -194,7 +194,7 @@ export class Permission extends Component<IPermissionProps, IPermissionState> {
         isResizable: true,
         name: messages['Admin consent required'],
         fieldName: 'isAdmin',
-        minWidth: (tokenPresent) ? 150 : 150,
+        minWidth: (tokenPresent) ? 150 : 200,
         maxWidth: (tokenPresent) ? 200 : 300,
         ariaLabel: translateMessage('Administrator permission')
       }

--- a/src/app/views/sidebar/history/History.tsx
+++ b/src/app/views/sidebar/history/History.tsx
@@ -269,7 +269,11 @@ export class History extends Component<IHistoryProps, any> {
                   ? `${expandText} ${props.group!.name}`
                   : `${collapseText} ${props.group!.name}`
               }
-              ariaLabel='expand collapse group'
+              ariaLabel={
+                props.group!.isCollapsed
+                  ? `${expandText} ${props.group!.name}`
+                  : `${collapseText} ${props.group!.name}`
+              }
               onClick={() => this.onToggleCollapse(props)}
             />
             <div className={classes.groupTitle}>


### PR DESCRIPTION
## Overview
This PR fixes multiple accessibility issues present on GE: 

- [x] **Sign in to Graph Explorer** button - The aria-label is updated as 'Sign in to Graph explorer' and hence the Narrator announces it as "Sign in to Graph explorer button" whereas before it announced it as 'Sign in to Button Button'.
- [x] **Expand/Collapse group** button under the **History** tab item - Narrator announces as 'Expand today' / 'Collapse Today' as opposed to 'Today expand collapse group button collapsed today'. 
- [x] **Access Token** tab - Replaced label component with a blocked type messageBar. This ensures the screen reader announces the message to users.
- [x] Modify Permissions (Preview) ->**Admin consent required** column - The column heading text is fully visible at 100% zoom. Previously, the text had an overflow.



## Testing Instructions
Step 1: Open the above URL in Edge browser.
Step 2: Open Narrator using 'Win + Ctrl+ Enter' key.
Step 3: Navigate to **Sign in to graph explorer** button using the Tab key.
Step 4: Observe the Fix.
Step 5: Navigate to the **History** tab item for the page by the Tab and Right Arrow key and activate it.
Step 6: Navigate to the **Expand collapse group button** by Tab key and activate it.
Step 7: Observe the narration here
Step 8: Navigate to the **Modified permission (Preview)** button by tab key and activate it by using the Enter key.
Step 9: Observe 'Admin Consent required' column fix

