### PR TITLE
Fix: repopulate modify permissions when panel closed

### DIFF
--- a/src/app/services/actions/permissions-action-creator.ts
+++ b/src/app/services/actions/permissions-action-creator.ts
@@ -3,8 +3,8 @@ import { MessageBarType } from 'office-ui-fabric-react';
 import { geLocale } from '../../../appLocale';
 import { authenticationWrapper } from '../../../modules/authentication';
 import { IAction } from '../../../types/action';
-import { IQuery } from '../../../types/query-runner';
 import { IRequestOptions } from '../../../types/request';
+import { IRootState } from '../../../types/root';
 import { sanitizeQueryUrl } from '../../utils/query-url-sanitization';
 import { parseSampleUrl } from '../../utils/sample-url-generation';
 import { translateMessage } from '../../utils/translate-messages';
@@ -39,14 +39,14 @@ export function fetchScopesError(response: object): IAction {
   };
 }
 
-export function fetchScopes(query?: IQuery): Function {
+export function fetchScopes(): Function {
   return async (dispatch: Function, getState: Function) => {
     let hasUrl = false; // whether permissions are for a specific url
     try {
-      const { devxApi } = getState();
+      const { devxApi, permissionsPanelOpen, sampleQuery: query }: IRootState = getState();
       let permissionsUrl = `${devxApi.baseUrl}/permissions`;
 
-      if (query) {
+      if (!permissionsPanelOpen) {
         const signature = sanitizeQueryUrl(query.sampleUrl);
         const { requestUrl, sampleUrl } = parseSampleUrl(signature);
 

--- a/src/app/views/query-runner/request/permissions/Permission.tsx
+++ b/src/app/views/query-runner/request/permissions/Permission.tsx
@@ -39,7 +39,7 @@ export class Permission extends Component<IPermissionProps, IPermissionState> {
   }
 
   public componentDidUpdate = (prevProps: IPermissionProps) => {
-    if (prevProps.sample !== this.props.sample) {
+    if ((prevProps.sample !== this.props.sample) || (prevProps.permissionsPanelOpen !== this.props.permissionsPanelOpen)) {
       this.getPermissions();
     }
     const permissions = this.props.scopes.data;
@@ -51,13 +51,7 @@ export class Permission extends Component<IPermissionProps, IPermissionState> {
   }
 
   private getPermissions() {
-    const { panel, sample } = this.props;
-    if (panel) {
-      this.props.actions!.fetchScopes();
-    }
-    else {
-      this.props.actions!.fetchScopes(sample);
-    }
+    this.props.actions!.fetchScopes();
   }
 
   public shouldComponentUpdate(nextProps: IPermissionProps, nextState: IPermissionState) {
@@ -65,6 +59,7 @@ export class Permission extends Component<IPermissionProps, IPermissionState> {
       || nextProps.scopes !== this.props.scopes
       || nextProps.consentedScopes !== this.props.consentedScopes
       || nextProps.dimensions !== this.props.dimensions
+      || nextProps.permissionsPanelOpen !== this.props.permissionsPanelOpen
       || nextState.permissions !== this.state.permissions;
     return shouldUpdate;
   }
@@ -242,7 +237,7 @@ export class Permission extends Component<IPermissionProps, IPermissionState> {
     if (loading) {
       return <Label>
         <FormattedMessage id={'Fetching permissions'} />...
-        </Label>;
+      </Label>;
     }
 
     const displayPermissionsPanel = () => {
@@ -278,13 +273,14 @@ export class Permission extends Component<IPermissionProps, IPermissionState> {
   }
 }
 
-function mapStateToProps({ sampleQuery, scopes, authToken, consentedScopes, dimensions }: IRootState) {
+function mapStateToProps({ sampleQuery, scopes, authToken, consentedScopes, dimensions, permissionsPanelOpen }: IRootState) {
   return {
     sample: sampleQuery,
     scopes,
     tokenPresent: authToken.token,
     consentedScopes,
-    dimensions
+    dimensions,
+    permissionsPanelOpen
   };
 }
 

--- a/src/types/permissions.ts
+++ b/src/types/permissions.ts
@@ -17,6 +17,7 @@ export interface IPermissionProps {
   panel: boolean;
   sample: IQuery[];
   tokenPresent: boolean;
+  permissionsPanelOpen: boolean;
   consentedScopes: string[];
   setPermissions: Function;
   actions?: {

--- a/src/types/root.ts
+++ b/src/types/root.ts
@@ -1,6 +1,7 @@
 import { IAdaptiveCardResponse } from './adaptivecard';
 import { IAuthenticateResult } from './authentication';
 import { IAutocompleteResponse } from './auto-complete';
+import { IDevxAPI } from './devx-api';
 import { IDimensions } from './dimensions';
 import { Mode } from './enums';
 import { IHistoryItem } from './history';
@@ -33,6 +34,7 @@ export interface IRootState {
   responseAreaExpanded: boolean;
   dimensions: IDimensions;
   autoComplete: IAutocompleteResponse;
+  devxApi: IDevxAPI;
 }
 
 export interface IApiFetch {


### PR DESCRIPTION
## Overview

Closes #994 

Scenario:
- A user opens a query's modify permission page
- The user opens the permissions panel 
- The user closes the permissions panel and is now back on the modify permissions page

The fix now repopulates the modify permissions screen with the permissions (if any) of the query URL that is in the URL bar

### Demo

Follow this link: [https://jolly-sand-0ac78c710-999.centralus.azurestaticapps.net/](https://jolly-sand-0ac78c710-999.centralus.azurestaticapps.net)

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Log in to GE
* Select `my mail` and take note of the permissions displayed
* Head over to the more actions icon and open the Select Permissions panel
* Close the Select Permissions panel
* Notice the original permissions belonging to `my mail` are displayed again