### PR TITLE
FIx: Clear the user's profile on sign out

### DIFF
--- a/src/app/services/actions/profile-action-creators.ts
+++ b/src/app/services/actions/profile-action-creators.ts
@@ -27,6 +27,15 @@ export function getProfileInfo(query: IQuery): Function {
   return (dispatch: Function) => {
     const respHeaders: any = {};
 
+    if (!query.sampleHeaders) {
+      query.sampleHeaders = [];
+    }
+
+    query.sampleHeaders.push({
+      name: 'Cache-Control',
+      value: 'no-cache'
+    });
+
     return authenticatedRequest(dispatch, query).then(async (response: Response) => {
 
       if (response && response.ok) {


### PR DESCRIPTION
## Overview

Closes #975 

The browser does not get a user's profile each time because of the default browser cache settings hence why the image is not fetched afresh from the service.

## Testing Instructions

* Log in to GE with account A with a profile image
* Logout of account A
* Log in to GE with account B with a different profile image
* Notice the different profile picture is loaded