### PR TITLE
Fix: url truncation

### DIFF
--- a/src/app/services/actions/query-action-creator-util.ts
+++ b/src/app/services/actions/query-action-creator-util.ts
@@ -21,7 +21,7 @@ export function queryResponse(response: object): IAction {
 
 export async function anonymousRequest(dispatch: Function, query: IQuery) {
   const authToken = '{token:https://graph.microsoft.com/}';
-  const escapedUrl = encodeURIComponent(query.sampleUrl);
+  const escapedUrl = encodeURIComponent(encodeHashCharacters(query));
   const graphUrl = `${GRAPH_API_SANDBOX_URL}/svc?url=${escapedUrl}`;
   const sampleHeaders: any = {};
   if (query.sampleHeaders && query.sampleHeaders.length > 0) {
@@ -112,8 +112,9 @@ const makeRequest = (httpVerb: string, scopes: string[]): Function => {
       authProvider,
       msalAuthOptions
     );
+
     const client = GraphClient.getInstance()
-      .api(query.sampleUrl)
+      .api(encodeHashCharacters(query))
       .middlewareOptions([middlewareOptions])
       .headers(sampleHeaders)
       .responseType(ResponseType.RAW);
@@ -145,3 +146,7 @@ const makeRequest = (httpVerb: string, scopes: string[]): Function => {
     return Promise.resolve(response);
   };
 };
+
+function encodeHashCharacters(query: IQuery): string {
+  return query.sampleUrl.replace(/#/g, '%23');
+}

--- a/src/app/services/actions/query-action-creator-util.ts
+++ b/src/app/services/actions/query-action-creator-util.ts
@@ -148,5 +148,5 @@ const makeRequest = (httpVerb: string, scopes: string[]): Function => {
 };
 
 function encodeHashCharacters(query: IQuery): string {
-  return query.sampleUrl.replace(/#/g, '%23');
+  return query.sampleUrl.replace(/#/g, '%2523');
 }


### PR DESCRIPTION
## Overview

Closes #979 

Double encodes the `#` characters present in the url

### Demo

N/A

### Notes

N/A

## Testing Instructions

* Run `GET https://graph.microsoft.com/v1.0/users/Nic#Von@chambele.onmicrosoft.com`
* Observe `message": "Request with $search query parameter only works through MSGraph with a special request header: 'ConsistencyLevel: eventual'",`
* Add the 'ConsistencyLevel: eventual' headers to the request
* Run the query again and notice it does not fail


* Run `GET https://graph.microsoft.com/v1.0/users/Nic#Von@chambele.onmicrosoft.com`
* The response will now indicate it can't find the user Nic#Von@chambele.onmicrosoft.com
* Look in Fiddler and observe that the full URL is sent.

