### PR TITLE
Task: refine url truncation

### DIFF
--- a/src/app/services/actions/query-action-creator-util.ts
+++ b/src/app/services/actions/query-action-creator-util.ts
@@ -22,7 +22,7 @@ export function queryResponse(response: object): IAction {
 export async function anonymousRequest(dispatch: Function, query: IQuery) {
   const authToken = '{token:https://graph.microsoft.com/}';
   const escapedUrl = encodeURIComponent(encodeHashCharacters(query));
-  const graphUrl = `${GRAPH_API_SANDBOX_URL}/svc?url=${escapedUrl}`;
+  const graphUrl = `${GRAPH_API_SANDBOX_URL}?url=${escapedUrl}`;
 
   const sampleHeaders: any = {};
   if (query.sampleHeaders && query.sampleHeaders.length > 0) {

--- a/src/app/services/actions/query-action-creator-util.ts
+++ b/src/app/services/actions/query-action-creator-util.ts
@@ -1,12 +1,14 @@
 import {
   AuthenticationHandlerOptions,
-  ResponseType,
+  ResponseType
 } from '@microsoft/microsoft-graph-client';
 import { MSALAuthenticationProviderOptions } from '@microsoft/microsoft-graph-client/lib/src/MSALAuthenticationProviderOptions';
+
 import { IAction } from '../../../types/action';
 import { ContentType } from '../../../types/enums';
 import { IQuery } from '../../../types/query-runner';
 import { IRequestOptions } from '../../../types/request';
+import { encodeHashCharacters } from '../../utils/query-url-sanitization';
 import { authProvider, GraphClient } from '../graph-client';
 import { DEFAULT_USER_SCOPES, GRAPH_API_SANDBOX_URL } from '../graph-constants';
 import { QUERY_GRAPH_SUCCESS } from '../redux-constants';
@@ -147,7 +149,3 @@ const makeRequest = (httpVerb: string, scopes: string[]): Function => {
     return Promise.resolve(response);
   };
 };
-
-function encodeHashCharacters(query: IQuery): string {
-  return query.sampleUrl.replace(/#/g, '%2523');
-}

--- a/src/app/services/actions/query-action-creator-util.ts
+++ b/src/app/services/actions/query-action-creator-util.ts
@@ -21,7 +21,7 @@ export function queryResponse(response: object): IAction {
 
 export async function anonymousRequest(dispatch: Function, query: IQuery) {
   const authToken = '{token:https://graph.microsoft.com/}';
-  const escapedUrl = encodeURIComponent(query.sampleUrl);
+  const escapedUrl = encodeURIComponent(encodeHashCharacters(query));
   const graphUrl = `${GRAPH_API_SANDBOX_URL}?url=${escapedUrl}`;
 
   const sampleHeaders: any = {};

--- a/src/app/services/actions/query-action-creator-util.ts
+++ b/src/app/services/actions/query-action-creator-util.ts
@@ -21,7 +21,7 @@ export function queryResponse(response: object): IAction {
 
 export async function anonymousRequest(dispatch: Function, query: IQuery) {
   const authToken = '{token:https://graph.microsoft.com/}';
-  const escapedUrl = encodeURIComponent(encodeHashCharacters(query));
+  const escapedUrl = encodeURIComponent(query.sampleUrl);
   const graphUrl = `${GRAPH_API_SANDBOX_URL}?url=${escapedUrl}`;
 
   const sampleHeaders: any = {};

--- a/src/app/utils/query-url-sanitization.ts
+++ b/src/app/utils/query-url-sanitization.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-useless-escape */
+import { IQuery } from '../../types/query-runner';
 import { GRAPH_URL } from '../services/graph-constants';
 import {
   isAllAlpha,
@@ -141,4 +142,8 @@ function sanitizeQueryParameters(queryString: string): string {
   // remove leading ? from query string
   queryString = queryString.substring(1);
   return queryString.split('&').map(sanitizeQueryParameter).join('&');
+}
+
+export function encodeHashCharacters(query: IQuery): string {
+  return query.sampleUrl.replace(/#/g, '%2523');
 }

--- a/src/app/views/common/share.ts
+++ b/src/app/views/common/share.ts
@@ -1,6 +1,7 @@
 import { geLocale } from '../../../appLocale';
 import { authenticationWrapper } from '../../../modules/authentication';
 import { IQuery } from '../../../types/query-runner';
+import { encodeHashCharacters } from '../../utils/query-url-sanitization';
 import { parseSampleUrl } from '../../utils/sample-url-generation';
 
 /**
@@ -10,7 +11,8 @@ import { parseSampleUrl } from '../../utils/sample-url-generation';
  */
 export const createShareLink = (sampleQuery: IQuery, authenticated?: boolean): string => {
   const { sampleBody, selectedVerb, sampleHeaders } = sampleQuery;
-  const { queryVersion, requestUrl, sampleUrl, search } = parseSampleUrl(sampleQuery.sampleUrl);
+  const { queryVersion, requestUrl, sampleUrl, search } =
+    parseSampleUrl(encodeHashCharacters(sampleQuery));
 
   if (!sampleUrl) {
     return '';


### PR DESCRIPTION
## Overview

Refines the work done in #1012 to:
- remove an extra path from sandbox URL brought in from a merge where the path was added
- prevents truncation when sharing a query with a # 