### PR TITLE
Fix: Response Preview truncation

### DIFF
--- a/src/app/views/common/monaco/Monaco.tsx
+++ b/src/app/views/common/monaco/Monaco.tsx
@@ -45,6 +45,7 @@ export function Monaco(props: IMonaco) {
                 horizontal: 'visible',
                 horizontalScrollbarSize: 17,
               },
+              wordWrap: 'on'
             }}
             onChange={onChange}
             theme={theme === 'light' ? 'vs' : 'vs-dark'}


### PR DESCRIPTION
## Overview
 Fixes response truncation observed when a user runs a query.
Fixes #957 

### Demo
_before fix:_
![image](https://user-images.githubusercontent.com/18407044/124772985-329fc100-df45-11eb-8a38-d093c007e0c7.png)

_after fix:_
![image](https://user-images.githubusercontent.com/18407044/124773316-84484b80-df45-11eb-9fa8-91740a51b413.png)


### Notes

If You get a 404-Bad request. Add 'ConsistencyLevel: eventual in the **Request header** tab

## Testing Instructions

* Load app.
* Run 
 `GET https://graph.microsoft.com/v1.0/servicePrincipals$count=true&$search="displayName:teams"&$select=id,displayName`.
* Observe **@odata.id** field in the Response Preview.
* Observe url is wrapped.
