### PR TITLE
Feature/DetailsList scrollbars only appear onHover

### DIFF
--- a/src/app/views/query-runner/request/headers/RequestHeaders.tsx
+++ b/src/app/views/query-runner/request/headers/RequestHeaders.tsx
@@ -21,6 +21,7 @@ const RequestHeaders = (props: any) => {
   const [headerName, setHeaderName] = useState('');
   const [headerValue, setHeaderValue] = useState('');
   const [announcedMessage, setAnnouncedMessage] = useState('');
+  const [isHoverOverHeadersList, setIsHoverOverHeadersList] = useState(false);
 
   const { intl: { messages } } = props;
   const sampleQueryHeaders = sampleQuery.sampleHeaders;
@@ -76,7 +77,11 @@ const RequestHeaders = (props: any) => {
   };
 
   return (
-    <div className={classes.container} style={{ height: convertVhToPx(height, 60) }}>
+    <div
+      onMouseEnter={() => { setIsHoverOverHeadersList(true); console.log('enter') }}
+      onMouseLeave={() => { setIsHoverOverHeadersList(false) }}
+      className={classes.container}
+      style={isHoverOverHeadersList ? { height: convertVhToPx(height, 60) } : { height: convertVhToPx(height, 60), overflow: "hidden" }}>
       <Announced message={announcedMessage} />
       <div className='row'>
         <div className='col-sm-5'>

--- a/src/app/views/query-runner/request/headers/RequestHeaders.tsx
+++ b/src/app/views/query-runner/request/headers/RequestHeaders.tsx
@@ -78,8 +78,8 @@ const RequestHeaders = (props: any) => {
 
   return (
     <div
-      onMouseEnter={() => { setIsHoverOverHeadersList(true); console.log('enter') }}
-      onMouseLeave={() => { setIsHoverOverHeadersList(false) }}
+      onMouseEnter={() => setIsHoverOverHeadersList(true)}
+      onMouseLeave={() => setIsHoverOverHeadersList(false)}
       className={classes.container}
       style={isHoverOverHeadersList ? { height: convertVhToPx(height, 60) } : { height: convertVhToPx(height, 60), overflow: "hidden" }}>
       <Announced message={announcedMessage} />

--- a/src/app/views/query-runner/request/permissions/TabList.tsx
+++ b/src/app/views/query-runner/request/permissions/TabList.tsx
@@ -65,8 +65,8 @@ const TabList = ({ columns, classes, renderItemColumn, renderDetailsHeader, maxH
         {tokenPresent && <FormattedMessage id='permissions required to run the query' />}
       </Label>
       <div
-        onMouseEnter={() => { setIsHoverOverPermissionsList(true) }}
-        onMouseLeave={() => { setIsHoverOverPermissionsList(false) }}>
+        onMouseEnter={() => setIsHoverOverPermissionsList(true)}
+        onMouseLeave={() => setIsHoverOverPermissionsList(false)}>
         <DetailsList
           styles={isHoverOverPermissionsList ? { root: { maxHeight } } : { root: { maxHeight, overflow: "hidden" } }}
           items={permissions}

--- a/src/app/views/query-runner/request/permissions/TabList.tsx
+++ b/src/app/views/query-runner/request/permissions/TabList.tsx
@@ -1,5 +1,5 @@
 import { DetailsList, DetailsListLayoutMode, IColumn, Label, Link, SelectionMode } from 'office-ui-fabric-react';
-import React from 'react';
+import React, { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -21,6 +21,7 @@ const TabList = ({ columns, classes, renderItemColumn, renderDetailsHeader, maxH
   const { consentedScopes, scopes, authToken } = useSelector((state: IRootState) => state);
   const permissions: IPermission[] = scopes.hasUrl ? scopes.data : [];
   const tokenPresent = !!authToken.token;
+  const [isHoverOverPermissionsList, setIsHoverOverPermissionsList] = useState(false);
 
   setConsentedStatus(tokenPresent, permissions, consentedScopes);
 
@@ -63,13 +64,18 @@ const TabList = ({ columns, classes, renderItemColumn, renderDetailsHeader, maxH
         {!tokenPresent && <FormattedMessage id='sign in to consent to permissions' />}
         {tokenPresent && <FormattedMessage id='permissions required to run the query' />}
       </Label>
-      <DetailsList styles={{ root: { maxHeight } }}
-        items={permissions}
-        columns={columns}
-        onRenderItemColumn={(item?: any, index?: number, column?: IColumn) => renderItemColumn(item, index, column)}
-        selectionMode={SelectionMode.none}
-        layoutMode={DetailsListLayoutMode.justified}
-        onRenderDetailsHeader={(props?: any, defaultRender?: any) => renderDetailsHeader(props, defaultRender)} />
+      <div
+        onMouseEnter={() => { setIsHoverOverPermissionsList(true) }}
+        onMouseLeave={() => { setIsHoverOverPermissionsList(false) }}>
+        <DetailsList
+          styles={isHoverOverPermissionsList ? { root: { maxHeight } } : { root: { maxHeight, overflow: "hidden" } }}
+          items={permissions}
+          columns={columns}
+          onRenderItemColumn={(item?: any, index?: number, column?: IColumn) => renderItemColumn(item, index, column)}
+          selectionMode={SelectionMode.none}
+          layoutMode={DetailsListLayoutMode.justified}
+          onRenderDetailsHeader={(props?: any, defaultRender?: any) => renderDetailsHeader(props, defaultRender)} />
+      </div>
       {permissions && permissions.length === 0 &&
         displayNoPermissionsFoundMessage()
       }

--- a/src/app/views/sidebar/history/History.tsx
+++ b/src/app/views/sidebar/history/History.tsx
@@ -518,20 +518,26 @@ export class History extends Component<IHistoryProps, any> {
           <Announced
             message={`${items.length} search results available.`}
           />
-          {items.length > 0 && <DetailsList
-            className={classes.queryList}
-            onRenderItemColumn={this.renderItemColumn}
-            items={items}
-            columns={columns}
-            selectionMode={SelectionMode.none}
-            groups={groups}
-            groupProps={{
-              showEmptyGroups: true,
-              onRenderHeader: this.renderGroupHeader,
-            }}
-            onRenderRow={this.renderRow}
-            onRenderDetailsHeader={this.renderDetailsHeader}
-          />}
+          {items.length > 0 &&
+            <div
+              onMouseEnter={() => { this.setState({ isHoverOverHistoryList: true }); }}
+              onMouseLeave={() => { this.setState({ isHoverOverHistoryList: false }); }}>
+              <DetailsList
+                styles={this.state.isHoverOverHistoryList ? { root: { overflow: 'scroll' } } : { root: { overflow: 'hidden' } }}
+                className={classes.queryList}
+                onRenderItemColumn={this.renderItemColumn}
+                items={items}
+                columns={columns}
+                selectionMode={SelectionMode.none}
+                groups={groups}
+                groupProps={{
+                  showEmptyGroups: true,
+                  onRenderHeader: this.renderGroupHeader,
+                }}
+                onRenderRow={this.renderRow}
+                onRenderDetailsHeader={this.renderDetailsHeader}
+              />
+            </div>}
         </div>
         <Dialog
           hidden={hideDialog}

--- a/src/app/views/sidebar/history/History.tsx
+++ b/src/app/views/sidebar/history/History.tsx
@@ -520,8 +520,8 @@ export class History extends Component<IHistoryProps, any> {
           />
           {items.length > 0 &&
             <div
-              onMouseEnter={() => { this.setState({ isHoverOverHistoryList: true }); }}
-              onMouseLeave={() => { this.setState({ isHoverOverHistoryList: false }); }}>
+              onMouseEnter={() => this.setState({ isHoverOverHistoryList: true })}
+              onMouseLeave={() => this.setState({ isHoverOverHistoryList: false })}>
               <DetailsList
                 styles={this.state.isHoverOverHistoryList ? { root: { overflow: 'scroll' } } : { root: { overflow: 'hidden' } }}
                 className={classes.queryList}

--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -438,8 +438,8 @@ export class SampleQueries extends Component<ISampleQueriesProps, any> {
           message={`${sampleQueries.length} search results available.`}
         />
         <div role='navigation'
-          onMouseEnter={() => { this.setState({ isHoverOverSampleQueriesList: true }) }}
-          onMouseLeave={() => { this.setState({ isHoverOverSampleQueriesList: false }) }}>
+          onMouseEnter={() => this.setState({ isHoverOverSampleQueriesList: true })}
+          onMouseLeave={() => this.setState({ isHoverOverSampleQueriesList: false })}>
           <DetailsList
             styles={this.state.isHoverOverSampleQueriesList ? { root: { overflow: 'scroll' } } : { root: { overflow: 'hidden' } }}
             className={classes.queryList}

--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -437,8 +437,11 @@ export class SampleQueries extends Component<ISampleQueriesProps, any> {
         <Announced
           message={`${sampleQueries.length} search results available.`}
         />
-        <div role='navigation'>
+        <div role='navigation'
+          onMouseEnter={() => { this.setState({ isHoverOverSampleQueriesList: true }) }}
+          onMouseLeave={() => { this.setState({ isHoverOverSampleQueriesList: false }) }}>
           <DetailsList
+            styles={this.state.isHoverOverSampleQueriesList ? { root: { overflow: 'scroll' } } : { root: { overflow: 'hidden' } }}
             className={classes.queryList}
             cellStyleProps={{
               cellRightPadding: 0,


### PR DESCRIPTION
## Overview
The existing DetailsList scrollbars are the default Edge light mode scrollbars that appear when there is overflow (see right of screenshot below), and they are jarring to the user especially if they are on dark mode. 
![image](https://user-images.githubusercontent.com/47487758/125691026-63fdf6e6-524b-45f7-961d-592af3af942c.png)

https://dev.azure.com/microsoftgarage/Intern%20GitHub/_sprints/taskboard/GI21%20-%20Graph%20Explorer/Intern%20GitHub/Y21-S/06?workitem=38891

### Demo
The changes in this PR will hide the scrollbars until the user hovers over a DetailsList with overflow, then the scrollbars will appear. 
https://gyazo.com/ceaaa8648891cd6e7b672bac68b775d8

### Notes
Four scrollbars have been changed: 
History list, Sample Queries list, Permissions (panel tab) list, and Request Headers (panel tab) list. 

## Testing Instructions
* Front-end, test the four lists above (and shown in the demo recording). 
* Cross browser testing: developed in Edge and Chrome 