### PR TITLE
Fix query link parsing with trailing '.'

### DIFF
--- a/src/app/utils/status-message.ts
+++ b/src/app/utils/status-message.ts
@@ -20,7 +20,7 @@ export function convertArrayToObject(array: any[]): object {
 };
 
 export function extractUrl(value: string): string[] | null {
-  return value.toString().match(/\bhttps?:\/\/\S+/gi);
+  return value.toString().match(/\bhttps?:\/\/\S+(?<!\.)/gi);
 }
 
 export function matchIncludesLink(matches: RegExpMatchArray, part: string) {


### PR DESCRIPTION
**Issue:**
Sample queries with tips that have clickable query links will populate the query runner with a trailing "." if the . was at the end of the link. This is due to the way that the links are parsed.

**To test:**
All of the "Excel" sample queries, and more, have periods at the end of the tip message that contain clickable query links. To test this change, click one of these links in the tips that end in a "." and ensure that:
  1. The link highlighting should not extend to the .
  2. The link placed in the query runner should not contain the .
 

https://user-images.githubusercontent.com/49354780/126227792-e5d61980-1257-4f28-8c29-718e3edc327d.mp4


If the following tests pass, the bug is fixed, as demonstrated in the gif 😊 

[AD#39035](https://dev.azure.com/microsoftgarage/Intern%20GitHub/_sprints/taskboard/GI21%20-%20Graph%20Explorer/Intern%20GitHub/Y21-S/07?workitem=39035)