### PR TITLE
Add translated aria labels

### DIFF
--- a/src/app/views/query-response/pivot-items/pivot-items.tsx
+++ b/src/app/views/query-response/pivot-items/pivot-items.tsx
@@ -62,7 +62,7 @@ export const getPivotItems = () => {
   const pivotItems = [
     <PivotItem
       key='response-preview'
-      ariaLabel='Response Preview'
+      ariaLabel={translateMessage('Response Preview')}
       itemIcon='Reply'
       itemKey='response-preview' // To be used to construct component name for telemetry data
       headerText={translateMessage('Response Preview')}
@@ -73,7 +73,7 @@ export const getPivotItems = () => {
     </PivotItem>,
     <PivotItem
       key='response-headers'
-      ariaLabel='Response Headers'
+      ariaLabel={translateMessage('Response Headers')}
       headerText={translateMessage('Response Headers')}
       itemIcon='FileComment'
       itemKey='response-headers'
@@ -88,7 +88,7 @@ export const getPivotItems = () => {
     pivotItems.push(
       <PivotItem
         key='code-snippets'
-        ariaLabel='Code Snippets'
+        ariaLabel={translateMessage('Snippets')}
         title={translateMessage('Snippets')}
         headerText={translateMessage('Snippets')}
         itemIcon='PasteAsCode'
@@ -99,7 +99,7 @@ export const getPivotItems = () => {
       </PivotItem>,
       <PivotItem
         key='graph-toolkit'
-        ariaLabel='Graph Toolkit'
+        ariaLabel={translateMessage('Graph toolkit')}
         itemIcon='CustomizeToolbar'
         itemKey='toolkit-component'
         headerText={translateMessage('Graph toolkit')}
@@ -110,7 +110,7 @@ export const getPivotItems = () => {
       </PivotItem>,
       <PivotItem
         key='adaptive-cards'
-        ariaLabel='Adaptive Cards'
+        ariaLabel={translateMessage('Adaptive Cards')}
         headerText={translateMessage('Adaptive Cards')}
         title={translateMessage('Adaptive Cards')}
         itemIcon='ContactCard'

--- a/src/app/views/query-runner/request/auth/Auth.tsx
+++ b/src/app/views/query-runner/request/auth/Auth.tsx
@@ -53,7 +53,7 @@ export function Auth(props: any) {
       <div>
         <div className={classes.accessTokenContainer}>
           <Label className={classes.accessTokenLabel}><FormattedMessage id='Access Token' /></Label>
-          <IconButton onClick={handleCopy} iconProps={copyIcon} title='Copy' ariaLabel='Copy' />
+          <IconButton onClick={handleCopy} iconProps={copyIcon} title={translateMessage('Copy')} ariaLabel={translateMessage('Copy')} />
           <IconButton iconProps={tokenDetailsIcon}
             title={translateMessage('Get token details (Powered by jwt.ms)')}
             ariaLabel={translateMessage('Get token details (Powered by jwt.ms)')}


### PR DESCRIPTION
## Overview

I had a brief chat with an engineer who was on the Fluent UI team who confirmed that aria labels should always be localized, and I noticed some aria labels not localized in the codebase. 
![image](https://user-images.githubusercontent.com/47487758/127564182-4343a8f8-86dd-42a1-961d-e46a1b8e3116.png)

https://dev.azure.com/microsoftgarage/Intern%20GitHub/_sprints/taskboard/GI21%20-%20Graph%20Explorer/Intern%20GitHub/Y21-S/08?workitem=39309