### PR TITLE
Task: remove sandbox api test

### DIFF
--- a/src/tests/utils/proxy-url.spec.ts
+++ b/src/tests/utils/proxy-url.spec.ts
@@ -1,4 +1,4 @@
-import { GRAPH_API_SANDBOX_ENDPOINT_URL, GRAPH_API_SANDBOX_URL } from "../../app/services/graph-constants";
+import { GRAPH_API_SANDBOX_ENDPOINT_URL } from "../../app/services/graph-constants";
 import fetch from "isomorphic-fetch";
 import { isValidHttpsUrl } from "../../app/utils/external-link-validation";
 import { createAnonymousRequest } from "../../app/services/actions/query-action-creator-util";

--- a/src/tests/utils/proxy-url.spec.ts
+++ b/src/tests/utils/proxy-url.spec.ts
@@ -29,20 +29,4 @@ describe('Sandbox api fetch should', () => {
     expect(response.ok).toBe(true);
   });
 
-  test('use old endpoint to make call to proxy', async () => {
-    const proxyUrl = GRAPH_API_SANDBOX_URL;
-
-    const query: IQuery = {
-      sampleUrl: 'https://graph.microsoft.com/v1.0/me',
-      sampleHeaders: [],
-      selectedVerb: 'GET',
-      selectedVersion: 'v1.0',
-      sampleBody: ''
-    }
-
-    const { graphUrl, options } = createAnonymousRequest(query, proxyUrl);
-    const response = await fetch(graphUrl, options);
-    expect(response.ok).toBe(true);
-  });
-
 });


### PR DESCRIPTION
## Overview

Due to changing the Proxy API endpoint, the test previously targeting the original endpoint is failing. This PR removes the test as it is no longer necessary
