### PR TITLE
Feature: Add Graph explorer documentation

### DIFF
--- a/src/app/views/query-runner/request/auth/Auth.tsx
+++ b/src/app/views/query-runner/request/auth/Auth.tsx
@@ -5,7 +5,7 @@ import { FormattedMessage } from 'react-intl';
 import { useSelector } from 'react-redux';
 import { authenticationWrapper } from '../../../../../modules/authentication';
 
-import { componentNames, eventTypes, telemetry } from '../../../../../telemetry';
+import { componentNames, telemetry } from '../../../../../telemetry';
 import { IRootState } from '../../../../../types/root';
 import { translateMessage } from '../../../../utils/translate-messages';
 import { classNames } from '../../../classnames';

--- a/src/app/views/settings/Settings.tsx
+++ b/src/app/views/settings/Settings.tsx
@@ -29,6 +29,7 @@ import { consentToScopes } from '../../services/actions/permissions-action-creat
 import { togglePermissionsPanel } from '../../services/actions/permissions-panel-action-creator';
 import { changeTheme } from '../../services/actions/theme-action-creator';
 import { Permission } from '../query-runner/request/permissions';
+import { translateMessage } from '../../utils/translate-messages';
 
 
 function Settings(props: ISettingsProps) {
@@ -56,6 +57,16 @@ function Settings(props: ISettingsProps) {
         onClick: () => trackOfficeDevProgramLinkClickEvent(),
       },
       {
+        key: 'graph-explorer-documentation',
+        text: translateMessage('Graph Explorer Documentation'),
+        href: 'https://docs.microsoft.com/en-us/graph/graph-explorer/graph-explorer-overview',
+        target: '_blank',
+        iconProps: {
+          iconName: 'TextDocument'
+        },
+        onClick: (e: any) => telemetry.trackLinkClickEvent(e.currentTarget.href, componentNames.GRAPH_EXPLORER_DOCUMENTATION_LINK)
+      },
+      {
         key: 'report-issue',
         text: messages['Report an Issue'],
         href: 'https://github.com/microsoftgraph/microsoft-graph-explorer-v4/issues/new/choose',
@@ -65,6 +76,7 @@ function Settings(props: ISettingsProps) {
         },
         onClick: () => trackReportAnIssueLinkClickEvent(),
       },
+
       {
         key: 'divider',
         text: '-',

--- a/src/app/views/settings/Settings.tsx
+++ b/src/app/views/settings/Settings.tsx
@@ -48,7 +48,7 @@ function Settings(props: ISettingsProps) {
     const menuItems: any = [
       {
         key: 'office-dev-program',
-        text: messages['Office Dev Program'],
+        text: translateMessage('Office Dev Program'),
         href: `https://developer.microsoft.com/${geLocale}/office/dev-program`,
         target: '_blank',
         iconProps: {
@@ -68,7 +68,7 @@ function Settings(props: ISettingsProps) {
       },
       {
         key: 'report-issue',
-        text: messages['Report an Issue'],
+        text: translateMessage('Report an Issue'),
         href: 'https://github.com/microsoftgraph/microsoft-graph-explorer-v4/issues/new/choose',
         target: '_blank',
         iconProps: {
@@ -84,7 +84,7 @@ function Settings(props: ISettingsProps) {
       },
       {
         key: 'change-theme',
-        text: messages['Change theme'],
+        text: translateMessage('Change theme'),
         iconProps: {
           iconName: 'Color',
         },
@@ -96,7 +96,7 @@ function Settings(props: ISettingsProps) {
       menuItems.push(
         {
           key: 'view-all-permissions',
-          text: messages['view all permissions'],
+          text: translateMessage('view all permissions'),
           iconProps: {
             iconName: 'AzureKeyVault',
           },
@@ -104,7 +104,7 @@ function Settings(props: ISettingsProps) {
         },
         {
           key: 'sign-out',
-          text: messages['sign out'],
+          text: translateMessage('sign out'),
           iconProps: {
             iconName: 'SignOut',
           },

--- a/src/app/views/settings/Settings.tsx
+++ b/src/app/views/settings/Settings.tsx
@@ -59,7 +59,7 @@ function Settings(props: ISettingsProps) {
       {
         key: 'graph-explorer-documentation',
         text: translateMessage('Graph Explorer Documentation'),
-        href: 'https://docs.microsoft.com/en-us/graph/graph-explorer/graph-explorer-overview',
+        href: `https://docs.microsoft.com/${geLocale}/graph/graph-explorer/graph-explorer-overview`,
         target: '_blank',
         iconProps: {
           iconName: 'TextDocument'

--- a/src/telemetry/component-names.ts
+++ b/src/telemetry/component-names.ts
@@ -47,6 +47,7 @@ export const MICROSOFT_APIS_TERMS_OF_USE_LINK = 'Microsoft APIs terms of use lin
 export const MICROSOFT_PRIVACY_STATEMENT_LINK = 'Microsoft privacy statement link';
 export const MICROSOFT_GRAPH_API_REFERENCE_DOCS_LINK = 'Microsoft graph API reference docs link';
 export const REPORT_AN_ISSUE_LINK = 'Report an issue link';
+export const GRAPH_EXPLORER_DOCUMENTATION_LINK = 'Graph Explorer Documentation Link';
 
 // Actions
 export const GET_SNIPPET_ACTION = 'Get snippet action';


### PR DESCRIPTION
## Overview
Add a link to Graph Explorer documentation in the 'More Actions' menu.
Fixes #881 

### Demo
![image](https://user-images.githubusercontent.com/18407044/127987962-10a1a13e-62a5-4622-8cf9-9533fc282b0d.png)
