### PR TITLE
Update snippets url

### DIFF
--- a/src/app/services/actions/snippet-action-creator.ts
+++ b/src/app/services/actions/snippet-action-creator.ts
@@ -31,7 +31,7 @@ export function getSnippet(language: string): Function {
   return async (dispatch: Function, getState: Function) => {
     const { devxApi, sampleQuery } = getState();
     try {
-      let snippetsUrl = `${devxApi.baseUrl}/api/graphexplorersnippets`;
+      let snippetsUrl = `${devxApi.baseUrl}/api/snippets`;
 
       const { requestUrl, sampleUrl, queryVersion, search } = parseSampleUrl(
         sampleQuery.sampleUrl


### PR DESCRIPTION
- Following the recent DevX API project name refactoring for consistency, the snippets url is generating a 404 as seen below:

![image](https://user-images.githubusercontent.com/36787645/132405108-f77c11d4-132d-4025-b050-5c549ecd3825.png)
 
- This PR proposes a fix for this by updating the Snippet generation endpoint url on the frontend.