### PR TITLE
Capture GE mode for all telemetry items

### DIFF
--- a/src/telemetry/filters.ts
+++ b/src/telemetry/filters.ts
@@ -70,6 +70,10 @@ export function addCommonTelemetryItemProperties(envelope: ITelemetryItem) {
   const accessToken = localStorage.getItem(accessTokenKey);
   telemetryItem.properties.IsAuthenticated = !!accessToken;
 
+  // Capture GE Mode for all telemetry items
+  const geMode = store.getState()?.graphExplorerMode;
+  telemetryItem.properties.GraphExplorerMode = geMode;
+
   return true;
 }
 


### PR DESCRIPTION
## Overview

Capture GE mode for all telemetry items sent to Application Insights.

This is to help us properly distinguish between Try It and main GE telemetry.

### Demo
Load Graph Explorer and click on the Run query button while on the network tab of developer tools.




