### PR TITLE
Update how we are sanitizing track trace to include more info

### DIFF
--- a/src/telemetry/filters.ts
+++ b/src/telemetry/filters.ts
@@ -112,8 +112,6 @@ export function sanitizeStackTrace(envelope: ITelemetryItem) {
 
       exception.hasFullStack = false;
       exception.stack = null;
-      exception.parsedStack = [parsedStack];
-      telemetryItem.exceptions = [exception];
     }
   }
   return true;


### PR DESCRIPTION
## Overview

We are missing some data by updating some properties of App Insights telemetry item properties. The aim was to ensure that we capture only data that is necessary but this has caused App Insights to send very minimal data thus missing some error metrics.


### Demo
Simulate error on Graph Explorer. Look at the data sent to the Azure Portal.