### PR TITLE
Capture telemetry for graph toolkit example link

### DIFF
--- a/src/app/services/graph-constants.ts
+++ b/src/app/services/graph-constants.ts
@@ -5,16 +5,20 @@ export const USER_PICTURE_URL = `${GRAPH_URL}/beta/me/photo/$value`;
 export const AUTH_URL = 'https://login.microsoftonline.com';
 export const DEFAULT_USER_SCOPES = 'openid profile User.Read';
 export const DEVX_API_URL = 'https://graphexplorerapi.azurewebsites.net';
-export const GRAPH_API_SANDBOX_URL = 'https://proxy.apisandbox.msdn.microsoft.com/svc';
-export const GRAPH_API_SANDBOX_ENDPOINT_URL = 'https://cdn.graph.office.net/en-us/graph/api/proxy/endpoint';
+export const GRAPH_API_SANDBOX_URL =
+  'https://proxy.apisandbox.msdn.microsoft.com/svc';
+export const GRAPH_API_SANDBOX_ENDPOINT_URL =
+  'https://cdn.graph.office.net/en-us/graph/api/proxy/endpoint';
 export const HOME_ACCOUNT_KEY = 'fbf1ecbe-27ab-42d7-96d4-3e6b03682ee4';
 export enum ACCOUNT_TYPE {
-    AAD = "AAD",
-    MSA = "MSA"
-};
+  AAD = 'AAD',
+  MSA = 'MSA',
+}
 export enum PERMS_SCOPE {
-    WORK = "DelegatedWork",
-    APPLICATION = "Application",
-    PERSONAL = "DelegatedPersonal"
-};
-export const ADAPTIVE_CARD_URL = 'https://templates.adaptivecards.io/graph.microsoft.com';
+  WORK = 'DelegatedWork',
+  APPLICATION = 'Application',
+  PERSONAL = 'DelegatedPersonal',
+}
+export const ADAPTIVE_CARD_URL =
+  'https://templates.adaptivecards.io/graph.microsoft.com';
+export const GRAPH_TOOOLKIT_EXAMPLE_URL = 'https://mgt.dev/?path=/story';

--- a/src/app/utils/graph-toolkit-lookup.ts
+++ b/src/app/utils/graph-toolkit-lookup.ts
@@ -1,5 +1,6 @@
 import templates from '../../graph-toolkit-examples';
 import { IQuery } from '../../types/query-runner';
+import { GRAPH_TOOOLKIT_EXAMPLE_URL } from '../services/graph-constants';
 import { parseSampleUrl } from './sample-url-generation';
 
 export function lookupToolkitUrl(sampleQuery: IQuery) {
@@ -14,13 +15,12 @@ export function lookupToolkitUrl(sampleQuery: IQuery) {
           let { search: componentUrl } = parseSampleUrl(url);
           componentUrl = componentUrl.replace('?id=', '');
           return {
-            exampleUrl: `https://mgt.dev/?path=/story/${componentUrl}`,
-            toolkitUrl: url
+            exampleUrl: `${GRAPH_TOOOLKIT_EXAMPLE_URL}/${componentUrl}`,
+            toolkitUrl: url,
           };
         }
       }
     }
-
   }
   return { toolkitUrl: null, exampleUrl: null };
 }

--- a/src/telemetry/filters.ts
+++ b/src/telemetry/filters.ts
@@ -4,6 +4,7 @@ import {
   ADAPTIVE_CARD_URL,
   DEVX_API_URL,
   GRAPH_API_SANDBOX_URL,
+  GRAPH_TOOOLKIT_EXAMPLE_URL,
   GRAPH_URL,
   HOME_ACCOUNT_KEY,
 } from '../app/services/graph-constants';
@@ -39,6 +40,7 @@ export function filterRemoteDependencyData(envelope: ITelemetryItem): boolean {
       GRAPH_API_SANDBOX_URL,
       new URL(graphProxyUrl).origin,
       new URL(ADAPTIVE_CARD_URL).origin,
+      new URL(GRAPH_TOOOLKIT_EXAMPLE_URL).origin,
     ];
     if (!targetsToInclude.includes(urlObject.origin)) {
       return false;


### PR DESCRIPTION
## Overview

Capture telemetry for when a user clicks on the graph toolkit example link.

### Testing Instructions

- Open developer tools on browser and go to network tab
- Run query as an anonymous user
- Check to see if telemetry data has been sent to Application Insights