### PR TITLE
makes query color in the text area visible in dark mode

### DIFF
--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -204,7 +204,8 @@ const QueryResponse = (props: IQueryResponseProps) => {
             height: 63,
             overflowY: 'scroll',
             border: 'none',
-            resize: 'none'
+            resize: 'none',
+            color: 'black'
           }}
           id='share-query-text'
           className='share-query-params'


### PR DESCRIPTION
## Overview

Solves #1119 

### Demo
![image](https://user-images.githubusercontent.com/45680252/135582467-fe4aefd3-d07a-444a-9375-d5e6acc76ed3.png)



### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions
Change theme to dark theme
Click on 'Share'
The share url is visible