### PR TITLE
Fix: add focus on button

### DIFF
--- a/src/app/views/common/submit-button/SubmitButton.tsx
+++ b/src/app/views/common/submit-button/SubmitButton.tsx
@@ -9,7 +9,8 @@ const SubmitButtonControl = ({
   text,
   ariaLabel,
   role,
-  disabled
+  disabled,
+  allowDisabledFocus
 }: ISubmitButtonControl) => {
 
   return (
@@ -18,6 +19,7 @@ const SubmitButtonControl = ({
         onClick={() => handleOnClick()}
         ariaLabel={ariaLabel}
         role={role}
+        allowDisabledFocus={allowDisabledFocus}
       >
         {text}
         {submitting && <>&nbsp;

--- a/src/app/views/query-runner/query-input/QueryInput.tsx
+++ b/src/app/views/query-runner/query-input/QueryInput.tsx
@@ -113,6 +113,7 @@ const QueryInput = (props: IQueryInputProps) => {
           role='button'
           handleOnClick={() => runQuery()}
           submitting={submitting}
+          allowDisabledFocus={true}
         />
       </div>
     </div>)

--- a/src/types/submit-button.ts
+++ b/src/types/submit-button.ts
@@ -6,4 +6,5 @@ export interface ISubmitButtonControl {
   ariaLabel?: string;
   role?: string;
   disabled?: boolean;
+  allowDisabledFocus?: boolean;
 }


### PR DESCRIPTION
## Overview

Ensures the focus doesn't move from the 'Run Query' button once it's activated.
Fixes #1146 

## Testing Instructions

* Navigate to the 'Run Query' button and Enter
* Notice focus remains on the button
