### PR TITLE
Fix: try it interaction

### DIFF
--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -215,9 +215,7 @@ class App extends Component<IAppProps, IAppState> {
 
   private handleInitMsg = (msg: IInitMessage) => {
     const { actions, profile } = this.props;
-    console.log({ actions, profile, code: msg.code });
     const { verb, headers, url, body }: any = parse(msg.code);
-    console.log({ verb, headers, url, body });
     if (actions) {
       actions.setSampleQuery({
         sampleUrl: url,

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -215,7 +215,9 @@ class App extends Component<IAppProps, IAppState> {
 
   private handleInitMsg = (msg: IInitMessage) => {
     const { actions, profile } = this.props;
+    console.log({ actions, profile, code: msg.code });
     const { verb, headers, url, body }: any = parse(msg.code);
+    console.log({ verb, headers, url, body });
     if (actions) {
       actions.setSampleQuery({
         sampleUrl: url,
@@ -395,7 +397,7 @@ class App extends Component<IAppProps, IAppState> {
                   <div style={{ marginBottom: 8 }}>
                     <QueryRunner onSelectVerb={this.handleSelectVerb} />
                   </div>
-                  <div style={ mobileScreen ? this.statusAreaMobileStyle : this.statusAreaLaptopStyle}>
+                  <div style={mobileScreen ? this.statusAreaMobileStyle : this.statusAreaLaptopStyle}>
                     {statusMessages(queryState, sampleQuery, actions)}
                     {termsOfUseMessage(termsOfUse, actions, classes, geLocale)}
                   </div>

--- a/src/app/views/query-runner/util/iframe-message-parser.spec.ts
+++ b/src/app/views/query-runner/util/iframe-message-parser.spec.ts
@@ -4,10 +4,10 @@ import { parse } from './iframe-message-parser';
 describe('Iframe Message Parser', () => {
   it('parses http request snippet correctly', () => {
     const message = `POST https://graph.microsoft.com/beta/me/calendars
-  Content-type: application/json
-  Prefer: A-timezone
+Content-type: application/json
+Prefer: A-timezone
 
-  { "name": "Volunteer" }`;
+{ "name": "Volunteer" }`;
 
     const parsed = parse(message);
     expect(parsed).toEqual({
@@ -23,10 +23,10 @@ describe('Iframe Message Parser', () => {
 
   it('parses http request snippet without a domain correctly', () => {
     const message = `POST /me/calendars
-  Content-type: application/json
-  Prefer: A-timezone
+Content-type: application/json
+Prefer: A-timezone
 
-  { "name": "Volunteer" }`;
+{ "name": "Volunteer" }`;
 
     const parsed = parse(message);
     expect(parsed).toEqual({

--- a/src/app/views/query-runner/util/iframe-message-parser.spec.ts
+++ b/src/app/views/query-runner/util/iframe-message-parser.spec.ts
@@ -1,12 +1,13 @@
+/* eslint-disable max-len */
 import { parse } from './iframe-message-parser';
 
 describe('Iframe Message Parser', () => {
   it('parses http request snippet correctly', () => {
     const message = `POST https://graph.microsoft.com/beta/me/calendars
-Content-type: application/json
-Prefer: A-timezone
+  Content-type: application/json
+  Prefer: A-timezone
 
-{ "name": "Volunteer" }`;
+  { "name": "Volunteer" }`;
 
     const parsed = parse(message);
     expect(parsed).toEqual({
@@ -22,10 +23,10 @@ Prefer: A-timezone
 
   it('parses http request snippet without a domain correctly', () => {
     const message = `POST /me/calendars
-Content-type: application/json
-Prefer: A-timezone
+  Content-type: application/json
+  Prefer: A-timezone
 
-{ "name": "Volunteer" }`;
+  { "name": "Volunteer" }`;
 
     const parsed = parse(message);
     expect(parsed).toEqual({
@@ -36,6 +37,37 @@ Prefer: A-timezone
         { 'Prefer': 'A-timezone' }
       ],
       body: '{ "name": "Volunteer" } '
+    });
+  });
+
+  it('parses http request snippet  "Use $search and OData cast to get membership in groups with display names that contain the letters "tier" including a count of returned objects" correctly', () => {
+    const message = `GET https://graph.microsoft.com/v1.0/users/{id}/memberOf/microsoft.graph.group?$count=true&$orderby=displayName&$search="displayName:tier"&$select=displayName,id
+ConsistencyLevel: eventual`;
+
+    const parsed = parse(message);
+    expect(parsed).toEqual({
+      verb: 'GET',
+      url: 'https://graph.microsoft.com/v1.0/users/{id}/memberOf/microsoft.graph.group?$count=true&$orderby=displayName&$search="displayName:tier"&$select=displayName,id',
+      headers: [
+        { 'ConsistencyLevel': 'eventual' }
+      ],
+      body: ''
+    });
+  });
+
+  it('parses http request snippet  "cast to get groups with a display name that starts with "a" correctly', () => {
+    const message = `GET https://graph.microsoft.com/v1.0/users/{id}/memberOf/microsoft.graph.group?$count=true&$orderby=displayName&$filter=startswith(displayName, 'a')
+ConsistencyLevel: eventual`;
+
+    const parsed = parse(message);
+    expect(parsed).toEqual({
+      verb: 'GET',
+      // eslint-disable-next-line quotes
+      url: `https://graph.microsoft.com/v1.0/users/{id}/memberOf/microsoft.graph.group?$count=true&$orderby=displayName&$filter=startswith(displayName, 'a')`,
+      headers: [
+        { 'ConsistencyLevel': 'eventual' }
+      ],
+      body: ''
     });
   });
 });

--- a/src/app/views/query-runner/util/iframe-message-parser.ts
+++ b/src/app/views/query-runner/util/iframe-message-parser.ts
@@ -122,7 +122,8 @@ function extractUrl(payload: string): object[] {
   // and the URL at index 1
   const urlParts = sampleUrl.split(' ');
   const verb = urlParts[0];
-  let url = sampleUrl.replace(`${verb} `, '');
+  let url = (urlParts.length > 2) ?
+    sampleUrl.replace(`${verb} `, '') : urlParts[1];
 
   let sampleDomain = '';
   domains.forEach(domain => {

--- a/src/app/views/query-runner/util/iframe-message-parser.ts
+++ b/src/app/views/query-runner/util/iframe-message-parser.ts
@@ -118,13 +118,11 @@ function extractUrl(payload: string): object[] {
   // of the resulting array
   const sampleUrl = payload.split('\n')[1];
 
-
   // The sampleUrl has the format VERB URL, after splitting it on the space character the VERB will be at index 0
   // and the URL at index 1
   const urlParts = sampleUrl.split(' ');
   const verb = urlParts[0];
-  let url = urlParts[1];
-
+  let url = sampleUrl.replace(`${verb} `, '');
 
   let sampleDomain = '';
   domains.forEach(domain => {


### PR DESCRIPTION
## Overview

Fixes #1021 
Fixes #998 

### Demo

"Try it" code in Microsoft Docs doesn't escape the " ' " character #998
![image](https://user-images.githubusercontent.com/58787602/140268758-38e00bfe-720a-4601-95c4-56ee66d77ebf.png)

GE try-it truncating URL #1021
![image](https://user-images.githubusercontent.com/58787602/140268941-a88601bd-480e-48e6-92ff-d517903ccfee.png)

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Go TO: https://review.docs.microsoft.com/en-us/graph/api/user-list-memberof?view=graph-rest-1.0&branch=pr-en-us-14820&tabs=http
* Scroll down to Example 5
* Click on try-it
* Notice that the whole URL is copied in without truncation
