### PR TITLE
Fix: Remove hover functions on history tab

### DIFF
--- a/src/app/views/sidebar/history/History.tsx
+++ b/src/app/views/sidebar/history/History.tsx
@@ -527,12 +527,7 @@ export class History extends Component<IHistoryProps, any> {
             message={`${items.length} search results available.`}
           />
           {items.length > 0 &&
-            <div
-              onMouseEnter={() => this.setState({ isHoverOverHistoryList: true })}
-              onMouseLeave={() => this.setState({ isHoverOverHistoryList: false })}>
               <DetailsList
-                styles={this.state.isHoverOverHistoryList ?
-                  { root: { overflow: 'scroll' } } : { root: { overflow: 'hidden' } }}
                 className={classes.queryList}
                 onRenderItemColumn={this.renderItemColumn}
                 items={items}
@@ -546,7 +541,7 @@ export class History extends Component<IHistoryProps, any> {
                 onRenderRow={this.renderRow}
                 onRenderDetailsHeader={this.renderDetailsHeader}
               />
-            </div>}
+          }
         </div>
         <Dialog
           hidden={hideDialog}


### PR DESCRIPTION
## Overview

The 'Older' and 'Yesterday' group collapse when the mouse focus is moved elsewhere after a user runs a query from either of these groups.
This fix ensures the focus remains on the query selected even if the mouse focus moves elsewhere.

Fixes #1156 

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Load Graph Explorer
* Navigate to the History Tab 
* Select a query from the "Yesterday' or 'Older' group
* Move mouse focus to anywhere else on the page
* Notice the group doesn't collapse, and highlight remains on the selected query.