### PR TITLE
enable right click on history items

### DIFF
--- a/src/app/views/common/ContextMenu.tsx
+++ b/src/app/views/common/ContextMenu.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { ContextualMenu } from '@fluentui/react';
+
+const ContextMenu = (props: any) => {
+  const {
+    component: Component = 'div',
+    items,
+    menuProps,
+    onItemClick,
+    ...componentProps
+  } = props;
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const [hidden, setHidden] = useState(true);
+
+  const onContextMenu = (e: any) => {
+    e.stopPropagation();
+    e.preventDefault();
+    setPosition({ x: e.clientX, y: e.clientY });
+    setHidden(false);
+  };
+
+  const onDismiss = () => {
+    setHidden(true);
+  };
+
+  return (
+    <>
+      <Component {...componentProps}
+        onContextMenu={onContextMenu}>
+        {props.children}
+      </Component>
+      <ContextualMenu
+        {...menuProps}
+        items={items}
+        hidden={hidden}
+        target={position}
+        onItemClick={onItemClick}
+        onDismiss={onDismiss}
+      />
+    </>
+  );
+}
+
+export default ContextMenu;

--- a/src/app/views/sidebar/history/History.tsx
+++ b/src/app/views/sidebar/history/History.tsx
@@ -12,7 +12,7 @@ import { bindActionCreators, Dispatch } from 'redux';
 import { componentNames, eventTypes, telemetry } from '../../../../telemetry';
 import { SortOrder } from '../../../../types/enums';
 import { IHarPayload } from '../../../../types/har';
-import { IHistoryItem, IHistoryProps } from '../../../../types/history';
+import { IHistoryItem, IHistoryItemContext, IHistoryProps } from '../../../../types/history';
 import { IQuery } from '../../../../types/query-runner';
 import { IRootState } from '../../../../types/root';
 import * as queryActionCreators from '../../../services/actions/query-action-creators';
@@ -28,6 +28,7 @@ import { translateMessage } from '../../../utils/translate-messages';
 import { classNames } from '../../classnames';
 import { sidebarStyles } from '../Sidebar.styles';
 import { createHarPayload, exportQuery, generateHar } from './har-utils';
+import ContextMenu  from '../../../views/common/ContextMenu';
 
 export class History extends Component<IHistoryProps, any> {
   constructor(props: any) {
@@ -109,16 +110,66 @@ export class History extends Component<IHistoryProps, any> {
     return items;
   }
 
+  contextMenuItems: IHistoryItemContext[] = [
+    {
+      key: 'view',
+      itemType: ContextualMenuItemType.Normal,
+      text: translateMessage('view')
+    },
+    {
+      key: 'runQuery',
+      itemType: ContextualMenuItemType.Normal,
+      text: translateMessage('Run Query')
+    },
+    {
+      key: 'exportQuery',
+      itemType: ContextualMenuItemType.Normal,
+      text: translateMessage('Export')
+    },
+    {
+      key: 'remove',
+      itemType: ContextualMenuItemType.Normal,
+      text: translateMessage('Delete')
+    }
+  ]
+
+  private selectContextMenuItem = (event: any, item: IHistoryItemContext, historyItem: any) => {
+    switch(item.key){
+      case 'view':
+        this.onViewQueryButton(historyItem);
+        break;
+      case 'runQuery':
+        this.onRunQuery(historyItem);
+        break;
+      case 'exportQuery':
+        this.onExportQuery(historyItem);
+        break;
+      case 'remove':
+        this.deleteQuery(historyItem);
+        break;
+    }
+  }
+
   public renderRow = (props: any): any => {
     const classes = classNames(this.props);
     return (
-      <div className={classes.groupHeader}>
-        <DetailsRow
-          {...props}
-          className={classes.queryRow}
-          onClick={() => this.onViewQueryListItem(props.item)}
-        />
-      </div>
+      <ContextMenu
+        style={{
+          flexGrow: 1,
+          textAlign: 'left',
+          boxSizing: 'border-box'
+        }}
+        items={this.contextMenuItems}
+        onItemClick={(e: any, item: IHistoryItemContext) => this.selectContextMenuItem(e, item, props.item)}
+      >
+        <div className={classes.groupHeader}>
+          <DetailsRow
+            {...props}
+            className={classes.queryRow}
+            onClick={() => this.onViewQueryListItem(props.item)}
+          />
+        </div>
+      </ContextMenu>
     );
   };
 

--- a/src/types/history.ts
+++ b/src/types/history.ts
@@ -1,4 +1,4 @@
-import { ITheme } from '@fluentui/react';
+import { ContextualMenuItemType, ITheme } from '@fluentui/react';
 import { Header } from './query-runner';
 
 export interface IHistoryItem extends History {
@@ -32,4 +32,10 @@ export interface IHistoryProps {
   theme?: ITheme;
   styles?: object;
   history: History[];
+}
+
+export interface IHistoryItemContext {
+  key: string;
+  itemType: ContextualMenuItemType;
+  text: string;
 }


### PR DESCRIPTION
## Overview
Implements #1176 

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions
Right-click on any history item. 
A context menu will appear. Click on the menu options to perform an action on the history item