### PR TITLE
Task: add status message for anonymous queries

### DIFF
--- a/src/app/services/actions/query-action-creators.ts
+++ b/src/app/services/actions/query-action-creators.ts
@@ -4,6 +4,7 @@ import { ContentType } from '../../../types/enums';
 import { IHistoryItem } from '../../../types/history';
 import { IQuery } from '../../../types/query-runner';
 import { IStatus } from '../../../types/status';
+import { setStatusMessage } from '../../utils/status-message';
 import { writeHistoryData } from '../../views/sidebar/history/history-utils';
 import {
   anonymousRequest,
@@ -95,7 +96,7 @@ export function runQuery(query: IQuery): Function {
 
     if (response) {
       status.status = response.status;
-      status.statusText = response.statusText;
+      status.statusText = response.statusText === '' ? setStatusMessage(response.status) : response.statusText;
     }
 
     if (response && response.ok) {

--- a/src/app/utils/status-message.ts
+++ b/src/app/utils/status-message.ts
@@ -37,3 +37,52 @@ export function getMatchesAndParts(message: string) {
   const parts: string[] = message.split(numberPattern);
   return { matches, parts };
 }
+
+const responseStatusMap = new Map([
+  [100, 'Continue'],
+  [101, 'Switching Protocols'],
+  [102, 'Processing'],
+  [200, 'OK'],
+  [201, 'Created'],
+  [202, 'Accepted'],
+  [203, 'Non Authoritative'],
+  [204, 'No Content'],
+  [205, 'Reset Content'],
+  [206, 'Partial Content'],
+  [300, 'Multiple Choices'],
+  [301, 'Moved Permanently'],
+  [302, 'Found'],
+  [303, 'See Other'],
+  [304, 'Not Modified'],
+  [305, 'Use Proxy'],
+  [307, 'Temporary Redirect'],
+  [400, 'Bad Request'],
+  [401, 'Unauthorized'],
+  [403, 'Forbidden'],
+  [404, 'Not Found'],
+  [405, 'Method Not Allowed'],
+  [406, 'Not Acceptable'],
+  [407, 'Proxy Authentication Required'],
+  [408, 'Request Timeout'],
+  [409, 'Conflict'],
+  [410, 'Gone'],
+  [411, 'Length Required'],
+  [412, 'Precondition Failed'],
+  [413, 'Request Entity Too Large'],
+  [414, 'Request-URI Too Long'],
+  [415, 'Unsupported Media Type'],
+  [416, 'Requested Range Not Satisfiable'],
+  [417, 'Expectation Failed'],
+  [422, 'Unprocessable Entity'],
+  [500, 'Internal Server Error'],
+  [501, 'Not Implemented'],
+  [502, 'Bad Gateway'],
+  [503, 'Service Unavailable'],
+  [504, 'Gateway Timeout'],
+  [505, 'HTTP Version Not Supported']
+]);
+
+export function setStatusMessage(status: number): string {
+  const statusMessage = responseStatusMap.get(status);
+  return statusMessage ? statusMessage : '';
+}

--- a/src/app/utils/status-message.ts
+++ b/src/app/utils/status-message.ts
@@ -38,7 +38,7 @@ export function getMatchesAndParts(message: string) {
   return { matches, parts };
 }
 
-const responseStatusTextMap = new Map([
+const httpStatusMessage = new Map([
   [100, 'Continue'],
   [101, 'Switching Protocols'],
   [102, 'Processing'],
@@ -83,6 +83,6 @@ const responseStatusTextMap = new Map([
 ]);
 
 export function setStatusMessage(status: number): string {
-  const statusMessage = responseStatusTextMap.get(status);
+  const statusMessage = httpStatusMessage.get(status);
   return statusMessage ? statusMessage : '';
 }

--- a/src/app/utils/status-message.ts
+++ b/src/app/utils/status-message.ts
@@ -38,7 +38,7 @@ export function getMatchesAndParts(message: string) {
   return { matches, parts };
 }
 
-const responseStatusMap = new Map([
+const responseStatusTextMap = new Map([
   [100, 'Continue'],
   [101, 'Switching Protocols'],
   [102, 'Processing'],
@@ -83,6 +83,6 @@ const responseStatusMap = new Map([
 ]);
 
 export function setStatusMessage(status: number): string {
-  const statusMessage = responseStatusMap.get(status);
+  const statusMessage = responseStatusTextMap.get(status);
   return statusMessage ? statusMessage : '';
 }

--- a/src/tests/utils/url-to-html.spec.ts
+++ b/src/tests/utils/url-to-html.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-import { extractUrl, replaceLinks, convertArrayToObject, getMatchesAndParts } from '../../app/utils/status-message';
+import { extractUrl, replaceLinks, convertArrayToObject, getMatchesAndParts, setStatusMessage } from '../../app/utils/status-message';
 
 describe('status message should', () => {
 
@@ -40,4 +40,10 @@ describe('status message should', () => {
     const { matches } = getMatchesAndParts(replaceLinks(message));
     expect(matches?.includes('$0')).toBe(true);
   });
+
+  it('should return a status message given a status code', () => {
+    const statusCode: number = 200;
+    const statusMessage = setStatusMessage(statusCode);
+    expect(statusMessage).toBe('OK');
+  })
 })


### PR DESCRIPTION
## Overview
Solves #1078 

### Demo
On production, the status message is missing
![image](https://user-images.githubusercontent.com/45680252/144180774-320fbc07-42b5-4420-8f12-444d5c1abaab.png)

This PR adds the status message to the response if it's unavailable
![image](https://user-images.githubusercontent.com/45680252/144180731-0481bbcd-1643-43ad-9f59-a106004af6aa.png)

## Testing Instructions
Start Graph Explorer
Click on any sample queries when you are **not signed in.** You should see the status messages for all GET sample queries