### PR TITLE
fix: restores ability to stretch request section

### DIFF
--- a/src/app/views/query-runner/request/Request.tsx
+++ b/src/app/views/query-runner/request/Request.tsx
@@ -180,7 +180,7 @@ export class Request extends Component<IRequestComponent, any> {
     const requestPivotItems = this.getPivotItems(dimensions.request.height);
     const { selectedPivot } = this.state;
     const pivot = selectedPivot.replace('.$', '');
-    const minHeight = 260;
+    const minHeight = 60;
     const maxHeight = 800;
     return (
       <>


### PR DESCRIPTION
## Overview
Solves #1272 

### Demo
![image](https://user-images.githubusercontent.com/45680252/144556284-2c9bc6f3-bfa4-42ac-ad98-7306c4015efd.png)

## Testing Instructions
Resize the request section to the top. It stretches to the top