### PR TITLE
Fix: return blue dots on supported tabs

### DIFF
--- a/src/app/views/query-response/pivot-items/pivot-items.tsx
+++ b/src/app/views/query-response/pivot-items/pivot-items.tsx
@@ -53,8 +53,8 @@ export const getPivotItems = () => {
         <Icon iconName={link.itemIcon} style={{ paddingRight: 5 }} />
         {link.headerText}
 
-        {link.ariaLabel === 'Adaptive Cards' && showDotIfAdaptiveCardPresent()}
-        {link.ariaLabel === 'Graph Toolkit' && showDotIfGraphToolkitPresent()}
+        {link.itemKey === 'adaptive-cards' && showDotIfAdaptiveCardPresent()}
+        {link.itemKey === 'toolkit-component' && showDotIfGraphToolkitPresent()}
       </TooltipHost>
     );
   }


### PR DESCRIPTION
## Overview

Returns the blue dot when supported queries are ran

### Demo

![image](https://user-images.githubusercontent.com/58787602/145363558-dac8b201-5f00-474b-b136-1115544a5412.png)
