### PR TITLE
add status message to history item

### DIFF
--- a/src/app/services/actions/query-action-creators.ts
+++ b/src/app/services/actions/query-action-creators.ts
@@ -159,7 +159,7 @@ async function createHistory(
   duration: number
 ) {
   const status = response.status;
-  const statusText = response.statusText;
+  const statusText = response.statusText === '' ? setStatusMessage(status) : response.statusText;
   const responseHeaders = { ...respHeaders };
   const contentType = respHeaders['content-type'];
 


### PR DESCRIPTION
## Overview
Solves #1363 

### Demo
![image](https://user-images.githubusercontent.com/45680252/150747154-0a89b2cd-c7fb-4088-bcff-1156ef8753ba.png)


### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions
Click on any sample query
Go to history tab
Click on the query in the history tab
Notice that the status message is displayed on the status bar