### PR TITLE
Fix: Query input 'i' icon focus

### DIFF
--- a/src/app/views/query-runner/query-input/auto-complete/suffix/SuffixRenderer.tsx
+++ b/src/app/views/query-runner/query-input/auto-complete/suffix/SuffixRenderer.tsx
@@ -1,5 +1,5 @@
 import {
-  Callout, getId, Icon, ITooltipHostStyles,
+  Callout, getId, IconButton, IIconProps, ITooltipHostStyles,
   Spinner, Text, TooltipHost
 } from '@fluentui/react';
 import React, { useState } from 'react';
@@ -84,15 +84,17 @@ const SuffixRenderer = () => {
   }
   const hints = getHints();
   const hintsAvailable = hints.length > 0;
+  const infoIcon: IIconProps = {iconName: 'Info'};
 
   if (hintsAvailable) {
     return (
       <>
-        <Icon
-          iconName='Info'
+        <IconButton
+          iconProps={infoIcon}
           className={styles.iconButton}
           onClick={toggleCallout}
           id={buttonId}
+          ariaLabel={translateMessage('More Info')}
         />
         {isCalloutVisible && (
           <Callout

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -429,5 +429,6 @@
   "Copied": "Copied",
   "Invalid whitespace in URL": "Invalid whitespace in URL",
   "Response content not available due to CORS policy": "The response content is not available in Graph Explorer due to CORS policy. You can execute this request in an API client, like Postman. Read more about CORS and understand how it works",
-  "here": "here"
+  "here": "here",
+  "More info": "More info"
 }


### PR DESCRIPTION
## Overview
Fixes #1372 
Adds focus on the 'i' icon on the query input textfield

### Demo
![image](https://user-images.githubusercontent.com/18407044/150953115-02b0a29e-c15b-4506-8120-5f65e0c44d76.png)

## Testing Instructions

* Open Graph Explorer
*  Using tab key navigate to the 'i' button present beside query edit field.
* Observe if keyboard focus is going on it.
