### PR TITLE
Fix: Add aria-label for items in the sample queries tab

### DIFF
--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -238,7 +238,7 @@ export class SampleQueries extends Component<ISampleQueriesProps, any> {
               (selectionDisabled ? classes.rowDisabled : '')
             }
             data-selection-disabled={selectionDisabled}
-            getRowAriaLabel={() => props.item.method + props.item.humanName}
+            getRowAriaLabel={() => props.item.method.toLowerCase() + props.item.humanName}
           />
         </div>
       );

--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -238,6 +238,7 @@ export class SampleQueries extends Component<ISampleQueriesProps, any> {
               (selectionDisabled ? classes.rowDisabled : '')
             }
             data-selection-disabled={selectionDisabled}
+            getRowAriaLabel={() => props.item.method + props.item.humanName}
           />
         </div>
       );


### PR DESCRIPTION
## Overview

Fixes #1369 
Adding an aria-label enables screen readers to read the different query samples.


## Testing Instructions

* Open GE
* Turn On Narrator using 'Ctrl+Win+Enter'.
* Navigate to the 'Get myprofile' button using down arrow key in scan mode (To turn on/off:  capslock + space)
