### PR TITLE
Fix: Enable focus to remain on copy button when clicked

### DIFF
--- a/src/app/views/common/copy/CopyButton.tsx
+++ b/src/app/views/common/copy/CopyButton.tsx
@@ -1,4 +1,4 @@
-import { IconButton, IIconProps, PrimaryButton } from '@fluentui/react';
+import { IButton, IconButton, IIconProps, PrimaryButton } from '@fluentui/react';
 import React, { useState } from 'react';
 import { translateMessage } from '../../../utils/translate-messages';
 
@@ -18,10 +18,14 @@ export function CopyButton(props:ICopyButtonProps) {
 
   const copyLabel: string = !copied ? translateMessage('Copy') : translateMessage('Copied');
 
+  const copyRef = React.createRef<IButton>();
+  const onSetFocus = () => copyRef.current!.focus();
+
   const handleCopyClick = async () => {
     props.handleOnClick(props);
     setCopied(true);
     handleTimeout();
+    onSetFocus();
   };
 
   const handleTimeout = () => {
@@ -40,9 +44,10 @@ export function CopyButton(props:ICopyButtonProps) {
           ariaLabel={copyLabel}
           style={props.style}
           className={props.className}
+          componentRef={copyRef}
         />
         :
-        <PrimaryButton onClick={handleCopyClick} text={copyLabel}/>
+        <PrimaryButton onClick={handleCopyClick} text={copyLabel} componentRef={copyRef}/>
       }
     </>
   )

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -51,7 +51,7 @@ const QueryResponse = (props: IQueryResponseProps) => {
   };
 
   const handleCopy = () => {
-    copy('share-query-text').then(() => toggleShareQueryDialogState());
+    copy('share-query-text');
     trackCopyEvent();
   };
 
@@ -190,7 +190,6 @@ const QueryResponse = (props: IQueryResponseProps) => {
             width: '100%',
             height: 63,
             overflowY: 'scroll',
-            border: 'none',
             resize: 'none',
             color: 'black'
           }}


### PR DESCRIPTION
## Overview

Fixes #1370 

- This fix enables focus to remain on the copy button once selected (i.e for all copy buttons: Access token, code snippets, Adaptive Cards-Json Schema, and Share dialog)
- also fixes an issue where clicking on copy in the "share" dialog would also close the dialog 
- It also add's a border on the textarea in the share dialog, which previously looked bare in light mode.


## Testing Instructions

1. Open URL in Edge browser.
2. Login with valid credential.
3. Navigate to the 'Action token' button using tab key and activate it using enter key.
4. Now, navigate to the 'Copy access token' icon button using tab key and activate it.
6. Observe if focus remains on the button