### PR TITLE
Fix: Selectively add headers to fetch call

### DIFF
--- a/src/app/services/actions/query-action-creator-util.ts
+++ b/src/app/services/actions/query-action-creator-util.ts
@@ -48,6 +48,8 @@ export function createAnonymousRequest(query: IQuery, proxyUrl: string) {
 
   const authToken = '{token:https://graph.microsoft.com/}';
   const headers = {
+    'cache-control': 'no-cache',
+    pragma: 'no-cache',
     Authorization: `Bearer ${authToken}`,
     'Content-Type': 'application/json',
     SdkVersion: 'GraphExplorer/4.0',

--- a/src/app/services/actions/query-action-creator-util.ts
+++ b/src/app/services/actions/query-action-creator-util.ts
@@ -11,6 +11,7 @@ import { IAction } from '../../../types/action';
 import { ContentType } from '../../../types/enums';
 import { IQuery } from '../../../types/query-runner';
 import { IRequestOptions } from '../../../types/request';
+import { IStatus } from '../../../types/status';
 import { encodeHashCharacters } from '../../utils/query-url-sanitization';
 import { authProvider, GraphClient } from '../graph-client';
 import { DEFAULT_USER_SCOPES } from '../graph-constants';
@@ -29,13 +30,13 @@ export async function anonymousRequest(
   query: IQuery,
   getState: Function
 ) {
+  const { proxyUrl, queryRunnerStatus } = getState();
+  const { graphUrl, options } = createAnonymousRequest(query, proxyUrl, queryRunnerStatus);
   dispatch(queryRunningStatus(true));
-  const { proxyUrl } = getState();
-  const { graphUrl, options } = createAnonymousRequest(query, proxyUrl);
   return fetch(graphUrl, options);
 }
 
-export function createAnonymousRequest(query: IQuery, proxyUrl: string) {
+export function createAnonymousRequest(query: IQuery, proxyUrl: string, queryRunnerStatus: IStatus) {
   const escapedUrl = encodeURIComponent(query.sampleUrl);
   const graphUrl = `${proxyUrl}?url=${escapedUrl}`;
   const sampleHeaders: any = {};
@@ -47,14 +48,17 @@ export function createAnonymousRequest(query: IQuery, proxyUrl: string) {
   }
 
   const authToken = '{token:https://graph.microsoft.com/}';
-  const headers = {
-    'cache-control': 'no-cache',
-    pragma: 'no-cache',
+  let headers = {
     Authorization: `Bearer ${authToken}`,
     'Content-Type': 'application/json',
     SdkVersion: 'GraphExplorer/4.0',
     ...sampleHeaders
   };
+
+  if (queryRunnerStatus && !queryRunnerStatus.ok) {
+    const updatedHeaders = { ...headers, 'cache-control': 'no-cache', pragma: 'no-cache' }
+    headers = updatedHeaders;
+  }
 
   const options: IRequestOptions = {
     method: query.selectedVerb,


### PR DESCRIPTION
## Overview
When running advanced queries in an anonymous experience, all GET responses are cached temporarily. This means that if the returned response is an error response, any subsequent API calls will hit the cache and not the API sandbox.
Unless the url is changed, any API call with the same url will hit the cache until the cache expires.

This fix forces a call to the API Sandbox in a subsequent request only if the previous request returned an error response
Solves #1063 

### Demo
![image](https://user-images.githubusercontent.com/45680252/151801526-b827ffce-fc4b-47e6-bc87-62308dc43533.png)
Running an advanced query without the ConsistencyLevel header

![image](https://user-images.githubusercontent.com/45680252/151801652-6487779e-8470-4fde-8da8-2089414a95fd.png)
Response returned after adding the correct header and making the same API call

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions
Run this query: https://developer.microsoft.com/en-us/graph/graph-explorer?request=users%2F%24count&method=GET&version=v1.0&GraphUrl=https://graph.microsoft.com
It doesn't have the correct request header

Notice the error response

Now add the header: ConsistencyLevel = eventual

Run the query

Notice the successful response.