### PR TITLE
Fix: Parse whitespace in query parameters

### DIFF
--- a/src/app/utils/sample-url-generation.spec.ts
+++ b/src/app/utils/sample-url-generation.spec.ts
@@ -34,13 +34,15 @@ describe('Sample Url Generation', () => {
   it('destructures sample url with % sign', () => {
     const name = 'DiegoS%40m365x214355.onmicrosoft.com';
     const search = `?$select=displayName,mail&$filter=mail eq '${name}'`;
+    const parsedSearch = `?$select=displayName,mail&$filter=mail+eq+'${name}'`;
+
     const url = `https://graph.microsoft.com/v1.0/users${search}`;
 
     const expectedUrl = {
       requestUrl: 'users',
       queryVersion: 'v1.0',
-      sampleUrl: url,
-      search
+      sampleUrl: `https://graph.microsoft.com/v1.0/users${parsedSearch}`,
+      search: parsedSearch
     };
 
     const parsedUrl = parseSampleUrl(url);
@@ -69,6 +71,23 @@ describe('Sample Url Generation', () => {
       queryVersion: '',
       sampleUrl: '',
       search: ''
+    };
+
+    const parsedUrl = parseSampleUrl(url);
+    expect(parsedUrl).toEqual(expectedUrl);
+  });
+
+  it('replaces whitespace with + sign', () => {
+    const search = '?filter=displayName eq \'All Company\'';
+    const parsedSearch= '?filter=displayName+eq+\'All+Company\'';
+
+    const url = `https://graph.microsoft.com/v1.0/groups${search}`;
+
+    const expectedUrl = {
+      requestUrl: 'groups',
+      queryVersion: 'v1.0',
+      sampleUrl:`https://graph.microsoft.com/v1.0/groups${parsedSearch}` ,
+      search: parsedSearch
     };
 
     const parsedUrl = parseSampleUrl(url);

--- a/src/app/utils/sample-url-generation.ts
+++ b/src/app/utils/sample-url-generation.ts
@@ -63,7 +63,7 @@ function generateSearchParameters(url: string, search: string) {
       }
     }
   }
-  return search;
+  return search.replace(/\s/g, '+');
 }
 
 function generateSampleUrl(
@@ -85,5 +85,5 @@ export function hasWhiteSpace(url: string): boolean {
   const parts = url.split('?');
   return parts.length > 1 ? whitespaceChars.some((char) => parts[0].trimStart().includes(char)) :
     whitespaceChars.some((char) => parts[0].trim().includes(char));
-
 }
+


### PR DESCRIPTION
## Overview
Replaces whitespace in query parameters with a '+' sign to enable a successful code snippets fetch.
Fix #1544 

### Demo
**Before fix**: 
![image](https://user-images.githubusercontent.com/18407044/158172028-4d701a94-0d0a-47b4-819d-16d9c6a294e3.png)

**After fix**: 
![image](https://user-images.githubusercontent.com/18407044/158172409-8edbfaea-784d-490d-949b-160d7b19fdba.png)


## Testing Instructions

* Load GE
* Paste `https://graph.microsoft.com/v1.0/groups/?$filter=displayName eq 'All Company'` and Run query
* Select 'Code Snippets' tab and view results.
