### PR TITLE
Fixes failing snippet calls

### DIFF
--- a/src/app/services/actions/snippet-action-creator.ts
+++ b/src/app/services/actions/snippet-action-creator.ts
@@ -61,8 +61,8 @@ export function getSnippet(language: string): Function {
           ? JSON.stringify(sampleQuery.sampleBody)
           : '';
 
-      const body = `${sampleQuery.selectedVerb} /${queryVersion}/${requestUrl + search}
-      HTTP/1.1\r\nHost: graph.microsoft.com\r\nContent-Type: application/json\r\n\r\n${requestBody}`;
+      const body = `${sampleQuery.selectedVerb} /${queryVersion}/${requestUrl +
+        search} HTTP/1.1\r\nHost: graph.microsoft.com\r\nContent-Type: application/json\r\n\r\n${requestBody}`;
       const options: IRequestOptions = { method, headers, body };
       const obj: any = {};
 

--- a/src/app/views/app-sections/FeedbackButton.tsx
+++ b/src/app/views/app-sections/FeedbackButton.tsx
@@ -58,8 +58,8 @@ export const FeedbackButton = () => {
           />
         </TooltipHost>
 
-        <FeedbackForm onDismissSurvey={toggleSurvey}
-          activated={enableSurvey} onDisableSurvey={disableSurvey} />
+        {enableSurvey && <FeedbackForm onDismissSurvey={toggleSurvey}
+          activated={enableSurvey} onDisableSurvey={disableSurvey} />}
       </div>
       }
     </div>


### PR DESCRIPTION
## Overview
Fixes failing code snippet calls

### Demo
![image](https://user-images.githubusercontent.com/45680252/158367683-40d9c4ae-d87c-4839-9ec7-e225ac3597e6.png)

### Notes
![image](https://user-images.githubusercontent.com/45680252/158367790-a73f9880-3f06-4248-bdca-bf32d39d6361.png)
The request body is incorrect. The http version information is on a new line.
It should be on the same line with the method and request url like so:
![image](https://user-images.githubusercontent.com/45680252/158367982-0aae9c62-f931-4171-86e0-ef5273d0c797.png)


## Testing Instructions
Ensure there's a query on the query input
Open code snippets tab
Click on any code snippet
Notice that snippet is fetched successfully