### PR TITLE
Adjust position of chevron icon on history items' headers

### DIFF
--- a/src/app/views/sidebar/history/History.tsx
+++ b/src/app/views/sidebar/history/History.tsx
@@ -216,7 +216,7 @@ export class History extends Component<IHistoryProps, any> {
                   shouldFocusOnMount: true,
                   items: buttonActions
                 }}
-                styles={{root: {paddingBottom: 10, marginLeft: -1.2}}}
+                styles={{root: {paddingBottom: 10, marginLeft: 1}}}
               />
             </TooltipHost>
           );
@@ -281,6 +281,7 @@ export class History extends Component<IHistoryProps, any> {
                 }}
                 ariaLabel={collapseButtonLabel}
                 onClick={() => this.onToggleCollapse(props)}
+                styles={{icon: {marginTop: '15px'}}}
               />
             </TooltipHost>
             <div className={classes.groupTitle}>


### PR DESCRIPTION
## Overview
Solves  #1561 

### Demo
![image](https://user-images.githubusercontent.com/45680252/158543730-9cca7cc0-949c-41d2-a3a4-97a6f1e13495.png)

![image](https://user-images.githubusercontent.com/45680252/158543762-d8f0a89c-f48e-45b0-a3b4-44f56fb459c8.png)


## Testing Instructions
Open Graph Explorer
Click on history tab
Notice the chevron icon is correctly positioned