### PR TITLE
Fix: Update Tip message format

### DIFF
--- a/src/app/views/app-sections/StatusMessages.tsx
+++ b/src/app/views/app-sections/StatusMessages.tsx
@@ -53,20 +53,19 @@ const StatusMessages = () => {
   if (queryRunnerStatus) {
     const { messageType, statusText, status, duration, hint } = queryRunnerStatus;
     let urls: any = {};
-    let message = statusText;
-    const extractedUrls = extractUrl(statusText);
+    let message = status.toString();
+    const extractedUrls = extractUrl(status.toString());
     if (extractedUrls) {
-      message = replaceLinks(statusText);
+      message = replaceLinks(status.toString());
       urls = convertArrayToObject(extractedUrls);
     }
-
 
     return <MessageBar messageBarType={messageType}
       isMultiline={true}
       onDismiss={() => dispatch(clearQueryStatus())}
       dismissButtonAriaLabel='Close'
       aria-live={'assertive'}>
-      {`${status} - `}{displayStatusMessage(message, urls)}
+      {`${statusText} - `}{displayStatusMessage(message, urls)}
 
       {duration && <>
         {` - ${duration}`}<FormattedMessage id='milliseconds' />

--- a/src/types/status.ts
+++ b/src/types/status.ts
@@ -3,7 +3,7 @@ import { MessageBarType } from '@fluentui/react';
 export interface IStatus {
   messageType: MessageBarType;
   ok: boolean;
-  status: number;
+  status: number | string;
   statusText: string;
   duration?: number;
   hint?: string;


### PR DESCRIPTION
## Overview

Fixes how the Tip message is displayed on running sample queries
fixes #1570 

### Demo

Currently the Tip messages displays the 'tip' word at the end and the links aren't highlighted
![image](https://user-images.githubusercontent.com/18407044/158780883-5718488b-4060-47cf-b96f-c818dfdef448.png)

After fix, the tip message format is restored
![image](https://user-images.githubusercontent.com/18407044/158780547-60abf377-79dd-44d8-ab62-31cf43c9bddb.png)

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Load GE
* Sign in
* In the _**Sample Queries**_ tab, expand the **_Applications_** group and select any GET query
* Observe Tip message