### PR TITLE
Fix: Validate permissions before any operations

### DIFF
--- a/src/app/views/query-runner/request/permissions/PanelList.tsx
+++ b/src/app/views/query-runner/request/permissions/PanelList.tsx
@@ -34,13 +34,13 @@ const PanelList = ({ messages,
   columns, classes, selection,
   renderItemColumn, renderDetailsHeader, renderCustomCheckbox }: IPanelList) => {
 
-  const sortedPermissions = (permissionsToSort: IPermission[]) : IPermission[] => {
-    return permissionsToSort.sort(dynamicSort('value', SortOrder.ASC));
+  const sortPermissions = (permissionsToSort: IPermission[]) : IPermission[] => {
+    return permissionsToSort ? permissionsToSort.sort(dynamicSort('value', SortOrder.ASC)) : [];
   }
 
   const { consentedScopes, scopes, authToken } = useSelector((state: IRootState) => state);
   const { fullPermissions } = scopes.data;
-  const [permissions, setPermissions] = useState(sortedPermissions(fullPermissions));
+  const [permissions, setPermissions] = useState(sortPermissions(fullPermissions));
   const permissionsList: any[] = [];
   const tokenPresent = !!authToken.token;
 

--- a/src/app/views/query-runner/request/permissions/TabList.tsx
+++ b/src/app/views/query-runner/request/permissions/TabList.tsx
@@ -19,7 +19,7 @@ interface ITabList {
 const TabList = ({ columns, classes, renderItemColumn, renderDetailsHeader, maxHeight }: ITabList) => {
   const dispatch = useDispatch();
   const { consentedScopes, scopes, authToken } = useSelector((state: IRootState) => state);
-  const permissions: IPermission[] =  scopes.data.specificPermissions;
+  const permissions: IPermission[] =  scopes.data.specificPermissions ? scopes.data.specificPermissions : [];
   const tokenPresent = !!authToken.token;
   const [isHoverOverPermissionsList, setIsHoverOverPermissionsList] = useState(false);
 
@@ -71,7 +71,7 @@ const TabList = ({ columns, classes, renderItemColumn, renderDetailsHeader, maxH
           layoutMode={DetailsListLayoutMode.justified}
           onRenderDetailsHeader={(props?: any, defaultRender?: any) => renderDetailsHeader(props, defaultRender)} />
       </div>
-      {permissions && permissions.length === 0 &&
+      {permissions.length === 0 &&
         displayNoPermissionsFoundMessage()
       }
     </>


### PR DESCRIPTION
## Overview
Fixes #1577 

### Demo
![image](https://user-images.githubusercontent.com/45680252/160337260-1ec7c69b-5b32-4ca8-9437-3689f301d72c.png)
Modify permissions and permissions panel work as expected


## Testing Instructions
Sign in to Graph Explorer
Click on Modify Permissions tab
Notice that permissions are displayed as they should be