### PR TITLE
Fix: Makes app height responsive on all browsers

### DIFF
--- a/src/app/services/reducers/dimensions-reducers.ts
+++ b/src/app/services/reducers/dimensions-reducers.ts
@@ -13,11 +13,11 @@ const initialState: IDimensions = {
   },
   sidebar: {
     width: '26%',
-    height: ''
+    height: '100%'
   },
   content: {
     width: '74%',
-    height: ''
+    height: '100%'
   }
 };
 

--- a/src/app/views/App.styles.ts
+++ b/src/app/views/App.styles.ts
@@ -11,7 +11,8 @@ export const appStyles = (theme: ITheme) => {
       paddingRight: '15px',
       paddingLeft: '4px',
       marginLeft: 'auto',
-      marginRight: 'auto'
+      marginRight: 'auto',
+      borderBottom: '1px solid black'
     },
     appRow: {
       display: 'flex',
@@ -67,7 +68,7 @@ export const appStyles = (theme: ITheme) => {
     statusAreaMobileScreen: {
       marginTop: 5
     },
-    statusAreaLaptopScreen: {
+    statusAreaFullScreen: {
       marginTop: 0
     },
     vResizeHandle: {

--- a/src/app/views/App.styles.ts
+++ b/src/app/views/App.styles.ts
@@ -86,6 +86,17 @@ export const appStyles = (theme: ITheme) => {
       position: 'absolute',
       top: '13px',
       right: '10px'
+    },
+    mainContent: {
+      overflow: 'hidden',
+      display: 'flex',
+      flexDirection: 'column' as 'column'
+    },
+    queryResponse: {
+      display: 'flex',
+      flexDirection: 'column' as 'column',
+      height: '100%',
+      overflow: 'hidden'
     }
   };
 };

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -480,7 +480,8 @@ class App extends Component<IAppProps, IAppState> {
                   width: graphExplorerMode === Mode.TryIt ? '100%' : contentWidth,
                   height: contentHeight
                 }}
-                style={!sidebarProperties.showSidebar && !mobileScreen ? {marginLeft: '8px'} : this.contentStyle }
+                style={!sidebarProperties.showSidebar && !mobileScreen ? {marginLeft: '8px', overflow: 'hidden'}
+                  : this.contentStyle }
               >
                 <div style={{ marginBottom: 8 }} >
                   <QueryRunner onSelectVerb={this.handleSelectVerb} />

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -71,7 +71,7 @@ class App extends Component<IAppProps, IAppState> {
   private mediaQueryList = window.matchMedia('(max-width: 992px)');
   private currentTheme: ITheme = getTheme();
   private statusAreaMobileStyle = appStyles(this.currentTheme).statusAreaMobileScreen;
-  private statusAreaLaptopStyle = appStyles(this.currentTheme).statusAreaLaptopScreen;
+  private statusAreaFullScreenStyle = appStyles(this.currentTheme).statusAreaFullScreen;
 
   constructor(props: IAppProps) {
     super(props);
@@ -418,7 +418,8 @@ class App extends Component<IAppProps, IAppState> {
           />
           <div className={ `ms-Grid-row ${classes.appRow}`} style={{
             flexWrap: mobileScreen && 'wrap',
-            marginRight: showSidebar && '-20px' }}>
+            marginRight: showSidebar && '-20px',
+            height: !mobileScreen ? '100vh' : '100%' }}>
 
             {graphExplorerMode === Mode.Complete && (
               <Resizable
@@ -468,7 +469,7 @@ class App extends Component<IAppProps, IAppState> {
 
             {displayContent && (
               <Resizable
-                bounds={'window'}
+                bounds={'parent'}
                 className={`ms-Grid-col ms-sm12 ms-md4 ms-lg4 ${layout}`}
                 enable={{
                   right: false
@@ -477,20 +478,26 @@ class App extends Component<IAppProps, IAppState> {
                   width: graphExplorerMode === Mode.TryIt ? '100%' : contentWidth,
                   height: contentHeight
                 }}
-                style={!sidebarProperties.showSidebar && !mobileScreen ? {marginLeft: '8px'} : {}}
+                style={!sidebarProperties.showSidebar && !mobileScreen ? {marginLeft: '8px'} : {
+                  overflow: 'hidden',
+                  display: 'flex',
+                  flexDirection: 'column'
+                }}
               >
-                <div style={{ marginBottom: 8 }}>
+                <div style={{ marginBottom: 8 }} >
                   <QueryRunner onSelectVerb={this.handleSelectVerb} />
-                  <div style={mobileScreen ? this.statusAreaMobileStyle : this.statusAreaLaptopStyle}>
+                  <div style={mobileScreen ? this.statusAreaMobileStyle : this.statusAreaFullScreenStyle}>
                     <TermsOfUseMessage />
                   </div>
                 </div>
 
-                <div>
-                  <div style={mobileScreen ? this.statusAreaMobileStyle : this.statusAreaLaptopStyle}>
+                <div style={{display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden'}}>
+                  <div style={mobileScreen ? this.statusAreaMobileStyle : this.statusAreaFullScreenStyle}>
                     <StatusMessages />
                   </div>
-                  <QueryResponse verb={this.state.selectedVerb} />
+                  <div style={{flexGrow:'1', flexShrink: '1', display:'flex'}}>
+                    <QueryResponse verb={this.state.selectedVerb} />
+                  </div>
                 </div>
               </Resizable>
             )}

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -419,7 +419,7 @@ class App extends Component<IAppProps, IAppState> {
           <div className={ `ms-Grid-row ${classes.appRow}`} style={{
             flexWrap: mobileScreen && 'wrap',
             marginRight: showSidebar && '-20px',
-            height: !mobileScreen ? '100vh' : '100%' }}>
+            height: mobileScreen ? '100%' : '100vh' }}>
 
             {graphExplorerMode === Mode.Complete && (
               <Resizable

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -72,6 +72,8 @@ class App extends Component<IAppProps, IAppState> {
   private currentTheme: ITheme = getTheme();
   private statusAreaMobileStyle = appStyles(this.currentTheme).statusAreaMobileScreen;
   private statusAreaFullScreenStyle = appStyles(this.currentTheme).statusAreaFullScreen;
+  private contentStyle = appStyles(this.currentTheme).mainContent;
+  private queryResponseStyle = appStyles(this.currentTheme).queryResponse;
 
   constructor(props: IAppProps) {
     super(props);
@@ -478,11 +480,7 @@ class App extends Component<IAppProps, IAppState> {
                   width: graphExplorerMode === Mode.TryIt ? '100%' : contentWidth,
                   height: contentHeight
                 }}
-                style={!sidebarProperties.showSidebar && !mobileScreen ? {marginLeft: '8px'} : {
-                  overflow: 'hidden',
-                  display: 'flex',
-                  flexDirection: 'column'
-                }}
+                style={!sidebarProperties.showSidebar && !mobileScreen ? {marginLeft: '8px'} : this.contentStyle }
               >
                 <div style={{ marginBottom: 8 }} >
                   <QueryRunner onSelectVerb={this.handleSelectVerb} />
@@ -491,11 +489,11 @@ class App extends Component<IAppProps, IAppState> {
                   </div>
                 </div>
 
-                <div style={{display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden'}}>
+                <div style={this.queryResponseStyle}>
                   <div style={mobileScreen ? this.statusAreaMobileStyle : this.statusAreaFullScreenStyle}>
                     <StatusMessages />
                   </div>
-                  <div style={{flexGrow:'1', flexShrink: '1', display:'flex'}}>
+                  <div style={{ display:'flex', flexGrow:'1', flexShrink: '1'}}>
                     <QueryResponse verb={this.state.selectedVerb} />
                   </div>
                 </div>

--- a/src/app/views/common/monaco/monaco.scss
+++ b/src/app/views/common/monaco/monaco.scss
@@ -5,6 +5,7 @@
   margin-top: 5px;
   padding-bottom: $gutter;
   width: inherit !important;
+  overflow: hidden;
 
   .react-monaco-editor-container {
     width: inherit !important;

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -4,7 +4,7 @@ import {
   Modal, Pivot, PivotItem, TooltipHost
 } from '@fluentui/react';
 import { Resizable } from 're-resizable';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { injectIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 import { componentNames, eventTypes, telemetry } from '../../../telemetry';
@@ -16,7 +16,6 @@ import { sanitizeQueryUrl } from '../../utils/query-url-sanitization';
 import { expandResponseArea } from '../../services/actions/response-expanded-action-creator';
 import { translateMessage } from '../../utils/translate-messages';
 import { copy } from '../common/copy';
-import { convertVhToPx } from '../common/dimensions/dimensions-adjustment';
 import { getPivotItems, onPivotItemClick } from './pivot-items/pivot-items';
 import './query-response.scss';
 import { IRootState } from '../../../types/root';
@@ -29,16 +28,11 @@ const QueryResponse = (props: IQueryResponseProps) => {
   const [showShareQueryDialog, setShareQuaryDialogStatus] = useState(true);
   const [showModal, setShowModal] = useState(false);
   const [query] = useState('');
-  const [responseHeight, setResponseHeight] = useState('610px');
-  const { dimensions, sampleQuery } = useSelector((state: IRootState) => state);
+  const { sampleQuery } = useSelector((state: IRootState) => state);
 
   const {
     intl: { messages }
   }: any = props;
-
-  useEffect(() => {
-    setResponseHeight(convertVhToPx(dimensions.response.height, 50));
-  }, [dimensions]);
 
   const toggleShareQueryDialogState = () => {
     setShareQuaryDialogStatus(!showShareQueryDialog);
@@ -96,13 +90,13 @@ const QueryResponse = (props: IQueryResponseProps) => {
       <Resizable
         style={{
           marginBottom: 10,
-          marginTop: 10
+          marginTop: 10,
+          flexGrow: 1,
+          flexShrink:1
         }}
-        maxHeight={800}
-        minHeight={350}
-        bounds={'window'}
+        bounds={'parent'}
         size={{
-          height: responseHeight,
+          height: '100%',
           width: '100%'
         }}
         enable={{
@@ -111,7 +105,7 @@ const QueryResponse = (props: IQueryResponseProps) => {
       >
         <div className='query-response' style={{
           minHeight: 350,
-          height: responseHeight
+          height: '100%'
         }}>
 
           <Pivot overflowBehavior="menu" onLinkClick={handlePivotItemClick}

--- a/src/app/views/query-runner/request/Request.tsx
+++ b/src/app/views/query-runner/request/Request.tsx
@@ -16,7 +16,6 @@ import { Mode } from '../../../../types/enums';
 import { IRequestComponent } from '../../../../types/request';
 import { IRootState } from '../../../../types/root';
 import { setDimensions } from '../../../services/actions/dimensions-action-creator';
-import { ACCOUNT_TYPE } from '../../../services/graph-constants';
 import { translateMessage } from '../../../utils/translate-messages';
 import { convertPxToVh, convertVhToPx } from '../../common/dimensions/dimensions-adjustment';
 import { Auth } from './auth';
@@ -42,7 +41,6 @@ export class Request extends Component<IRequestComponent, any> {
     const {
       handleOnEditorChange,
       mode,
-      profile,
       intl: { messages }
     }: any = this.props;
 
@@ -181,7 +179,8 @@ export class Request extends Component<IRequestComponent, any> {
         <Resizable
           style={{
             border: 'solid 1px #ddd',
-            marginBottom: 10
+            marginBottom: 10,
+            overflow: 'hidden'
           }}
           onResizeStop={(e: any, direction: any, ref: any) => {
             if (ref && ref.style && ref.style.height) {


### PR DESCRIPTION
## Overview
Fixes #1414 

### Demo


### Notes
Rationale behind setting heights to 100%
- When moving the app between different screens, it does not extend to fill the full height of the browser window. Forcing a height of 100% ensures that the app fits the full screen regardless of the height of the browser window. 

## Testing Instructions
![image](https://user-images.githubusercontent.com/45680252/161533935-b0502480-a168-48e7-8d82-36f0c00c0169.png)
Resize the request section upwards. Notice that the response section does not extend beyond the bounds of the app

Move the app between different screens. Notice that it resizes to fit into the new screen. The request and response sections resize to fit the new screen.

Zoom the app until it changes to a mobile view. Zoom back to full-screen view. Notice that the sidebar color is consistent throughout the length of the sidebar.
