### PR TITLE
Fix: Change flex direction to column when on try-it experience

### DIFF
--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -420,8 +420,9 @@ class App extends Component<IAppProps, IAppState> {
           />
           <div className={ `ms-Grid-row ${classes.appRow}`} style={{
             flexWrap: mobileScreen && 'wrap',
-            marginRight: showSidebar && '-20px',
-            height: mobileScreen ? '100%' : '100vh' }}>
+            marginRight: showSidebar || (graphExplorerMode === Mode.TryIt)  && '-20px',
+            height: mobileScreen ? '100%' : '100vh',
+            flexDirection: (graphExplorerMode === Mode.TryIt) ? 'column' : 'row' }}>
 
             {graphExplorerMode === Mode.Complete && (
               <Resizable


### PR DESCRIPTION
## Overview
Fixes #1635 

### Demo
![image](https://user-images.githubusercontent.com/45680252/162416389-c812734e-6930-4bc6-8440-15816ab6bcfd.png)

### Notes
The flex direction on try-it experience should be a column. The content area is displayed as a mobile view. 
## Testing Instructions

* How to test this PR
Check out this branch
Add a 'theme' parameter to the url like so: 'https://jolly-sand-0ac78c710-1636.centralus.azurestaticapps.net/?theme=dark'
Notice the fix