### PR TITLE
Fix: Send proper request body type for code snippets

### DIFF
--- a/src/app/services/actions/snippet-action-creator.ts
+++ b/src/app/services/actions/snippet-action-creator.ts
@@ -30,6 +30,8 @@ export function getSnippetPending(): any {
 export function getSnippet(language: string): Function {
   return async (dispatch: Function, getState: Function) => {
     const { devxApi, sampleQuery } = getState();
+    let body: string = '';
+
     try {
       let snippetsUrl = `${devxApi.baseUrl}/api/graphexplorersnippets`;
 
@@ -56,13 +58,17 @@ export function getSnippet(language: string): Function {
 
       const requestBody =
         sampleQuery.sampleBody &&
-          Object.keys(sampleQuery.sampleBody).length !== 0 && // check if empty object
-          sampleQuery.sampleBody.trim() !== ''
+          Object.keys(sampleQuery.sampleBody).length !== 0
           ? JSON.stringify(sampleQuery.sampleBody)
           : '';
 
-      // eslint-disable-next-line max-len
-      const body = `${sampleQuery.selectedVerb} /${queryVersion}/${requestUrl + search} HTTP/1.1\r\nHost: graph.microsoft.com\r\nContent-Type: application/json\r\n\r\n${requestBody}`;
+      if(sampleQuery.selectedVerb === 'GET'){
+        // eslint-disable-next-line max-len
+        body = `${sampleQuery.selectedVerb} /${queryVersion}/${requestUrl + search} HTTP/1.1\r\nHost: graph.microsoft.com\r\nContent-Type: application/json\r\n\r\n`;
+      } else {
+        // eslint-disable-next-line max-len
+        body = `${sampleQuery.selectedVerb} /${queryVersion}/${requestUrl + search} HTTP/1.1\r\nHost: graph.microsoft.com\r\nContent-Type: application/json\r\n\r\n${requestBody}`;
+      }
 
       const options: IRequestOptions = { method, headers, body };
       const obj: any = {};


### PR DESCRIPTION
## Overview

1. Fixes an issue where the Go and Powershell snippets wouldn't display snippets when there was a request body. E.g POST and PATCH requests
This was because the request body was being sent as a string instead of a JSON 

![image](https://user-images.githubusercontent.com/18407044/162433100-6c94d990-c1e9-4f1d-95e7-9904cd364ed6.png)

2.  This PR also adds validation to ensure we do not send a request body when there's a GET request

Fixes #1608 

### Demo
Powershell tab
![image](https://user-images.githubusercontent.com/18407044/162437880-bb055198-5aa4-400c-a8ad-25be1ee7ee03.png)

Go Tab
![image](https://user-images.githubusercontent.com/18407044/162437960-372dc760-d824-4e98-b101-bb237e7e6092.png)

### Notes
- Even though the other snippets tab would display info, it wasn't always correct... for example the CSharp snippet was missing the highlighted section 
![image](https://user-images.githubusercontent.com/18407044/162438146-fe9ecdde-1ef4-428f-8421-9befa330adb4.png)
 - Sometimes the snippets may still be unavailable due to a null reference on the API side or the resource may not be available in the schema used.

## Testing Instructions

* Open Graph Explorer
* Select version POST, version 'Beta, and input query as 'https://graph.microsoft.com/beta/domains'
with a body similar to this.
![image](https://user-images.githubusercontent.com/18407044/162437475-e0e2b701-ff6c-4ad7-8b2c-27bcfa946aac.png)
* Select Code Snippets tab
* Observe Powershell and Go snippets are displayed
* Try with other POST/PATCH queries as well