### PR TITLE
Fix: Display permissions on Modify Permissions tab

### DIFF
--- a/src/app/views/query-runner/request/permissions/TabList.tsx
+++ b/src/app/views/query-runner/request/permissions/TabList.tsx
@@ -45,7 +45,7 @@ const TabList = ({ columns, classes, renderItemColumn, renderDetailsHeader, maxH
     </Label>)
   }
 
-  if (!tokenPresent) {
+  if (!tokenPresent && permissions.length === 0) {
     return displayNotSignedInMessage();
   }
 


### PR DESCRIPTION
## Overview
Fixes #1640 

### Demo
![image](https://user-images.githubusercontent.com/45680252/162457414-ffef2e64-6952-4991-bf9f-4f527442013a.png)

### Notes


## Testing Instructions
Check out this branch
Ensure there's a query in the query text box
Click on Modify Permissions tab