### PR TITLE
Fix: autocomplete suggestions overflow

### DIFF
--- a/src/app/views/query-runner/query-input/auto-complete/AutoComplete.styles.ts
+++ b/src/app/views/query-runner/query-input/auto-complete/AutoComplete.styles.ts
@@ -1,7 +1,7 @@
 import { ITheme } from '@fluentui/react';
 
 export const autoCompleteStyles = (theme: ITheme) => {
-  const controlWidth = '40%';
+  const controlWidth = '95.5%';
 
   return {
     input: {
@@ -18,7 +18,7 @@ export const autoCompleteStyles = (theme: ITheme) => {
       paddingLeft: 0,
       position: 'absolute',
       backgroundColor: theme.palette.neutralLighter,
-      minWidth: controlWidth,
+      minWidth: '40%',
       zIndex: 1,
       cursor: 'pointer',
       color: theme.palette.black


### PR DESCRIPTION
## Overview
Fixes autocomlete suggestions overflowing beyond the width of the app

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

## Testing Instructions

Check out this PR locally
Add '?' at the end of a query like 'https://graph.microsoft.com/v1.0/me?'
Notice the autocomplete suggestions stay within the normal bounds