### PR TITLE
Task: Extend sidebar content space

### DIFF
--- a/src/app/views/sidebar/Sidebar.styles.ts
+++ b/src/app/views/sidebar/Sidebar.styles.ts
@@ -16,7 +16,7 @@ export const sidebarStyles = (theme: ITheme) => {
     queryList: {
       marginBottom: theme.spacing.s1,
       cursor: 'pointer',
-      maxHeight: pageHeightInVh,
+      maxHeight: '83vh',
       minHeight: pageHeightInVh,
       overflow: 'hidden',
       fontSize: FontSizes.medium,


### PR DESCRIPTION
## Overview
Makes sidebar content cover more space that is now available

### Demo
Previously:
![image](https://user-images.githubusercontent.com/45680252/166628402-3026172d-fdcd-46f4-b2d5-52f9f14a5111.png)

Currently:
![image](https://user-images.githubusercontent.com/45680252/166628510-a316e9b7-c06d-441a-b9a3-b8016f0472e0.png)


### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
Check out this branch
Run it locally
Notice that the samples, resources and history items cover the available space