### PR TITLE
Remove scrollbar from menu

### DIFF
--- a/src/app/views/settings/Settings.tsx
+++ b/src/app/views/settings/Settings.tsx
@@ -6,7 +6,6 @@ import {
   DialogFooter,
   DialogType,
   getId,
-  getTheme,
   IconButton,
   registerIcons,
   TooltipHost
@@ -82,7 +81,13 @@ function Settings(props: ISettingsProps) {
         href: 'https://github.com/microsoftgraph/microsoft-graph-explorer-v4',
         target: '_blank',
         iconProps: {
-          iconName: 'GitHubLogo'
+          iconName: 'GitHubLogo',
+          styles: {
+            root: {
+              position: 'relative',
+              top: '-2px'
+            }
+          }
         },
         onClick: () => trackGithubLinkClickEvent()
       }
@@ -127,10 +132,17 @@ function Settings(props: ISettingsProps) {
     });
   };
 
+  const calloutStyles: React.CSSProperties = {
+    overflowY: 'hidden'
+  }
+
   const menuProperties = {
     shouldFocusOnMount: true,
     alignTargetEdge: true,
-    items
+    items,
+    calloutProps: {
+      style: calloutStyles
+    }
   };
 
   return (


### PR DESCRIPTION
## Overview
- Removes scrollbar from settings menu
- Centers the GitHub logo

### Demo
<img width="247" alt="image" src="https://user-images.githubusercontent.com/45680252/167414214-1fbcaf03-5288-45a6-9cd4-b94d61f2a48d.png">

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
Check out this branch
Click on the settings icon
A settings menu appears. Notice that the scrollbar is no longer there