### PR TITLE
Fix: align right header items

### DIFF
--- a/src/app/views/authentication/Authentication.styles.ts
+++ b/src/app/views/authentication/Authentication.styles.ts
@@ -14,11 +14,19 @@ export const authenticationStyles = (theme: ITheme) => {
       alignItems: 'flex-start',
       justifyContent: 'start',
       marginRight: theme.spacing.s1,
-      padding: theme.spacing.s1
+      padding: theme.spacing.s1,
+      position: 'relative',
+      top: '1px'
     },
     spinnerContainer: {
       display: 'flex',
       flexDirection: 'row'
+    },
+    loginProgressLabelStyles: {
+      root: {
+        position: 'relative',
+        top: '6px'
+      }
     }
   };
 };

--- a/src/app/views/authentication/Authentication.tsx
+++ b/src/app/views/authentication/Authentication.tsx
@@ -75,7 +75,7 @@ const Authentication = (props: any) => {
       <div className={classes.spinnerContainer}>
         <Spinner className={classes.spinner} size={SpinnerSize.medium} />
         {!minimised && (
-          <Label>
+          <Label styles={{ root: { position: 'relative', top: '8px'}}} >
             <FormattedMessage
               id={`Signing you ${loginInProgress ? 'in' : 'out'}...`}
             />

--- a/src/app/views/authentication/profile/Profile.styles.ts
+++ b/src/app/views/authentication/profile/Profile.styles.ts
@@ -19,6 +19,12 @@ export const profileStyles = (theme: ITheme) => {
         paddingBottom: 10,
         textTransform: 'lowercase'
       }
+    },
+    profileSpinnerStyles: {
+      root: {
+        position: 'relative' as 'relative',
+        top: '2px'
+      }
     }
   }
 }

--- a/src/app/views/authentication/profile/Profile.tsx
+++ b/src/app/views/authentication/profile/Profile.tsx
@@ -76,6 +76,7 @@ const Profile = (props: any) => {
   const theme = getTheme();
   const linkStyles = profileStyles(theme).linkStyles
   const personaStyleToken = profileStyles(theme).personaStyleToken;
+  const profileSpinnerStyles = profileStyles(theme).profileSpinnerStyles;
 
 
   useEffect(() => {
@@ -86,7 +87,7 @@ const Profile = (props: any) => {
 
 
   if (!profile) {
-    return (<Spinner size={SpinnerSize.medium} />);
+    return (<Spinner size={SpinnerSize.medium} styles={profileSpinnerStyles} />);
   }
 
   const handleSignOut = () => {

--- a/src/app/views/main-header/MainHeader.styles.ts
+++ b/src/app/views/main-header/MainHeader.styles.ts
@@ -9,7 +9,7 @@ export const mainHeaderStyles = (theme: ITheme) => {
         marginBottom: '9px'
       }
     },
-    authenticationItemStyles: {
+    rightItemsStyles: {
       root: {
         alignItems: 'center'
       }

--- a/src/app/views/main-header/MainHeader.styles.ts
+++ b/src/app/views/main-header/MainHeader.styles.ts
@@ -10,8 +10,14 @@ export const mainHeaderStyles = (theme: ITheme, props?: any) => {
       }
     },
     authenticationItemStyles: {
-      alignItems: 'center',
-      display: 'flex'
+      root: {
+        alignItems: 'center'
+      }
+    },
+    feedbackIconAdjustmentStyles: {
+      position: 'relative' as 'relative',
+      right: '-6px',
+      top: '4px'
     }
   }
 }

--- a/src/app/views/main-header/MainHeader.tsx
+++ b/src/app/views/main-header/MainHeader.tsx
@@ -39,8 +39,8 @@ export const MainHeader: React.FunctionComponent <MainHeaderProps> = (props: Mai
   const minimised = props.minimised;
   const currentTheme = getTheme();
   const itemAlignmentStackStyles = mainHeaderStyles(currentTheme).rootStyles;
-  const personaItemsStyles = mainHeaderStyles(currentTheme).authenticationItemStyles;
-  const feedbackAdjustmentStyles = mainHeaderStyles(currentTheme).feedbackIconAdjustmentStyles;
+  const rightItemsStyles = mainHeaderStyles(currentTheme).rightItemsStyles;
+  const feedbackIconAdjustmentStyles = mainHeaderStyles(currentTheme).feedbackIconAdjustmentStyles;
 
   return (
     <Stack tokens={sectionStackTokens}>
@@ -72,7 +72,7 @@ export const MainHeader: React.FunctionComponent <MainHeaderProps> = (props: Mai
           </Label>
         </Stack>
 
-        <Stack horizontal styles={personaItemsStyles}>
+        <Stack horizontal styles={rightItemsStyles}>
           {!profile &&
             <TooltipHost
               content={
@@ -90,7 +90,7 @@ export const MainHeader: React.FunctionComponent <MainHeaderProps> = (props: Mai
             <DefaultButton text={`${profile.tenant} Tenant`} checked={true} style={{border: 'none', cursor: 'default'}}
             />
           }
-          <span style={feedbackAdjustmentStyles}> <FeedbackButton /> </span>
+          <span style={feedbackIconAdjustmentStyles}> <FeedbackButton /> </span>
           <Settings />
           <Authentication />
         </Stack>

--- a/src/app/views/main-header/MainHeader.tsx
+++ b/src/app/views/main-header/MainHeader.tsx
@@ -45,7 +45,8 @@ export const MainHeader: React.FunctionComponent <MainHeaderProps> = (props: Mai
   const minimised = props.minimised;
   const currentTheme = getTheme();
   const itemAlignmentStackStyles = mainHeaderStyles(currentTheme, authToken).rootStyles;
-  const itemStyles = mainHeaderStyles(currentTheme).authenticationItemStyles;
+  const personaItemsStyles = mainHeaderStyles(currentTheme).authenticationItemStyles;
+  const feedbackAdjustmentStyles = mainHeaderStyles(currentTheme).feedbackIconAdjustmentStyles;
 
   const showUnAuthenticatedText = (): React.ReactNode => {
     return (
@@ -94,14 +95,11 @@ export const MainHeader: React.FunctionComponent <MainHeaderProps> = (props: Mai
           </Label>
         </Stack>
 
-        <Stack >
-          <span style={itemStyles}>
-            <Label>{profile?.tenant}</Label>
-            <FeedbackButton />
-            <Settings />
-            <Authentication />
-          </span>
-          <span style={itemStyles}></span>
+        <Stack horizontal styles={personaItemsStyles}>
+          <Label> {profile?.tenant} </Label>
+          <span style={feedbackAdjustmentStyles}><FeedbackButton /></span>
+          <Settings />
+          <Authentication />
         </Stack>
 
       </Stack>

--- a/src/app/views/main-header/MainHeader.tsx
+++ b/src/app/views/main-header/MainHeader.tsx
@@ -38,9 +38,8 @@ export const MainHeader: React.FunctionComponent <MainHeaderProps> = (props: Mai
   );
   const minimised = props.minimised;
   const currentTheme = getTheme();
-  const itemAlignmentStackStyles = mainHeaderStyles(currentTheme).rootStyles;
-  const rightItemsStyles = mainHeaderStyles(currentTheme).rightItemsStyles;
-  const feedbackIconAdjustmentStyles = mainHeaderStyles(currentTheme).feedbackIconAdjustmentStyles;
+  const { rootStyles : itemAlignmentStackStyles, rightItemsStyles,
+    feedbackIconAdjustmentStyles } = mainHeaderStyles(currentTheme);
 
   return (
     <Stack tokens={sectionStackTokens}>


### PR DESCRIPTION
## Overview
Aligns tenant name, settings and authentication items

### Demo
<img width="190" alt="image" src="https://user-images.githubusercontent.com/45680252/167678596-bc01e689-43bd-4dec-b935-bf27c87762dc.png">

<img width="162" alt="image" src="https://user-images.githubusercontent.com/45680252/167678664-d9d45d7e-a028-4da8-92f7-b231a2df1341.png">


### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
Check out this branch
Run it locally
Notice that all header items are well aligned
Click on the persona icon to sign in. Notice that the spinner and the signing in text are all aligned