### PR TITLE
Show CORS information for reports that result in an exception

### DIFF
--- a/src/app/services/actions/query-action-creator-util.ts
+++ b/src/app/services/actions/query-action-creator-util.ts
@@ -263,7 +263,7 @@ export function queryResultsInCorsError(sampleUrl: string): boolean {
   if (
     (['/drive/', '/drives/', '/driveItem/'].some((x) =>
       sampleUrl.includes(x)) && sampleUrl.endsWith('/content')) ||
-    (sampleUrl.includes('/reports/') && sampleUrl.includes('$format=text/csv'))
+    sampleUrl.includes('/reports/')
   ) {
     return true;
   }


### PR DESCRIPTION
## Overview
Fixes #1725 
If a reports  endpoint throws an exception, it's most likely a CORS error. 

### Demo
<img width="799" alt="image" src="https://user-images.githubusercontent.com/25274795/168054205-a937bedc-c7d9-47d2-9933-eee5298881e6.png">


## Testing Instructions

* Run the query `https://graph.microsoft.com/v1.0/reports/getMailboxUsageDetail(period='D7')`
* CORS information should be displayed in the response area
