### PR TITLE
Keeps theme chooser options within one line

### DIFF
--- a/src/app/views/main-header/ThemeSetting.tsx
+++ b/src/app/views/main-header/ThemeSetting.tsx
@@ -30,7 +30,8 @@ export const ThemeSetting: React.FunctionComponent = () => {
       SelectedTheme: selectedTheme.key.replace('-', ' ').toSentenceCase()
     });
   };
-  return(
+
+  return (
     <div>
       <ActionButton
         ariaLabel={translateMessage('change theme')}
@@ -52,6 +53,7 @@ export const ThemeSetting: React.FunctionComponent = () => {
           <ChoiceGroup
             label='Pick one theme'
             defaultSelectedKey={appTheme}
+            styles={{ flexContainer: { flexWrap: 'nowrap'  }} }
             options={[
               {
                 key: AppTheme.Light,


### PR DESCRIPTION
## Overview
Keeps theme chooser dialog options within one line
Solves #1738 

### Demo
<img width="261" alt="image" src="https://user-images.githubusercontent.com/45680252/168729235-b4f0117d-dc19-4598-b3fd-5847201802b3.png">

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
Check out this branch and run it locally
Click on the theme toggle button at the top right
Notice the chooser dialog has the options in one line