### PR TITLE
Show isolated resources

### DIFF
--- a/src/app/views/sidebar/resource-explorer/ResourceExplorer.tsx
+++ b/src/app/views/sidebar/resource-explorer/ResourceExplorer.tsx
@@ -108,7 +108,7 @@ const unstyledResourceExplorer = (props: any) => {
   const isolateTree = (navLink: any): void => {
     const tree = [
       {
-        isExpanded: false,
+        isExpanded: true,
         links: navLink.links
       }
     ];

--- a/src/app/views/sidebar/resource-explorer/ResourceLink.tsx
+++ b/src/app/views/sidebar/resource-explorer/ResourceLink.tsx
@@ -24,7 +24,7 @@ const ResourceLink = (props: IResourceLinkProps) => {
 
 
   const iconButtonStyles = {
-    root: { paddingBottom: 10, marginTop: -5, marginRight: 2 },
+    root: { marginTop: -5, marginRight: 2 },
     menuIcon: { fontSize: 20, padding: 5 }
   };
 


### PR DESCRIPTION
## Overview
Fixes isolation issue on Resource Explorer, where clicking 'Isolate' does not show the isolated resources
Solves #1743 

### Demo
<img width="493" alt="image" src="https://user-images.githubusercontent.com/45680252/168886305-50a49121-97cc-42c9-bccc-e51f1517c4d3.png">


### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
Check out this branch and run it locally
Click on the resources tab
Click on the more actions button on any resource item
Now click Isolate
Notice that the isolated resource items are available