### PR TITLE
Fix: Auth icon size

### DIFF
--- a/src/app/views/authentication/Authentication.tsx
+++ b/src/app/views/authentication/Authentication.tsx
@@ -97,13 +97,11 @@ const Authentication = (props: any) => {
         showSignInButtonOrProfile(tokenPresent, mobileScreen, signIn)
       ) : (
         <>
-          <br />
           {showSignInButtonOrProfile(
             tokenPresent,
             mobileScreen,
             signIn
           )}
-          <br />
         </>
       )}
     </>

--- a/src/app/views/authentication/auth-util-components/UtilComponents.tsx
+++ b/src/app/views/authentication/auth-util-components/UtilComponents.tsx
@@ -28,9 +28,9 @@ export function showSignInButtonOrProfile(
   </ActionButton>;
 
   return (
-    <div>
+    <>
       {!tokenPresent && signInButton}
       {tokenPresent && <Profile signIn={signIn}/>}
-    </div>
+    </>
   );
 }

--- a/src/app/views/authentication/profile/Profile.styles.ts
+++ b/src/app/views/authentication/profile/Profile.styles.ts
@@ -18,6 +18,10 @@ export const profileStyles = (theme: ITheme) => {
       {
         paddingBottom: 10,
         textTransform: 'lowercase'
+      },
+      root: {
+        height: '100%',
+        paddingLeft: '3px'
       }
     },
     profileSpinnerStyles: {
@@ -30,10 +34,27 @@ export const profileStyles = (theme: ITheme) => {
       root: {
         position: 'relative' as 'relative',
         bottom: '25px',
-        left: '87px',
+        left: '92px',
         textDecoration: 'underline',
         color: `${theme.palette.themePrimary} !important`
       }
+    },
+    personaButtonStyles: {
+      root: {
+        ':hover': {
+          background: `${theme.palette.neutralLight} !important`
+        },
+        height: '100%',
+        flex: 1,
+        display: 'flex',
+        alignItems: 'stretch'
+      }
+    },
+    profileContainerStyles: {
+      display: 'flex',
+      alignItems: 'stretch',
+      flex: 1,
+      height: '100%'
     }
   }
 }

--- a/src/app/views/authentication/profile/Profile.tsx
+++ b/src/app/views/authentication/profile/Profile.tsx
@@ -67,7 +67,8 @@ const Profile = (props: any) => {
   const labelId = useId('callout-label');
   const descriptionId = useId('callout-description');
   const theme = getTheme();
-  const { personaStyleToken , profileSpinnerStyles, permissionsLabelStyles } = profileStyles(theme);
+  const { personaStyleToken , profileSpinnerStyles, permissionsLabelStyles,
+    personaButtonStyles, profileContainerStyles } = profileStyles(theme);
 
   useEffect(() => {
     if (authenticated) {
@@ -183,9 +184,7 @@ const Profile = (props: any) => {
         id={buttonId}
         onClick={toggleIsCalloutVisible}
         role='button'
-        styles={{root: {':hover': {
-          background: `${theme.palette.neutralLight} !important`
-        }}}}
+        styles={personaButtonStyles}
       >
         {smallPersona}
       </ActionButton>
@@ -203,7 +202,7 @@ const Profile = (props: any) => {
           onDismiss={toggleIsCalloutVisible}
           setInitialFocus
         >
-          <Stack horizontal horizontalAlign='space-between' styles={{root:{ paddingBottom: 15}}}>
+          <Stack horizontal horizontalAlign='space-between' styles={{root:{ paddingBottom: 0}}}>
             {profile &&
             <ActionButton text={`${profile.tenant}`} disabled={true}/>
             }
@@ -230,7 +229,7 @@ const Profile = (props: any) => {
   }
 
   return (
-    <div className={classes.profile}>
+    <div className={classes.profile} style={profileContainerStyles}>
       {showProfileComponent(persona)}
       <Panel
         isOpen={permissionsPanelOpen}


### PR DESCRIPTION
## Overview
Hovering over profile icon reveals a consistent profile size

### Demo

<img width="105" alt="image" src="https://user-images.githubusercontent.com/45680252/170504389-f12b2e07-9862-41a1-bdab-602f2e1a6dbe.png">

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
Click on the sign-in profile
Sign in with your account
Hover over the profile, help and settings icons
Notice that the size of the icons is the same