### PR TITLE
Fix: Restore permissions styles

### DIFF
--- a/src/app/views/authentication/auth-util-components/ProfileButton.styles.ts
+++ b/src/app/views/authentication/auth-util-components/ProfileButton.styles.ts
@@ -1,6 +1,6 @@
 import { ITheme } from '@fluentui/react'
 
-export const utilComponentStyles = (theme: ITheme) => {
+export const profileButtonStyles = (theme: ITheme) => {
   return {
     actionButtonStyles: {
       root: {

--- a/src/app/views/authentication/auth-util-components/ProfileButton.tsx
+++ b/src/app/views/authentication/auth-util-components/ProfileButton.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { translateMessage } from '../../../utils/translate-messages';
 import Profile from '../profile/Profile';
-import { utilComponentStyles } from './UtilComponents.styles';
+import { profileButtonStyles } from './ProfileButton.styles';
 
 export function showSignInButtonOrProfile(
   tokenPresent: boolean,
@@ -12,7 +12,7 @@ export function showSignInButtonOrProfile(
 ) {
 
   const currentTheme = getTheme();
-  const { actionButtonStyles } = utilComponentStyles(currentTheme);
+  const { actionButtonStyles } = profileButtonStyles(currentTheme);
   const signInButton = <ActionButton
     ariaLabel={translateMessage('sign in')}
     role='button'

--- a/src/app/views/authentication/auth-util-components/UtilComponents.styles.ts
+++ b/src/app/views/authentication/auth-util-components/UtilComponents.styles.ts
@@ -1,0 +1,18 @@
+import { ITheme } from '@fluentui/react'
+
+export const utilComponentStyles = (theme: ITheme) => {
+  return {
+    actionButtonStyles: {
+      root: {
+        height: 50,
+        width: 80,
+        ':hover': {
+          background: `${theme.palette.neutralLight} !important`
+        },
+        whiteSpace: 'nowrap',
+        paddingLeft: '10px',
+        flexBasis: '60px'
+      }
+    }
+  }
+}

--- a/src/app/views/authentication/auth-util-components/UtilComponents.tsx
+++ b/src/app/views/authentication/auth-util-components/UtilComponents.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { translateMessage } from '../../../utils/translate-messages';
 import Profile from '../profile/Profile';
+import { utilComponentStyles } from './UtilComponents.styles';
 
 export function showSignInButtonOrProfile(
   tokenPresent: boolean,
@@ -11,18 +12,13 @@ export function showSignInButtonOrProfile(
 ) {
 
   const currentTheme = getTheme();
+  const { actionButtonStyles } = utilComponentStyles(currentTheme);
   const signInButton = <ActionButton
     ariaLabel={translateMessage('sign in')}
     role='button'
     iconProps={{ iconName: 'Contact' }}
     onClick={() => signIn()}
-    styles={{
-      root:{
-        height: 50,
-        width: 80,
-        ':hover': {
-          background: `${currentTheme.palette.neutralLight} !important`
-        }}}}
+    styles={actionButtonStyles}
   >
     {!mobileScreen && <FormattedMessage id='sign in' />}
   </ActionButton>;

--- a/src/app/views/authentication/auth-util-components/index.tsx
+++ b/src/app/views/authentication/auth-util-components/index.tsx
@@ -1,1 +1,1 @@
-export { showSignInButtonOrProfile } from './UtilComponents';
+export { showSignInButtonOrProfile } from './ProfileButton';

--- a/src/app/views/authentication/profile/Profile.styles.ts
+++ b/src/app/views/authentication/profile/Profile.styles.ts
@@ -55,6 +55,22 @@ export const profileStyles = (theme: ITheme) => {
       alignItems: 'stretch',
       flex: 1,
       height: '100%'
+    },
+    permissionPanelStyles: {
+      footer: {
+        backgroundColor: theme.palette.white
+      },
+      commands: {
+        backgroundColor: theme.palette.white
+      }
+    },
+    inactiveConsentStyles: {
+      marginRight: 10,
+      backgroundColor: theme.palette.themeSecondary
+    },
+    activeConsentStyles: {
+      marginRight: 10,
+      backgroundColor: theme.palette.themeDarker
     }
   }
 }

--- a/src/app/views/authentication/profile/Profile.tsx
+++ b/src/app/views/authentication/profile/Profile.tsx
@@ -67,8 +67,8 @@ const Profile = (props: any) => {
   const labelId = useId('callout-label');
   const descriptionId = useId('callout-description');
   const theme = getTheme();
-  const { personaStyleToken , profileSpinnerStyles, permissionsLabelStyles,
-    personaButtonStyles, profileContainerStyles } = profileStyles(theme);
+  const { personaStyleToken , profileSpinnerStyles, permissionsLabelStyles, inactiveConsentStyles,
+    personaButtonStyles, profileContainerStyles, permissionPanelStyles, activeConsentStyles } = profileStyles(theme);
 
   useEffect(() => {
     if (authenticated) {
@@ -140,7 +140,7 @@ const Profile = (props: any) => {
         <PrimaryButton
           disabled={selectedPermissions.length === 0}
           onClick={() => handleConsent()}
-          style={{ marginRight: 10 }}
+          style={(selectedPermissions.length === 0) ? activeConsentStyles: inactiveConsentStyles}
         >
           {translateMessage('Consent')}
         </PrimaryButton>
@@ -241,6 +241,7 @@ const Profile = (props: any) => {
         isFooterAtBottom={true}
         closeButtonAriaLabel='Close'
         overlayProps={panelOverlayProps}
+        styles={permissionPanelStyles}
       >
         <Permission panel={true} setPermissions={setPermissions} />
       </Panel>

--- a/src/app/views/main-header/MainHeader.styles.ts
+++ b/src/app/views/main-header/MainHeader.styles.ts
@@ -1,6 +1,6 @@
-import { ITheme } from '@fluentui/react';
+import { FontSizes, FontWeights, ITheme } from '@fluentui/react';
 
-export const mainHeaderStyles = (theme: ITheme) => {
+export const mainHeaderStyles = (theme: ITheme, mobileScreen?: boolean) => {
   return {
     rootStyles: {
       root: {
@@ -11,7 +11,8 @@ export const mainHeaderStyles = (theme: ITheme) => {
     },
     rightItemsStyles: {
       root: {
-        alignItems: 'center'
+        alignItems: 'center',
+        flexBasis: mobileScreen ? '137px' : ''
       }
     },
     feedbackIconAdjustmentStyles: {
@@ -50,6 +51,12 @@ export const mainHeaderStyles = (theme: ITheme) => {
         display: 'flex',
         alignItems: 'stretch'
       }
+    },
+    graphExplorerLabelStyles: {
+      fontSize: mobileScreen ? FontSizes.medium : FontSizes.xLarge,
+      fontWeight: FontWeights.semibold,
+      position: mobileScreen ? 'relative' as 'relative' : 'static' as 'static',
+      top: '3px'
     }
   }
 }

--- a/src/app/views/main-header/MainHeader.tsx
+++ b/src/app/views/main-header/MainHeader.tsx
@@ -47,8 +47,8 @@ export const MainHeader: React.FunctionComponent <MainHeaderProps> = (props: Mai
   const minimised = props.minimised;
   const mobileScreen = props.mobileScreen;
   const currentTheme = getTheme();
-  const { rootStyles : itemAlignmentStackStyles, rightItemsStyles,
-    feedbackIconAdjustmentStyles, tenantStyles, moreInformationStyles } = mainHeaderStyles(currentTheme);
+  const { rootStyles : itemAlignmentStackStyles, rightItemsStyles, graphExplorerLabelStyles,
+    feedbackIconAdjustmentStyles, tenantStyles, moreInformationStyles } = mainHeaderStyles(currentTheme, mobileScreen);
 
   return (
     <Stack tokens={sectionStackTokens}>
@@ -76,8 +76,7 @@ export const MainHeader: React.FunctionComponent <MainHeaderProps> = (props: Mai
               onClick={() => props.toggleSidebar()} />
           </TooltipHost>
           <Label
-            style={{ fontSize: mobileScreen ? FontSizes.medium : FontSizes.xLarge,
-              fontWeight: FontWeights.semibold }}>
+            style={graphExplorerLabelStyles}>
             Graph Explorer
           </Label>
         </Stack>

--- a/src/app/views/main-header/MainHeader.tsx
+++ b/src/app/views/main-header/MainHeader.tsx
@@ -8,6 +8,7 @@ import {
   IconButton,
   IStackTokens,
   Label,
+  registerIcons,
   Stack,
   TooltipHost
 } from '@fluentui/react';
@@ -32,9 +33,13 @@ const sectionStackTokens: IStackTokens = {
   childrenGap: 0 };
 const itemAlignmentsStackTokens: IStackTokens = {
   childrenGap: 10
-
 };
 
+registerIcons({
+  icons: {
+    tenantIcon: <TenantIcon />
+  }
+});
 export const MainHeader: React.FunctionComponent <MainHeaderProps> = (props: MainHeaderProps) => {
   const { profile } = useSelector(
     (state: IRootState) => state
@@ -78,7 +83,6 @@ export const MainHeader: React.FunctionComponent <MainHeaderProps> = (props: Mai
         </Stack>
 
         <Stack horizontal styles={rightItemsStyles} >
-          {!mobileScreen && <TenantIcon />}
           {!profile && !mobileScreen &&
             <TooltipHost
               content={
@@ -89,12 +93,12 @@ export const MainHeader: React.FunctionComponent <MainHeaderProps> = (props: Mai
               id={getId()}
               calloutProps={{ gapSpace: 0 }}
             >
-              <DefaultButton text={translateMessage('Tenant: Sample')}
+              <DefaultButton iconProps={{ iconName: 'tenantIcon'}} text={translateMessage('Tenant: Sample')}
                 style={tenantStyles}/>
             </TooltipHost>
           }
           {profile && !mobileScreen &&
-            <DefaultButton text={`Tenant: ${profile.tenant}`} checked={true}
+            <DefaultButton  iconProps={{ iconName: 'tenantIcon'}} text={`Tenant: ${profile.tenant}`} checked={true}
               style={tenantStyles}
             />
           }

--- a/src/app/views/main-header/settings/Settings.tsx
+++ b/src/app/views/main-header/settings/Settings.tsx
@@ -7,12 +7,10 @@ import {
   getId,
   getTheme,
   IconButton,
-  registerIcons,
   TooltipHost
 } from '@fluentui/react';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { GitHubLogoIcon } from '@fluentui/react-icons-mdl2';
 
 import '../../../utils/string-operations';
 import { componentNames, eventTypes, telemetry } from '../../../../telemetry';
@@ -32,12 +30,6 @@ export const Settings: React.FunctionComponent<ISettingsProps> = () => {
   const [themeChooserDialogHidden, hideThemeChooserDialog] = useState(true);
   const [items, setItems] = useState([]);
   const currentTheme = getTheme();
-
-  registerIcons({
-    icons: {
-      GitHubLogo: <GitHubLogoIcon />
-    }
-  });
 
   useEffect(() => {
     const menuItems: any = [


### PR DESCRIPTION
## Overview
Restores styling on the permissions panel:
<img width="317" alt="image" src="https://user-images.githubusercontent.com/45680252/170926478-a211a24f-b895-4177-84c5-a49817304ab2.png">

<img width="324" alt="image" src="https://user-images.githubusercontent.com/45680252/170926504-d14f9408-6591-4548-94a0-de7368d9ca9b.png">

Fixes alignment issue on the Graph explorer label on mobile screen
<img width="120" alt="image" src="https://user-images.githubusercontent.com/45680252/170926727-79ee5ca7-0e40-4aca-8635-d195fdaab94b.png">

<img width="477" alt="image" src="https://user-images.githubusercontent.com/45680252/170926927-4bf69cfb-3f90-46c0-aa47-833f864ca55d.png">



### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
Check out this branch
Run it locally
Resize screen from mobile to full screen view. Notice fix