### PR TITLE
Remove button-name from accessibility exclusion

### DIFF
--- a/src/tests/accessibility/accessibility.spec.ts
+++ b/src/tests/accessibility/accessibility.spec.ts
@@ -42,7 +42,6 @@ describe('Graph Explorer accessibility', () => {
         'document-title',
         'html-has-lang',
         'page-has-heading-one',
-        'button-name',
         'landmark-unique'
       ])
       .analyze();


### PR DESCRIPTION
## Overview
Now that the pivot items have an overflow behavior aria label, we can remove the rule that excludes button-names on the accessibility checks.


### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output