### PR TITLE
Task: Limit sidebar resize

### DIFF
--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -261,7 +261,7 @@ class App extends Component<IAppProps, IAppState> {
 
   public toggleSidebar = (): void => {
     const shouldShowSidebar = this.setSidebarProperties();
-    this.changeDimensions(shouldShowSidebar ? '26%' : '4%');
+    this.changeDimensions(shouldShowSidebar ? '26%' : '1%');
     telemetry.trackEvent(
       eventTypes.BUTTON_CLICK_EVENT,
       {
@@ -417,7 +417,7 @@ class App extends Component<IAppProps, IAppState> {
                   }
                 }}
                 className={`ms-Grid-col ms-sm12 ms-md4 ms-lg4 ${sidebarWidth} resizable-sidebar`}
-                minWidth={'4'}
+                minWidth={71}
                 maxWidth={maxWidth}
                 enable={{
                   right: true


### PR DESCRIPTION
## Overview
Limits sidebar resizing so that the sidebar buttons do not overlap the sidebar on hover as shown: 
<img width="59" alt="image" src="https://user-images.githubusercontent.com/45680252/171104026-7fc8f335-0b5f-4c14-a90c-43c4037bb770.png">

### Demo
<img width="78" alt="image" src="https://user-images.githubusercontent.com/45680252/171104066-f36dd222-abc1-47fc-a59f-a4f38bbf1ec5.png">


### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
Check out this branch and run it locally
Resize the sidebar until the sidebar items disappear and you have sidebar buttons only. 
Notice that the resizing does not go beyond a certain point.