### PR TITLE
Speed up tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,7 +18,10 @@ module.exports = {
     '**/?(*.)+(spec|test).[jt]s'
   ],
   globals: {
-    crypto: require('crypto')
+    crypto: require('crypto'),
+    'ts-jest': {
+      isolatedModules: true
+    }
   },
   testEnvironmentOptions: {
     url: 'http://localhost'

--- a/package-lock.json
+++ b/package-lock.json
@@ -3509,7 +3509,7 @@
       "version": "file:packages/officebrowserfeedbacknpm-1.6.6.tgz",
       "integrity": "sha512-GlERHSZSZrJyyY6FBKoRNgNkW8EJa3g5c45Oi/PKrrHW5fVj1mK53OElJxmLWAZLkQsoNVTCvg55AI0gBVVKJA==",
       "requires": {
-        "@augloop/types-core": "file:packages/types-core-2.16.189.tgz",
+        "@augloop/types-core": "2.16.189",
         "@ms-ofb/officefloodgatecore": "*",
         "es6-promise": "4.2.8",
         "tslib": "^1.9.3",
@@ -3758,19 +3758,6 @@
           "dev": true,
           "requires": {
             "@types/react": "*"
-          },
-          "dependencies": {
-            "@types/react": {
-              "version": "17.0.30",
-              "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.30.tgz",
-              "integrity": "sha512-3Dt/A8gd3TCXi2aRe84y7cK1K8G+N9CZRDG8kDGguOKa0kf/ZkSwTmVIDPsm/KbQOVMaDJXwhBtuOXxqwdpWVg==",
-              "dev": true,
-              "requires": {
-                "@types/prop-types": "*",
-                "@types/scheduler": "*",
-                "csstype": "^3.0.2"
-              }
-            }
           }
         }
       }
@@ -5364,7 +5351,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
     "at-least-node": {
@@ -12923,7 +12910,7 @@
     "lz-string": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
       "dev": true
     },
     "magic-string": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "scripts": {
                 "start": "node scripts/start.js",
                 "build": "node scripts/build.js && node versioned-build.js",
-                "test": "node scripts/test.js --no-watch --testPathIgnorePatterns=src/tests/accessibility /scripts/",
+                "test": "node scripts/test.js --no-watch --testPathIgnorePatterns=src/tests/accessibility /scripts/ --max-old-space-size=8192",
                 "lint": "eslint . \"**/*.{js,ts,tsx}\"",
                 "start-server": "npm start",
                 "ci": "start-server-and-test start-server http://localhost:3000 test-ci",

--- a/src/app/services/actions/autocomplete-action-creators.spec.ts
+++ b/src/app/services/actions/autocomplete-action-creators.spec.ts
@@ -120,7 +120,7 @@ store.getState = () => {
     ...currentState
   }
 }
-describe.skip('Test autocomplete action creators', () => {
+describe('Test autocomplete action creators', () => {
   beforeEach(() => {
     // eslint-disable-next-line no-undef
     fetchMock.resetMocks();

--- a/src/app/services/actions/permissions-action-creator.spec.ts
+++ b/src/app/services/actions/permissions-action-creator.spec.ts
@@ -124,7 +124,7 @@ store.getState = () => {
   }
 }
 
-describe.skip('tests permissions action creators', () => {
+describe('tests permissions action creators', () => {
   it('Tests if FETCH_SCOPES_SUCCESS is dispatched when fetchScopesSuccess is called', () => {
     // Arrange
     const response: IPermissionsResponse = {

--- a/src/app/services/actions/query-action-creators.spec.ts
+++ b/src/app/services/actions/query-action-creators.spec.ts
@@ -8,7 +8,7 @@ import { QUERY_GRAPH_RUNNING, QUERY_GRAPH_STATUS, QUERY_GRAPH_SUCCESS } from '..
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 
-describe.skip('query actions', () => {
+describe('query actions', () => {
   beforeEach(() => {
     fetchMock.resetMocks();
   });

--- a/src/app/services/reducers/resources-reducer.spec.ts
+++ b/src/app/services/reducers/resources-reducer.spec.ts
@@ -80,7 +80,7 @@ describe('Resources Reducer', () => {
     expect(state).toEqual(newState);
   });
 
-  it.skip('should handle FETCH_RESOURCES_ERROR', () => {
+  it('should handle FETCH_RESOURCES_ERROR', () => {
 
     const mockResponse = new Error('400');
 

--- a/src/tests/proxy-url.spec.ts
+++ b/src/tests/proxy-url.spec.ts
@@ -6,7 +6,7 @@ import { isValidHttpsUrl } from '../app/utils/external-link-validation';
 import { IQuery } from '../types/query-runner';
 import { IStatus } from '../types/status';
 
-describe.skip('Sandbox api fetch should', () => {
+describe('Sandbox api fetch should', () => {
 
   test('return valid url', async () => {
     const res = await fetch(GRAPH_API_SANDBOX_ENDPOINT_URL);


### PR DESCRIPTION
Fixes #1763 
All tests now run in under 2 minutes
### Demo
<img width="280" alt="image" src="https://user-images.githubusercontent.com/45680252/173549015-77d64d41-8cd0-4271-b0b8-4c4f75c03768.png">

### Notes
Jest takes a long time to import modules, perform necessary mocks and run the tests. More time is taken during compile time. The actual tests however, run in milliseconds.
We catch type errors early during development, and during the build step on the linter workflow. 
For instance, when we make a typo on one of the heavily used types (IQuery)
<img width="146" alt="image" src="https://user-images.githubusercontent.com/45680252/173553889-ed92a09e-2eaa-404b-8df1-6a2ca0e47da5.png">
We get type errors right on development:
<img width="682" alt="image" src="https://user-images.githubusercontent.com/45680252/173554019-7f6fd287-da37-460e-be8d-666cc31b91da.png">

Running build on the code with type errors results in the following:
<img width="584" alt="image" src="https://user-images.githubusercontent.com/45680252/173554569-0708593f-9358-4a40-a8af-646e0e435ae6.png">

Therefore type checking when running tests is an unnecessary step. To disable type checking when compiling tests and run each file as an isolated module, we set
"ts-jest":{
    isolatedModules: true
  }
This has the effect of incredibly speeding up tests.
Increasing the heap size for npm also resulted in increased speed of the tests.

## Testing Instructions

* How to test this PR
Check out this branch
Run 'npm run test'
Notice that all tests run in under 2 minutes