### PR TITLE
Sanitize sample url before sharing

### DIFF
--- a/src/app/views/query-runner/query-input/share-query/ShareQuery.tsx
+++ b/src/app/views/query-runner/query-input/share-query/ShareQuery.tsx
@@ -21,6 +21,8 @@ export const ShareQuery = () => {
   const [shareLink, setShareLink] = useState(() => createShareLink(sampleQuery));
 
   useEffect(() => {
+    const sanitizedQueryUrl = sanitizeQueryUrl(sampleQuery.sampleUrl);
+    sampleQuery.sampleUrl = sanitizedQueryUrl;
     setShareLink(createShareLink(sampleQuery));
   }, [sampleQuery]);
 


### PR DESCRIPTION
## Overview
Closes #1838 

### Demo
![image](https://user-images.githubusercontent.com/45680252/174007011-0b460574-5588-4ad3-baef-73201a3c7849.png)
Notice that the shared query has the {user-id} encoded

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
Check out this branch and run it locally
Add a url with any PII on the query textbox
Click on the share query button
Notice that the query in the share-query dialog does not contain the PII