### PR TITLE
Chore: reduce PR body content

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -61,8 +61,8 @@ jobs:
           git fetch origin master --depth 100
           git fetch origin dev --depth 100
 
-          masterPrBody=$(git rev-list --oneline $branchName ^origin/master)
-          devPrBody=$(git rev-list --oneline $branchName ^origin/dev)
+          masterPrBody=$(git rev-list v$currentVersion.. --oneline $branchName ^origin/master)
+          devPrBody=$(git rev-list v$currentVersion.. --oneline $branchName ^origin/dev)
 
           echo 'masterPrBody<<END_OF_OUTPUT' >> $GITHUB_ENV
           echo "$masterPrBody" >> $GITHUB_ENV


### PR DESCRIPTION
## Overview

The PR body is unnecessarily verbose when we are making our releases. 
This will reduce the content to what's been committed since the last tag