### PR TITLE
Fix: Center method names on sample queries

### DIFF
--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -209,7 +209,10 @@ const unstyledSampleQueries = (sampleProps?: ISampleQueriesProps): JSX.Element =
                 className={classes.badge}
                 style={{
                   background: getStyleFor(item.method),
-                  textAlign: 'center'
+                  textAlign: 'center',
+                  backgroundColor: 'red',
+                  position: 'relative',
+                  right: '5px'
                 }}
               >
                 {item.method}

--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -210,7 +210,6 @@ const unstyledSampleQueries = (sampleProps?: ISampleQueriesProps): JSX.Element =
                 style={{
                   background: getStyleFor(item.method),
                   textAlign: 'center',
-                  backgroundColor: 'red',
                   position: 'relative',
                   right: '5px'
                 }}


### PR DESCRIPTION
## Overview
Fixes #1930 

### Demo
<img width="46" alt="image" src="https://user-images.githubusercontent.com/45680252/179475068-b14cbc3e-b5d9-4798-bff1-cba6a3475957.png">
<img width="55" alt="image" src="https://user-images.githubusercontent.com/45680252/179475096-28361a50-34a0-48d1-83f1-a4772dd6c112.png">

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
Checkout this branch and run it locally
Check the method names on the sample queries tab