### PR TITLE
Task: Add missing header telemetry

### DIFF
--- a/src/app/views/authentication/Authentication.tsx
+++ b/src/app/views/authentication/Authentication.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { injectIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 import { authenticationWrapper } from '../../../modules/authentication';
-import { componentNames, errorTypes, telemetry } from '../../../telemetry';
+import { componentNames, errorTypes, eventTypes, telemetry } from '../../../telemetry';
 import { IRootState } from '../../../types/root';
 import { getAuthTokenSuccess, getConsentedScopesSuccess } from '../../services/actions/auth-action-creators';
 import { setQueryResponseStatus } from '../../services/actions/query-status-action-creator';
@@ -29,6 +29,9 @@ const Authentication = (props: any) => {
   }: any = props;
   const signIn = async (): Promise<void> => {
     setLoginInProgress(true);
+    telemetry.trackEvent(eventTypes.BUTTON_CLICK_EVENT, {
+      ComponentName: componentNames.SIGN_IN_BUTTON
+    });
 
     try {
       const authResponse = await authenticationWrapper.logIn();
@@ -65,6 +68,9 @@ const Authentication = (props: any) => {
 
   const signInWithOther = async (): Promise<void> => {
     setLoginInProgress(true);
+    telemetry.trackEvent(eventTypes.BUTTON_CLICK_EVENT, {
+      ComponentName: componentNames.SIGN_IN_WITH_OTHER_BUTTON
+    });
     try{
       const authResponse = await authenticationWrapper.logInWithOther();
       if (authResponse) {

--- a/src/app/views/authentication/Authentication.tsx
+++ b/src/app/views/authentication/Authentication.tsx
@@ -69,7 +69,7 @@ const Authentication = (props: any) => {
   const signInWithOther = async (): Promise<void> => {
     setLoginInProgress(true);
     telemetry.trackEvent(eventTypes.BUTTON_CLICK_EVENT, {
-      ComponentName: componentNames.SIGN_IN_WITH_OTHER_BUTTON
+      ComponentName: componentNames.SIGN_IN_WITH_OTHER_ACCOUNT_BUTTON
     });
     try{
       const authResponse = await authenticationWrapper.logInWithOther();

--- a/src/app/views/main-header/Help.tsx
+++ b/src/app/views/main-header/Help.tsx
@@ -61,8 +61,8 @@ export const Help = () => {
           iconName: 'Documentation'
         },
         onClick: (e: any) => telemetry.trackLinkClickEvent(
-            e.currentTarget.href,
-            componentNames.GRAPH_DOCUMENTATION_LINK)
+          e.currentTarget.href,
+          componentNames.GRAPH_DOCUMENTATION_LINK)
       },
       {
         key: 'github',

--- a/src/app/views/main-header/Help.tsx
+++ b/src/app/views/main-header/Help.tsx
@@ -88,6 +88,12 @@ export const Help = () => {
     });
   };
 
+  const trackHelpClickEvent = () => {
+    telemetry.trackEvent(eventTypes.BUTTON_CLICK_EVENT, {
+      ComponentName: componentNames.HELP_BUTTON
+    });
+  }
+
   const calloutStyles: React.CSSProperties = {
     overflowY: 'hidden'
   }
@@ -121,6 +127,7 @@ export const Help = () => {
           styles={helpButtonStyles}
           menuIconProps={{ iconName: 'Help' }}
           menuProps={menuProperties}
+          onClick={() => trackHelpClickEvent()}
         />
       </TooltipHost>
     </div>

--- a/src/app/views/main-header/Help.tsx
+++ b/src/app/views/main-header/Help.tsx
@@ -39,7 +39,7 @@ export const Help = () => {
         iconProps: {
           iconName: 'ReportWarning'
         },
-        onClick: () => trackLinkClickEvents(componentNames.REPORT_AN_ISSUE_LINK)
+        onClick: (e: any) => telemetry.trackLinkClickEvent(e.currentTarget.href, componentNames.REPORT_AN_ISSUE_LINK)
       },
       { key: 'divider_1', itemType: ContextualMenuItemType.Divider },
       {
@@ -50,7 +50,7 @@ export const Help = () => {
         iconProps: {
           iconName: 'TextDocument'
         },
-        onClick: () => trackLinkClickEvents(componentNames.GE_DOCUMENTATION_LINK)
+        onClick: (e: any) => telemetry.trackLinkClickEvent(e.currentTarget.href, componentNames.GE_DOCUMENTATION_LINK)
       },
       {
         key: 'graph-documentation',
@@ -60,7 +60,9 @@ export const Help = () => {
         iconProps: {
           iconName: 'Documentation'
         },
-        onClick: () => trackLinkClickEvents(componentNames.GRAPH_DOCUMENTATION_LINK)
+        onClick: (e: any) => telemetry.trackLinkClickEvent(
+            e.currentTarget.href,
+            componentNames.GRAPH_DOCUMENTATION_LINK)
       },
       {
         key: 'github',
@@ -76,19 +78,13 @@ export const Help = () => {
             }
           }
         },
-        onClick: () => trackLinkClickEvents(componentNames.GITHUB_LINK)
+        onClick: (e: any) => telemetry.trackLinkClickEvent(e.currentTarget.href, componentNames.GITHUB_LINK)
       }
     ];
     setItems(menuItems);
   }, [authenticated]);
 
-  const trackLinkClickEvents = (componentName: string) => {
-    telemetry.trackEvent(eventTypes.LINK_CLICK_EVENT, {
-      ComponentName: componentName
-    });
-  };
-
-  const trackHelpClickEvent = () => {
+  const trackHelpButtonClickEvent = () => {
     telemetry.trackEvent(eventTypes.BUTTON_CLICK_EVENT, {
       ComponentName: componentNames.HELP_BUTTON
     });
@@ -127,7 +123,7 @@ export const Help = () => {
           styles={helpButtonStyles}
           menuIconProps={{ iconName: 'Help' }}
           menuProps={menuProperties}
-          onClick={() => trackHelpClickEvent()}
+          onMenuClick={trackHelpButtonClickEvent}
         />
       </TooltipHost>
     </div>

--- a/src/app/views/main-header/settings/Settings.tsx
+++ b/src/app/views/main-header/settings/Settings.tsx
@@ -82,7 +82,7 @@ export const Settings: React.FunctionComponent<ISettingsProps> = () => {
     });
   };
 
-  const trackSettingsClickEvent = () => {
+  const trackSettingsButtonClickEvent = () => {
     telemetry.trackEvent(eventTypes.BUTTON_CLICK_EVENT, {
       ComponentName: componentNames.SETTINGS_BUTTON
     });
@@ -125,7 +125,7 @@ export const Settings: React.FunctionComponent<ISettingsProps> = () => {
           styles={settingsButtonStyles}
           menuIconProps={{ iconName: 'Settings' }}
           menuProps={menuProperties}
-          onClick={() => trackSettingsClickEvent()}
+          onMenuClick={trackSettingsButtonClickEvent}
         />
       </TooltipHost>
       <div>

--- a/src/app/views/main-header/settings/Settings.tsx
+++ b/src/app/views/main-header/settings/Settings.tsx
@@ -82,6 +82,12 @@ export const Settings: React.FunctionComponent<ISettingsProps> = () => {
     });
   };
 
+  const trackSettingsClickEvent = () => {
+    telemetry.trackEvent(eventTypes.BUTTON_CLICK_EVENT, {
+      ComponentName: componentNames.SETTINGS_BUTTON
+    });
+  }
+
   const calloutStyles: React.CSSProperties = {
     overflowY: 'hidden'
   }
@@ -119,6 +125,7 @@ export const Settings: React.FunctionComponent<ISettingsProps> = () => {
           styles={settingsButtonStyles}
           menuIconProps={{ iconName: 'Settings' }}
           menuProps={menuProperties}
+          onClick={() => trackSettingsClickEvent()}
         />
       </TooltipHost>
       <div>

--- a/src/telemetry/component-names.ts
+++ b/src/telemetry/component-names.ts
@@ -1,7 +1,7 @@
 // Names of instrumented components
 
 // Buttons
-export const FEEDBACK_BUTTON = 'Feedback button'
+export const FEEDBACK_BUTTON = 'Feedback button';
 export const RUN_QUERY_BUTTON = 'Run query button';
 export const THEME_CHANGE_BUTTON = 'Theme change button';
 export const SELECT_THEME_BUTTON = 'Select theme button';
@@ -20,6 +20,10 @@ export const RESPONSE_HEADERS_COPY_BUTTON = 'Response headers copy button';
 export const DOWNLOAD_POSTMAN_COLLECTION_BUTTON = 'Download postman collection button';
 export const REMOVE_RESOURCE_FROM_COLLECTION_BUTTON = 'Remove resource from collection button';
 export const QUERY_COPY_BUTTON = 'Query copy button';
+export const SETTINGS_BUTTON = 'Settings button';
+export const HELP_BUTTON = 'Help button';
+export const SIGN_IN_BUTTON = 'Sign in button';
+export const SIGN_IN_WITH_OTHER_BUTTON = 'Sign in with other button';
 
 // List items
 export const HISTORY_LIST_ITEM = 'History list item';

--- a/src/telemetry/component-names.ts
+++ b/src/telemetry/component-names.ts
@@ -23,7 +23,7 @@ export const QUERY_COPY_BUTTON = 'Query copy button';
 export const SETTINGS_BUTTON = 'Settings button';
 export const HELP_BUTTON = 'Help button';
 export const SIGN_IN_BUTTON = 'Sign in button';
-export const SIGN_IN_WITH_OTHER_BUTTON = 'Sign in with other button';
+export const SIGN_IN_WITH_OTHER_ACCOUNT_BUTTON = 'Sign in with other account button';
 
 // List items
 export const HISTORY_LIST_ITEM = 'History list item';


### PR DESCRIPTION
## Overview

Fixes #1943 
This PR adds telemetry to measure clicks on the Settings button, Help button, Sign in button and the Sign in with a different account button.