### PR TITLE
Fix: Remove expand/collapse string

### DIFF
--- a/src/app/utils/generate-groups.ts
+++ b/src/app/utils/generate-groups.ts
@@ -7,7 +7,6 @@ export function generateGroupsFromList(list: any[], property: string) : IGroup[]
   let isCollapsed = false;
   let previousCount = 0;
   let count = 0;
-  const toggleCollapse: string = isCollapsed ? 'collapsed ': 'expanded '
 
   if (!list || list.length === 0 || list.some(e => !e[property])) {
     return groups;
@@ -17,7 +16,7 @@ export function generateGroupsFromList(list: any[], property: string) : IGroup[]
     if (!map.has(listItem[property])) {
       map.set(listItem[property], true);
       count = list.filter(item => item[property] === listItem[property]).length;
-      const ariaLabel: string = listItem[property] + ' has ' + count + ' results ' + toggleCollapse;
+      const ariaLabel: string = listItem[property] + ' has ' + count + ' results ';
       if (groups.length > 0) {
         isCollapsed = true;
       }


### PR DESCRIPTION
## Overview

Fixes #1862 

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

- Turn on Narrator using ‘Win + Ctrl + Enter’ key.
- Open Graph Explorer in Edge browser.
- Navigate the left navigation pane via down arrow key,
- Observe narrator no longer mentions the expand/collapse state