### PR TITLE
Fix: Use resources as a source of truth

### DIFF
--- a/src/modules/suggestions/suggestions.ts
+++ b/src/modules/suggestions/suggestions.ts
@@ -26,6 +26,12 @@ class Suggestions implements ISuggestions {
       return localOptions;
     }
 
+    /*
+    * blocks calls to the API for path segments
+    * uses resource explorer and cache as source of truth
+    */
+    if (context === 'paths') { return null; }
+
     return this.fetchSuggestionsFromNetwork(url, api, version);
   }
 


### PR DESCRIPTION
## Overview

Fixes #1954

It prevents making calls to the API unless when fetching for query parameters