### PR TITLE
Task: Add PHP docs link telemetry

### DIFF
--- a/src/telemetry/component-names.ts
+++ b/src/telemetry/component-names.ts
@@ -70,6 +70,9 @@ export const CODE_SNIPPET_LANGUAGES = {
   },
   Powershell: {
     sdk: 'PowerShell snippet SDK link', doc: 'PowerShell snippet docs link'
+  },
+  PHP: {
+    sdk: 'PHP snippet SDK link', doc: 'PHP snippet docs link'
   }
 }
 export const GE_DOCUMENTATION_LINK = 'GE documentation link';


### PR DESCRIPTION
## Overview

Adds telemetry needed to capture clicks on the PHP docs present in the Code snippets tab
