### PR TITLE
Disable sanitization of query url when sharing query

### DIFF
--- a/src/app/views/query-runner/query-input/share-query/ShareQuery.tsx
+++ b/src/app/views/query-runner/query-input/share-query/ShareQuery.tsx
@@ -7,6 +7,7 @@ import { useSelector } from 'react-redux';
 
 import { componentNames, eventTypes, telemetry } from '../../../../../telemetry';
 import { IRootState } from '../../../../../types/root';
+import { sanitizeQueryUrl } from '../../../../utils/query-url-sanitization';
 import { translateMessage } from '../../../../utils/translate-messages';
 import { copy } from '../../../common/copy';
 import { CopyButton } from '../../../common/copy/CopyButton';
@@ -18,6 +19,8 @@ export const ShareQuery = () => {
   const { sampleQuery } = useSelector((state: IRootState) => state);
   const [showShareQueryDialog, setShareQuaryDialogStatus] = useState(true);
 
+  const query = { ...sampleQuery };
+  const sanitizedQueryUrl = sanitizeQueryUrl(query.sampleUrl);
   const shareLink = createShareLink(sampleQuery);
 
   const toggleShareQueryDialogState = () => {
@@ -33,7 +36,7 @@ export const ShareQuery = () => {
     telemetry.trackEvent(eventTypes.BUTTON_CLICK_EVENT,
       {
         ComponentName: componentNames.SHARE_QUERY_COPY_BUTTON,
-        QuerySignature: `${sampleQuery.selectedVerb} ${sampleQuery}`
+        QuerySignature: `${query.selectedVerb} ${sanitizedQueryUrl}`
       });
   }
 

--- a/src/app/views/query-runner/query-input/share-query/ShareQuery.tsx
+++ b/src/app/views/query-runner/query-input/share-query/ShareQuery.tsx
@@ -7,7 +7,6 @@ import { useSelector } from 'react-redux';
 
 import { componentNames, eventTypes, telemetry } from '../../../../../telemetry';
 import { IRootState } from '../../../../../types/root';
-import { sanitizeQueryUrl } from '../../../../utils/query-url-sanitization';
 import { translateMessage } from '../../../../utils/translate-messages';
 import { copy } from '../../../common/copy';
 import { CopyButton } from '../../../common/copy/CopyButton';
@@ -19,10 +18,7 @@ export const ShareQuery = () => {
   const { sampleQuery } = useSelector((state: IRootState) => state);
   const [showShareQueryDialog, setShareQuaryDialogStatus] = useState(true);
 
-  const query = { ...sampleQuery };
-  const sanitizedQueryUrl = sanitizeQueryUrl(query.sampleUrl);
-  query.sampleUrl = sanitizedQueryUrl;
-  const shareLink = createShareLink(query);
+  const shareLink = createShareLink(sampleQuery);
 
   const toggleShareQueryDialogState = () => {
     setShareQuaryDialogStatus(prevState => !prevState);
@@ -37,7 +33,7 @@ export const ShareQuery = () => {
     telemetry.trackEvent(eventTypes.BUTTON_CLICK_EVENT,
       {
         ComponentName: componentNames.SHARE_QUERY_COPY_BUTTON,
-        QuerySignature: `${sampleQuery.selectedVerb} ${sanitizedQueryUrl}`
+        QuerySignature: `${sampleQuery.selectedVerb} ${sampleQuery}`
       });
   }
 


### PR DESCRIPTION
## Overview
Fixes #1991 #1986 

Page no longer results in 404 when queries with 
### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
Type a query with query parameters on the query textbox
Click on the share button and copy the generated share url
Paste the url in a new tab
Notice that it no longer results in a 404