### PR TITLE
Fix: Text-alignment on the text in query response tabs

### DIFF
--- a/src/app/views/query-response/adaptive-cards/AdaptiveCard.tsx
+++ b/src/app/views/query-response/adaptive-cards/AdaptiveCard.tsx
@@ -84,7 +84,7 @@ class AdaptiveCard extends Component<IAdaptiveCardProps> {
     if (body && !pending) {
       if (!data || (queryStatus && !queryStatus.ok)) {
         return (
-          <Label className={classes.emptyStateLabel} styles={{root: this.textStyle}}>
+          <Label styles={{root: this.textStyle}}>
             <FormattedMessage id='The Adaptive Card for this response is not available' />
             &nbsp;
             <Link

--- a/src/app/views/query-response/adaptive-cards/AdaptiveCard.tsx
+++ b/src/app/views/query-response/adaptive-cards/AdaptiveCard.tsx
@@ -1,5 +1,6 @@
 import * as AdaptiveCardsAPI from 'adaptivecards';
-import { Label, Link, MessageBar, MessageBarType, Pivot, PivotItem, styled } from '@fluentui/react';
+import { getTheme, IStyle, ITheme, Label, Link,
+  MessageBar, MessageBarType, Pivot, PivotItem, styled } from '@fluentui/react';
 import React, { Component } from 'react';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
@@ -24,6 +25,9 @@ class AdaptiveCard extends Component<IAdaptiveCardProps> {
     super(props);
     this.adaptiveCard = new AdaptiveCardsAPI.AdaptiveCard();
   }
+
+  currentTheme: ITheme = getTheme();
+  textStyle = queryResponseStyles(this.currentTheme).queryResponseText.root as IStyle
 
   public componentDidMount() {
     const { body, sampleQuery, hostConfig } = this.props;
@@ -80,11 +84,10 @@ class AdaptiveCard extends Component<IAdaptiveCardProps> {
     if (body && !pending) {
       if (!data || (queryStatus && !queryStatus.ok)) {
         return (
-          <Label className={classes.emptyStateLabel}>
+          <Label className={classes.emptyStateLabel} styles={{root: this.textStyle}}>
             <FormattedMessage id='The Adaptive Card for this response is not available' />
             &nbsp;
             <Link
-              className={classes.link}
               href={'https://adaptivecards.io/designer/'}
               tabIndex={0}
               target='_blank'

--- a/src/app/views/query-response/graph-toolkit/GraphToolkit.tsx
+++ b/src/app/views/query-response/graph-toolkit/GraphToolkit.tsx
@@ -24,7 +24,7 @@ class GraphToolkit extends Component<any> {
   }
 
   currentTheme: ITheme = getTheme();
-  textStyle = queryResponseStyles(this.currentTheme).toolkitText.root as IStyle
+  textStyle = queryResponseStyles(this.currentTheme).queryResponseText.root as IStyle
 
   public render() {
     const { sampleQuery } = this.props;

--- a/src/app/views/query-response/queryResponse.styles.ts
+++ b/src/app/views/query-response/queryResponse.styles.ts
@@ -28,11 +28,10 @@ export const queryResponseStyles = (theme: ITheme) => {
       float: 'right',
       zIndex: 1
     },
-    toolkitText: {
+    queryResponseText: {
       root: {
         display: 'inline-block',
-        marginTop: '13%',
-        marginLeft: '16%'
+        marginLeft: '2%'
       }
     }
   };


### PR DESCRIPTION
## Overview

Closes #2019 

### Demo

![image](https://user-images.githubusercontent.com/34104277/184162527-fb341e84-c508-4ba3-9585-fd3df05ad524.png)

![image](https://user-images.githubusercontent.com/34104277/184162712-76bf94ea-505f-4fc0-9f14-e4f4a9c64375.png)

## Testing Instructions

* How to test this PR

- Checkout to fix/top-left-align-text and run locally
- Copy this URL (https://graph.microsoft.com/v1.0/applications?$count=true) in the query textbox
- Run the query
- Click on toolkit component and observe fix
- Click on adaptive cards and observe fix