### PR TITLE
Fix: Autoloading suggestions on  /me

### DIFF
--- a/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
+++ b/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
@@ -40,7 +40,9 @@ const AutoComplete = (props: IAutoCompleteProps) => {
   const [suggestions, setSuggestions] = useState<string[]>([]);
 
   useEffect(() => {
-    setQueryUrl(sampleQuery.sampleUrl);
+    if (previousQuery) {
+      initialiseAutoComplete(sampleQuery.sampleUrl)
+    }
   }, [sampleQuery.sampleUrl]);
 
   useEffect(() => {
@@ -59,16 +61,11 @@ const AutoComplete = (props: IAutoCompleteProps) => {
   };
 
   const initialiseAutoComplete = (currentValue: string) => {
-    console.log('Here is the query url ', currentValue)
     setQueryUrl(currentValue);
 
     if (currentValue.includes(GRAPH_URL)) {
       const { index, context } = getLastDelimiterInUrl(currentValue);
-      console.log('Here is the index ', index, ' and the context ', context);
-
-      // If url is https://graph.microsoft.com/me --> searchText=/me and prev is everything else
       const { searchText: searchWith, previous: preceedingText } = getSearchText(currentValue, index!);
-      console.log('Here is the search text ', searchWith, ' and the preceeding text ', preceedingText);
       setSearchText(searchWith);
       requestForAutocompleteOptions(preceedingText, context);
     }
@@ -155,7 +152,6 @@ const AutoComplete = (props: IAutoCompleteProps) => {
   };
 
 
-  // url here is the preceeding text: https://graph.microsoft.com/v1/me
   const requestForAutocompleteOptions = (url: string, context: SignContext) => {
     const signature = sanitizeQueryUrl(url);
     const { requestUrl, queryVersion } = parseSampleUrl(signature);
@@ -169,7 +165,7 @@ const AutoComplete = (props: IAutoCompleteProps) => {
     }
 
     const urlExistsInStore = autoCompleteOptions && requestUrl === autoCompleteOptions.url;
-    if (urlExistsInStore && shouldShowSuggestions) {
+    if (urlExistsInStore) {
       displayAutoCompleteSuggestions(autoCompleteOptions.url);
       return;
     }
@@ -187,7 +183,6 @@ const AutoComplete = (props: IAutoCompleteProps) => {
       theSuggestions = GRAPH_API_VERSIONS;
     }
     else if (autoCompleteOptions) {
-      console.log('Here are the autocomplete options ', autoCompleteOptions);
       theSuggestions = getSuggestions(url, autoCompleteOptions);
     }
 

--- a/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
+++ b/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
@@ -40,9 +40,7 @@ const AutoComplete = (props: IAutoCompleteProps) => {
   const [suggestions, setSuggestions] = useState<string[]>([]);
 
   useEffect(() => {
-    if (previousQuery) {
-      initialiseAutoComplete(sampleQuery.sampleUrl)
-    }
+    setQueryUrl(sampleQuery.sampleUrl);
   }, [sampleQuery.sampleUrl]);
 
   useEffect(() => {
@@ -61,11 +59,16 @@ const AutoComplete = (props: IAutoCompleteProps) => {
   };
 
   const initialiseAutoComplete = (currentValue: string) => {
+    console.log('Here is the query url ', currentValue)
     setQueryUrl(currentValue);
 
     if (currentValue.includes(GRAPH_URL)) {
       const { index, context } = getLastDelimiterInUrl(currentValue);
+      console.log('Here is the index ', index, ' and the context ', context);
+
+      // If url is https://graph.microsoft.com/me --> searchText=/me and prev is everything else
       const { searchText: searchWith, previous: preceedingText } = getSearchText(currentValue, index!);
+      console.log('Here is the search text ', searchWith, ' and the preceeding text ', preceedingText);
       setSearchText(searchWith);
       requestForAutocompleteOptions(preceedingText, context);
     }
@@ -152,6 +155,7 @@ const AutoComplete = (props: IAutoCompleteProps) => {
   };
 
 
+  // url here is the preceeding text: https://graph.microsoft.com/v1/me
   const requestForAutocompleteOptions = (url: string, context: SignContext) => {
     const signature = sanitizeQueryUrl(url);
     const { requestUrl, queryVersion } = parseSampleUrl(signature);
@@ -165,7 +169,7 @@ const AutoComplete = (props: IAutoCompleteProps) => {
     }
 
     const urlExistsInStore = autoCompleteOptions && requestUrl === autoCompleteOptions.url;
-    if (urlExistsInStore) {
+    if (urlExistsInStore && shouldShowSuggestions) {
       displayAutoCompleteSuggestions(autoCompleteOptions.url);
       return;
     }
@@ -183,6 +187,7 @@ const AutoComplete = (props: IAutoCompleteProps) => {
       theSuggestions = GRAPH_API_VERSIONS;
     }
     else if (autoCompleteOptions) {
+      console.log('Here are the autocomplete options ', autoCompleteOptions);
       theSuggestions = getSuggestions(url, autoCompleteOptions);
     }
 

--- a/src/app/views/query-runner/query-input/auto-complete/auto-complete.util.ts
+++ b/src/app/views/query-runner/query-input/auto-complete/auto-complete.util.ts
@@ -21,7 +21,7 @@ function getLastCharacterOf(content: string) {
 // Filter out suggestions that don't contain the user's input
 function getFilteredSuggestions(compareString: string, suggestions: string[]) {
   return suggestions.filter((suggestion: string) => {
-    return suggestion.toLowerCase().indexOf(compareString.toLowerCase()) > -1;
+    return suggestion.toLowerCase().startsWith(compareString.toLocaleLowerCase());
   });
 }
 


### PR DESCRIPTION
## Overview
Fixes #2017 

### Demo
<img width="611" alt="image" src="https://user-images.githubusercontent.com/45680252/184602928-f4776264-3618-4cf3-bae8-5dc4b9fc2104.png">
Autocomplete options do not appear for /me unless when typing on the query textbox

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
Check out this branch and run it locally
Click on 'my profile (beta)' sample
Now click on 'my profile' sample
Notice that the suggestions do not appear for these cases