### PR TITLE
Fix: Disable running queries on clicking samples

### DIFF
--- a/src/app/views/app-sections/StatusMessages.tsx
+++ b/src/app/views/app-sections/StatusMessages.tsx
@@ -47,7 +47,6 @@ const StatusMessages = () => {
   function setQuery(link: string) {
     const query: IQuery = { ...sampleQuery };
     query.sampleUrl = link;
-    query.selectedVerb = 'GET';
     dispatch(setSampleQuery(query));
   }
 

--- a/src/app/views/app-sections/StatusMessages.tsx
+++ b/src/app/views/app-sections/StatusMessages.tsx
@@ -47,6 +47,7 @@ const StatusMessages = () => {
   function setQuery(link: string) {
     const query: IQuery = { ...sampleQuery };
     query.sampleUrl = link;
+    query.selectedVerb = 'GET';
     dispatch(setSampleQuery(query));
   }
 

--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -88,10 +88,6 @@ const unstyledSampleQueries = (sampleProps?: ISampleQueriesProps): JSX.Element =
       displayTipMessage(query);
     }
 
-    if (shouldRunQuery(query)) {
-      dispatch(runQuery(sampleQuery));
-    }
-
     trackSampleQueryClickEvent(query);
     dispatch(setSampleQuery(sampleQuery));
   };
@@ -113,17 +109,6 @@ const unstyledSampleQueries = (sampleProps?: ISampleQueriesProps): JSX.Element =
       status: query.tip
     }));
   }
-
-  const shouldRunQuery = (query: ISampleQuery) => {
-    if (query.tip && tokenPresent) {
-      return false;
-    }
-    if (!tokenPresent || query.method === 'GET') {
-      return true;
-    }
-    return false;
-  }
-
 
   const renderItemColumn = (
     item: ISampleQuery,


### PR DESCRIPTION
## Overview
Closes #2035 

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

## Testing Instructions

* How to test this PR
Check out this branch and run it locally
Click on any sample query
Notice that the query is populated on the query runner area and not run
Repeat these steps for the Resources