### PR TITLE
Fix: Populate method with GET for queries selected from tips

### DIFF
--- a/src/app/views/app-sections/StatusMessages.tsx
+++ b/src/app/views/app-sections/StatusMessages.tsx
@@ -47,6 +47,7 @@ const StatusMessages = () => {
   function setQuery(link: string) {
     const query: IQuery = { ...sampleQuery };
     query.sampleUrl = link;
+    query.selectedVerb = 'GET';
     dispatch(setSampleQuery(query));
   }
 

--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -29,7 +29,6 @@ import { sidebarStyles } from '../Sidebar.styles';
 import { searchBoxStyles } from '../../../utils/searchbox.styles';
 import { fetchSamples } from '../../../services/actions/samples-action-creators';
 import { setQueryResponseStatus } from '../../../services/actions/query-status-action-creator';
-import { runQuery } from '../../../services/actions/query-action-creators';
 import { setSampleQuery } from '../../../services/actions/query-input-action-creators';
 import { translateMessage } from '../../../utils/translate-messages';
 import { NoResultsFound } from '../sidebar-utils/SearchResult';


### PR DESCRIPTION
## Overview
Fixes #2046 

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
Check out this branch and run it locally
Sign in with any account
Click on any sample that has a tip e.g., 'delete an application'
Click on the query on the status message
Notice that the method is updated