### PR TITLE
Fix: Resize query response area when zoomed out

### DIFF
--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -369,7 +369,6 @@ class App extends Component<IAppProps, IAppState> {
     let sideWidth = sidebar.width;
     let maxWidth = '50%';
     let contentWidth = content.width;
-    const contentHeight = content.height;
 
     const query = createShareLink(sampleQuery, authenticated);
     const { mobileScreen, showSidebar } = sidebarProperties;
@@ -453,15 +452,21 @@ class App extends Component<IAppProps, IAppState> {
                 }}
                 size={{
                   width: graphExplorerMode === Mode.TryIt ? '100%' : contentWidth,
-                  height: contentHeight
+                  height: ''
                 }}
-                style={!sidebarProperties.showSidebar && !mobileScreen ? { marginLeft: '8px', flex: 1 } : {flex: 1}}
+                style={!sidebarProperties.showSidebar && !mobileScreen ? {
+                  marginLeft: '8px', display:'flex', flexDirection: 'column', alignItems: 'stretch', flex: 1
+                } : {
+                  display:'flex', flexDirection: 'column', alignItems: 'stretch', flex: 1
+                }}
               >
-                <div style={{ marginBottom: 8}} >
+                <div style={{ marginBottom: 2}} >
                   <QueryRunner onSelectVerb={this.handleSelectVerb} />
                 </div>
 
-                <div>
+                <div style={{
+                  display:'flex', flexDirection: 'column', alignItems: 'stretch', flex: 1
+                }}>
                   <div style={mobileScreen ? this.statusAreaMobileStyle : this.statusAreaFullScreenStyle}>
                     <StatusMessages />
                   </div>

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -1,10 +1,10 @@
 import {
   Announced, Dialog, DialogFooter, DialogType,
   DefaultButton, FontSizes, IconButton,
-  Modal, Pivot, PivotItem, ITheme, getTheme
+  Modal, Pivot, PivotItem, getTheme, ITheme
 } from '@fluentui/react';
 import { Resizable } from 're-resizable';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, CSSProperties } from 'react';
 import { injectIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 import { componentNames, eventTypes, telemetry } from '../../../telemetry';
@@ -43,6 +43,13 @@ const QueryResponse = (props: IQueryResponseProps) => {
     intl: { messages }
   }: any = props;
 
+  const flexQueryElement: CSSProperties = {
+    display:'flex',
+    flexDirection: 'column',
+    alignItems: 'stretch',
+    flex: 1,
+    marginTop: -13
+  }
   const toggleShareQueryDialogState = () => {
     setShareQuaryDialogStatus(!showShareQueryDialog);
   };
@@ -98,14 +105,14 @@ const QueryResponse = (props: IQueryResponseProps) => {
   }
 
   return (
-    <>
+    <div style={flexQueryElement} >
       <Resizable
         style={{
-          marginBottom: 10,
-          marginTop: 10
+          marginBottom: 20,
+          marginTop: 10,
+          flex: 1
         }}
         bounds={'window'}
-        maxHeight={810}
         minHeight={350}
         size={{
           height: responseHeight,
@@ -117,7 +124,8 @@ const QueryResponse = (props: IQueryResponseProps) => {
       >
         <div className='query-response' style={{
           minHeight: 350,
-          height: '100%'
+          height: '100%',
+          flex: 1
         }}
         onScroll={onScroll}>
 
@@ -200,7 +208,7 @@ const QueryResponse = (props: IQueryResponseProps) => {
           />
         </DialogFooter>
       </Dialog>
-    </>
+    </div>
   );
 };
 

--- a/src/app/views/query-runner/request/body/RequestBody.tsx
+++ b/src/app/views/query-runner/request/body/RequestBody.tsx
@@ -4,16 +4,14 @@ import { useSelector } from 'react-redux';
 
 import { IRootState } from '../../../../../types/root';
 import { Monaco } from '../../../common';
-import { convertVhToPx } from '../../../common/dimensions/dimensions-adjustment';
 
 const RequestBody = ({ handleOnEditorChange }: any) => {
-  const { dimensions: { request: { height } }, sampleQuery } = useSelector((state: IRootState) => state);
+  const { sampleQuery } = useSelector((state: IRootState) => state);
 
   return (
     <FocusZone>
       <Monaco
         body={sampleQuery.sampleBody}
-        height={convertVhToPx(height, 60)}
         onChange={(value) => handleOnEditorChange(value)} />
     </FocusZone>
 


### PR DESCRIPTION
## Overview

Closes #1989 

### Demo

When zoomed out to 50%:
![image](https://user-images.githubusercontent.com/34104277/185303411-e025caa4-2b40-4e4f-a0ec-c6fe5201b8e3.png)

When query response area is resized:
![image](https://user-images.githubusercontent.com/34104277/185303570-75fbb632-f140-4cea-8ba8-cb780adfc948.png)

## Testing Instructions

### How to test this PR
- Checkout to this branch
- Load Graph Explorer
- Zoom out to 50% and observe fix
- Resize query response area and observe fix