### PR TITLE
Fix: Schema validation for Adaptive cards 

### DIFF
--- a/src/app/views/common/monaco/Monaco.tsx
+++ b/src/app/views/common/monaco/Monaco.tsx
@@ -1,6 +1,6 @@
 import { FocusZone } from '@fluentui/react';
-import Editor, { OnChange } from '@monaco-editor/react';
-import React from 'react';
+import Editor, { OnChange, useMonaco } from '@monaco-editor/react';
+import React, { useEffect } from 'react';
 
 import { ThemeContext } from '../../../../themes/theme-context';
 import './monaco.scss';
@@ -25,6 +25,19 @@ export function Monaco(props: IMonaco) {
     body = formatJsonStringForAllBrowsers(body);
   }
   const itemHeight = height ? height : '300px';
+
+  const monaco = useMonaco();
+  useEffect(() => {
+    if (monaco) {
+      monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+        validate: true,
+        allowComments: false,
+        schemas: [],
+        enableSchemaRequest: true,
+        schemaRequest: 'ignore'
+      });
+    }
+  }, [monaco]);
 
   return (
     <FocusZone disabled={props.extraInfoElement ? false : true}>

--- a/src/app/views/query-response/adaptive-cards/AdaptiveCard.tsx
+++ b/src/app/views/query-response/adaptive-cards/AdaptiveCard.tsx
@@ -163,7 +163,7 @@ class AdaptiveCard extends Component<IAdaptiveCardProps> {
                 <Monaco
                   language='json'
                   body={data.template}
-                  height={'800px'}
+                  height={'35vh'}
                 />
               </div>
             </PivotItem>

--- a/src/app/views/query-response/adaptive-cards/AdaptiveCard.tsx
+++ b/src/app/views/query-response/adaptive-cards/AdaptiveCard.tsx
@@ -163,7 +163,7 @@ class AdaptiveCard extends Component<IAdaptiveCardProps> {
                 <Monaco
                   language='json'
                   body={data.template}
-                  height={'35vh'}
+                  height={'800px'}
                 />
               </div>
             </PivotItem>


### PR DESCRIPTION
## Overview
Fix #2020 

### Demo

![image](https://user-images.githubusercontent.com/18407044/187174787-344317be-30b9-4f61-904d-8c5d360e38b2.png)

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Checkout branch and load GE
* Run the v1.0/me query
* Navigate to Adaptive Cards, JSON Schema tab
* Observe yellow line is no longer there