### PR TITLE
Fix: Prevent sample groups from collapsing

### DIFF
--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -4,7 +4,7 @@ import {
   GroupHeader, IColumn, Icon, IDetailsRowStyles, IGroup, Link, MessageBar, MessageBarType, SearchBox,
   SelectionMode, Spinner, SpinnerSize, styled, TooltipHost
 } from '@fluentui/react';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -53,6 +53,8 @@ const unstyledSampleQueries = (sampleProps?: ISampleQueriesProps): JSX.Element =
   };
   const classes = classNames(classProps);
 
+  const renderGroups = useRef(true);
+
   useEffect(() => {
     if (samples.queries.length === 0) {
       dispatch(fetchSamples());
@@ -62,12 +64,17 @@ const unstyledSampleQueries = (sampleProps?: ISampleQueriesProps): JSX.Element =
   }, [samples.queries, tokenPresent])
 
   useEffect(() => {
-    if (groups && groups.length === 0) {
+    if (renderGroups.current) {
+      console.log('Regenerating list')
       setGroups(generateGroupsFromList(sampleQueries, 'category'));
+      if(groups.length > 0){
+        renderGroups.current = false;
+      }
     }
   }, [sampleQueries, searchStarted]);
 
   const searchValueChanged = (_event: any, value?: string): void => {
+    renderGroups.current = true;
     setSearchStarted(searchStatus => !searchStatus);
     const { queries } = samples;
     const filteredQueries = value ? performSearch(queries, value) : queries;

--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -53,7 +53,7 @@ const unstyledSampleQueries = (sampleProps?: ISampleQueriesProps): JSX.Element =
   };
   const classes = classNames(classProps);
 
-  const renderGroups = useRef(true);
+  const shouldGenerateGroups = useRef(true);
 
   useEffect(() => {
     if (samples.queries.length === 0) {
@@ -64,17 +64,16 @@ const unstyledSampleQueries = (sampleProps?: ISampleQueriesProps): JSX.Element =
   }, [samples.queries, tokenPresent])
 
   useEffect(() => {
-    if (renderGroups.current) {
-      console.log('Regenerating list')
+    if (shouldGenerateGroups.current) {
       setGroups(generateGroupsFromList(sampleQueries, 'category'));
-      if(groups.length > 0){
-        renderGroups.current = false;
+      if(groups && groups.length > 0){
+        shouldGenerateGroups.current = false;
       }
     }
   }, [sampleQueries, searchStarted]);
 
   const searchValueChanged = (_event: any, value?: string): void => {
-    renderGroups.current = true;
+    shouldGenerateGroups.current = true;
     setSearchStarted(searchStatus => !searchStatus);
     const { queries } = samples;
     const filteredQueries = value ? performSearch(queries, value) : queries;

--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -33,7 +33,7 @@ import { setSampleQuery } from '../../../services/actions/query-input-action-cre
 import { translateMessage } from '../../../utils/translate-messages';
 import { NoResultsFound } from '../sidebar-utils/SearchResult';
 
-const unstyledSampleQueries = (sampleProps?: ISampleQueriesProps): JSX.Element => {
+const UnstyledSampleQueries = (sampleProps?: ISampleQueriesProps): JSX.Element => {
 
   const [selectedQuery, setSelectedQuery] = useState<ISampleQuery | null>(null)
   const { authToken, profile, samples } =
@@ -376,5 +376,5 @@ const unstyledSampleQueries = (sampleProps?: ISampleQueriesProps): JSX.Element =
 }
 
 // @ts-ignore
-const SampleQueries = styled(unstyledSampleQueries, sidebarStyles);
+const SampleQueries = styled(UnstyledSampleQueries, sidebarStyles);
 export default SampleQueries;

--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -4,7 +4,7 @@ import {
   GroupHeader, IColumn, Icon, IDetailsRowStyles, IGroup, Link, MessageBar, MessageBarType, SearchBox,
   SelectionMode, Spinner, SpinnerSize, styled, TooltipHost
 } from '@fluentui/react';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 


### PR DESCRIPTION
## Overview
Closes #2100 

### Demo
<img width="940" alt="image" src="https://user-images.githubusercontent.com/45680252/188463008-0f9652d3-542d-48f6-afc1-bc3255b4a069.png">


### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
Click on any sample group and select any item
Notice that the sample group does not collapse