### PR TITLE
Fix: Update wordSeparators in Monaco

### DIFF
--- a/src/app/views/common/monaco/Monaco.tsx
+++ b/src/app/views/common/monaco/Monaco.tsx
@@ -63,7 +63,7 @@ export function Monaco(props: IMonaco) {
               scrollBeyondLastLine: true,
               overviewRulerBorder: false,
               // eslint-disable-next-line no-useless-escape
-              wordSeparators:'`~!#$%^&*()=+[{]}\|;:\'",<>/?'
+              wordSeparators:'"'
             }}
             onChange={onChange}
             theme={theme === 'light' ? 'vs' : 'vs-dark'}

--- a/src/app/views/common/monaco/Monaco.tsx
+++ b/src/app/views/common/monaco/Monaco.tsx
@@ -62,7 +62,6 @@ export function Monaco(props: IMonaco) {
               renderLineHighlight: 'none',
               scrollBeyondLastLine: true,
               overviewRulerBorder: false,
-              // eslint-disable-next-line no-useless-escape
               wordSeparators:'"'
             }}
             onChange={onChange}

--- a/src/app/views/common/monaco/Monaco.tsx
+++ b/src/app/views/common/monaco/Monaco.tsx
@@ -61,10 +61,13 @@ export function Monaco(props: IMonaco) {
               showFoldingControls: 'always',
               renderLineHighlight: 'none',
               scrollBeyondLastLine: true,
-              overviewRulerBorder: false
+              overviewRulerBorder: false,
+              // eslint-disable-next-line no-useless-escape
+              wordSeparators:'`~!#$%^&*()=+[{]}\|;:\'",<>/?'
             }}
             onChange={onChange}
             theme={theme === 'light' ? 'vs' : 'vs-dark'}
+            smartSelect={{selectLeadingAndTrailingWhitespace: true}}
           />)}
         </ThemeContext.Consumer>
       </div>

--- a/src/app/views/common/monaco/Monaco.tsx
+++ b/src/app/views/common/monaco/Monaco.tsx
@@ -67,7 +67,6 @@ export function Monaco(props: IMonaco) {
             }}
             onChange={onChange}
             theme={theme === 'light' ? 'vs' : 'vs-dark'}
-            smartSelect={{selectLeadingAndTrailingWhitespace: true}}
           />)}
         </ThemeContext.Consumer>
       </div>

--- a/src/app/views/query-response/adaptive-cards/AdaptiveCard.tsx
+++ b/src/app/views/query-response/adaptive-cards/AdaptiveCard.tsx
@@ -109,7 +109,7 @@ class AdaptiveCard extends Component<IAdaptiveCardProps> {
             componentNames.JSON_SCHEMA_COPY_BUTTON, sampleQuery);
         }
         return (
-          <Pivot className='pivot-response'
+          <Pivot className='adaptive-pivot'
             onLinkClick={(pivotItem) => onPivotItemClick(sampleQuery, pivotItem)}
             styles={{ text: { fontSize: FontSizes.size14 } }}>
             <PivotItem

--- a/src/app/views/query-response/query-response.scss
+++ b/src/app/views/query-response/query-response.scss
@@ -19,6 +19,9 @@
     .unstyled-pivot button:nth-last-child(2) {
       float: none;
     }
+    .adaptive-pivot button:nth-last-child(2) {
+      float: none;
+    }
   }
 
   .default-text {


### PR DESCRIPTION
## Overview
Fixes #553 

### Demo
![image](https://user-images.githubusercontent.com/45680252/189355709-257732bf-68a3-4741-b9b3-fa1ccd4a60ae.png)
By double-clicking on the ID field, we get the whole ID

### Notes
Be default, word separators string on the Monaco editor is: '`~!@#$%^&*()-=+[{]}\\|;:\'",.<>/?. We only need " as a word separator. This makes it possible to select all fields within ""

## Testing Instructions

* How to test this PR
Run a query like /v1.0/me
Double click on the ID field
Notice that the whole ID field is selected