### PR TITLE
Task: Update doc.microsoft links to learn.microsoft

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
 
-If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://docs.microsoft.com/en-us/previous-versions/tn-archive/cc751383(v=technet.10)), please report it to us as described below.
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](<https://learn.microsoft.com/en-us/previous-versions/tn-archive/cc751383(v=technet.10)>), please report it to us as described below.
 
 ## Reporting Security Issues
 
@@ -12,19 +12,19 @@ If you believe you have found a security vulnerability in any Microsoft-owned re
 
 Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://msrc.microsoft.com/create-report).
 
-If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com). If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
 
-You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc). 
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc).
 
 Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
 
-  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
-  * Full paths of source file(s) related to the manifestation of the issue
-  * The location of the affected source code (tag/branch/commit or direct URL)
-  * Any special configuration required to reproduce the issue
-  * Step-by-step instructions to reproduce the issue
-  * Proof-of-concept or exploit code (if possible)
-  * Impact of the issue, including how an attacker might exploit the issue
+- Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+- Full paths of source file(s) related to the manifestation of the issue
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if possible)
+- Impact of the issue, including how an attacker might exploit the issue
 
 This information will help us triage your report more quickly.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4842,6 +4842,14 @@
       "requires": {
         "@types/cheerio": "*",
         "@types/react": "*"
+      },
+      "dependencies": {
+        "@types/react": {
+          "version": "17.0.30",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.30.tgz",
+          "integrity": "sha512-3Dt/A8gd3TCXi2aRe84y7cK1K8G+N9CZRDG8kDGguOKa0kf/ZkSwTmVIDPsm/KbQOVMaDJXwhBtuOXxqwdpWVg==",
+          "dev": true
+        }
       }
     },
     "@types/enzyme-adapter-react-16": {
@@ -4990,31 +4998,14 @@
       }
     },
     "@types/jsdom": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.0.tgz",
-      "integrity": "sha512-YfAchFs0yM1QPDrLm2VHe+WHGtqms3NXnXAMolrgrVP6fgBHHXy1ozAbo/dFtPNtZC/m66bPiCTWYmqp1F14gA==",
+      "version": "16.2.15",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-16.2.15.tgz",
+      "integrity": "sha512-nwF87yjBKuX/roqGYerZZM0Nv1pZDMAT5YhOHYeM/72Fic+VEqJh4nyoqoapzJnW3pUlfxPY5FhgsJtM+dRnQQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "@types/tough-cookie": "*",
-        "parse5": "^7.0.0"
-      },
-      "dependencies": {
-        "entities": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-          "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-          "dev": true
-        },
-        "parse5": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
-          "integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
-          "dev": true,
-          "requires": {
-            "entities": "^4.4.0"
-          }
-        }
+        "@types/parse5": "^6.0.3",
+        "@types/tough-cookie": "*"
       }
     },
     "@types/json-schema": {
@@ -5068,6 +5059,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+    },
+    "@types/parse5": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
+      "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==",
+      "dev": true
     },
     "@types/prettier": {
       "version": "2.6.1",
@@ -5935,13 +5932,21 @@
       "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
     },
     "acorn-globals": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
-      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+      "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
       "dev": true,
       "requires": {
-        "acorn": "^8.1.0",
-        "acorn-walk": "^8.0.2"
+        "acorn": "^7.1.1",
+        "acorn-walk": "^7.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "dev": true
+        }
       }
     },
     "acorn-import-assertions": {
@@ -5956,9 +5961,9 @@
       "dev": true
     },
     "acorn-walk": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
     },
     "adaptive-expressions": {
@@ -6636,6 +6641,12 @@
         "fill-range": "^7.0.1"
       }
     },
+    "browser-process-hrtime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
+      "dev": true
+    },
     "browserslist": {
       "version": "4.20.3",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
@@ -6674,7 +6685,7 @@
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
     "buffer-from": {
@@ -8870,7 +8881,7 @@
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
@@ -9832,7 +9843,7 @@
     "is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g=="
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE="
     },
     "is-negative-zero": {
       "version": "2.0.2",
@@ -9855,7 +9866,7 @@
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg=="
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-path-cwd": {
       "version": "2.2.0",
@@ -9892,7 +9903,7 @@
     "is-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA=="
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
     },
     "is-root": {
       "version": "2.1.0",
@@ -11171,68 +11182,54 @@
       }
     },
     "jest-environment-jsdom": {
-      "version": "29.1.2",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.1.2.tgz",
-      "integrity": "sha512-D+XNIKia5+uDjSMwL/G1l6N9MCb7LymKI8FpcLo7kkISjc/Sa9w+dXXEa7u1Wijo3f8sVLqfxdGqYtRhmca+Xw==",
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-28.1.3.tgz",
+      "integrity": "sha512-HnlGUmZRdxfCByd3GM2F100DgQOajUBzEitjGqIREcb45kGjZvRrKUdlaF6escXBdcXNl0OBh+1ZrfeZT3GnAg==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^29.1.2",
-        "@jest/fake-timers": "^29.1.2",
-        "@jest/types": "^29.1.2",
-        "@types/jsdom": "^20.0.0",
+        "@jest/environment": "^28.1.3",
+        "@jest/fake-timers": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "@types/jsdom": "^16.2.4",
         "@types/node": "*",
-        "jest-mock": "^29.1.2",
-        "jest-util": "^29.1.2",
-        "jsdom": "^20.0.0"
+        "jest-mock": "^28.1.3",
+        "jest-util": "^28.1.3",
+        "jsdom": "^19.0.0"
       },
       "dependencies": {
         "@jest/environment": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.1.2.tgz",
-          "integrity": "sha512-rG7xZ2UeOfvOVzoLIJ0ZmvPl4tBEQ2n73CZJSlzUjPw4or1oSWC0s0Rk0ZX+pIBJ04aVr6hLWFn1DFtrnf8MhQ==",
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-28.1.3.tgz",
+          "integrity": "sha512-1bf40cMFTEkKyEf585R9Iz1WayDjHoHqvts0XFYEqyKM3cFWDpeMoqKKTAF9LSYQModPUlh8FKptoM2YcMWAXA==",
           "dev": true,
           "requires": {
-            "@jest/fake-timers": "^29.1.2",
-            "@jest/types": "^29.1.2",
+            "@jest/fake-timers": "^28.1.3",
+            "@jest/types": "^28.1.3",
             "@types/node": "*",
-            "jest-mock": "^29.1.2"
+            "jest-mock": "^28.1.3"
           }
         },
         "@jest/fake-timers": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.1.2.tgz",
-          "integrity": "sha512-GppaEqS+QQYegedxVMpCe2xCXxxeYwQ7RsNx55zc8f+1q1qevkZGKequfTASI7ejmg9WwI+SJCrHe9X11bLL9Q==",
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-28.1.3.tgz",
+          "integrity": "sha512-D/wOkL2POHv52h+ok5Oj/1gOG9HSywdoPtFsRCUmlCILXNn5eIWmcnd3DIiWlJnpGvQtmajqBP95Ei0EimxfLw==",
           "dev": true,
           "requires": {
-            "@jest/types": "^29.1.2",
+            "@jest/types": "^28.1.3",
             "@sinonjs/fake-timers": "^9.1.2",
             "@types/node": "*",
-            "jest-message-util": "^29.1.2",
-            "jest-mock": "^29.1.2",
-            "jest-util": "^29.1.2"
+            "jest-message-util": "^28.1.3",
+            "jest-mock": "^28.1.3",
+            "jest-util": "^28.1.3"
           }
         },
         "@jest/schemas": {
-          "version": "29.0.0",
-          "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
-          "integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.1.3.tgz",
+          "integrity": "sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==",
           "dev": true,
           "requires": {
             "@sinclair/typebox": "^0.24.1"
-          }
-        },
-        "@jest/types": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.1.2.tgz",
-          "integrity": "sha512-DcXGtoTykQB5jiwCmVr8H4vdg2OJhQex3qPkG+ISyDO7xQXbt/4R6dowcRyPemRnkH7JoHvZuxPBdlq+9JxFCg==",
-          "dev": true,
-          "requires": {
-            "@jest/schemas": "^29.0.0",
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^17.0.8",
-            "chalk": "^4.0.0"
           }
         },
         "@sinclair/typebox": {
@@ -11282,54 +11279,40 @@
           "dev": true
         },
         "jest-message-util": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.1.2.tgz",
-          "integrity": "sha512-9oJ2Os+Qh6IlxLpmvshVbGUiSkZVc2FK+uGOm6tghafnB2RyjKAxMZhtxThRMxfX1J1SOMhTn9oK3/MutRWQJQ==",
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.1.3.tgz",
+          "integrity": "sha512-PFdn9Iewbt575zKPf1286Ht9EPoJmYT7P0kY+RibeYZ2XtOr53pDLEFoTWXbd1h4JiGiWpTBC84fc8xMXQMb7g==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
-            "@jest/types": "^29.1.2",
+            "@jest/types": "^28.1.3",
             "@types/stack-utils": "^2.0.0",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.9",
             "micromatch": "^4.0.4",
-            "pretty-format": "^29.1.2",
+            "pretty-format": "^28.1.3",
             "slash": "^3.0.0",
             "stack-utils": "^2.0.3"
           }
         },
         "jest-mock": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.1.2.tgz",
-          "integrity": "sha512-PFDAdjjWbjPUtQPkQufvniXIS3N9Tv7tbibePEjIIprzjgo0qQlyUiVMrT4vL8FaSJo1QXifQUOuPH3HQC/aMA==",
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-28.1.3.tgz",
+          "integrity": "sha512-o3J2jr6dMMWYVH4Lh/NKmDXdosrsJgi4AviS8oXLujcjpCMBb1FMsblDnOXKZKfSiHLxYub1eS0IHuRXsio9eA==",
           "dev": true,
           "requires": {
-            "@jest/types": "^29.1.2",
-            "@types/node": "*",
-            "jest-util": "^29.1.2"
-          }
-        },
-        "jest-util": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.1.2.tgz",
-          "integrity": "sha512-vPCk9F353i0Ymx3WQq3+a4lZ07NXu9Ca8wya6o4Fe4/aO1e1awMMprZ3woPFpKwghEOW+UXgd15vVotuNN9ONQ==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^29.1.2",
-            "@types/node": "*",
-            "chalk": "^4.0.0",
-            "ci-info": "^3.2.0",
-            "graceful-fs": "^4.2.9",
-            "picomatch": "^2.2.3"
+            "@jest/types": "^28.1.3",
+            "@types/node": "*"
           }
         },
         "pretty-format": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.1.2.tgz",
-          "integrity": "sha512-CGJ6VVGXVRP2o2Dorl4mAwwvDWT25luIsYhkyVQW32E4nL+TgW939J7LlKT/npq5Cpq6j3s+sy+13yk7xYpBmg==",
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
+          "integrity": "sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.0.0",
+            "@jest/schemas": "^28.1.3",
+            "ansi-regex": "^5.0.1",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           },
@@ -13472,54 +13455,40 @@
       }
     },
     "jsdom": {
-      "version": "20.0.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.1.tgz",
-      "integrity": "sha512-pksjj7Rqoa+wdpkKcLzQRHhJCEE42qQhl/xLMUKHgoSejaKOdaXEAnqs6uDNwMl/fciHTzKeR8Wm8cw7N+g98A==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-19.0.0.tgz",
+      "integrity": "sha512-RYAyjCbxy/vri/CfnjUWJQQtZ3LKlLnDqj+9XLNnJPgEGeirZs3hllKR20re8LUZ6o1b1X4Jat+Qd26zmP41+A==",
       "dev": true,
       "requires": {
-        "abab": "^2.0.6",
-        "acorn": "^8.8.0",
-        "acorn-globals": "^7.0.0",
+        "abab": "^2.0.5",
+        "acorn": "^8.5.0",
+        "acorn-globals": "^6.0.0",
         "cssom": "^0.5.0",
         "cssstyle": "^2.3.0",
-        "data-urls": "^3.0.2",
-        "decimal.js": "^10.4.1",
+        "data-urls": "^3.0.1",
+        "decimal.js": "^10.3.1",
         "domexception": "^4.0.0",
         "escodegen": "^2.0.0",
         "form-data": "^4.0.0",
         "html-encoding-sniffer": "^3.0.0",
         "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.1",
+        "https-proxy-agent": "^5.0.0",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.2",
-        "parse5": "^7.1.1",
-        "saxes": "^6.0.0",
+        "nwsapi": "^2.2.0",
+        "parse5": "6.0.1",
+        "saxes": "^5.0.1",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.2",
+        "tough-cookie": "^4.0.0",
+        "w3c-hr-time": "^1.0.2",
         "w3c-xmlserializer": "^3.0.0",
         "webidl-conversions": "^7.0.0",
         "whatwg-encoding": "^2.0.0",
         "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0",
-        "ws": "^8.9.0",
+        "whatwg-url": "^10.0.0",
+        "ws": "^8.2.3",
         "xml-name-validator": "^4.0.0"
       },
       "dependencies": {
-        "entities": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-          "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-          "dev": true
-        },
-        "parse5": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
-          "integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
-          "dev": true,
-          "requires": {
-            "entities": "^4.4.0"
-          }
-        },
         "tr46": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
@@ -13536,20 +13505,14 @@
           "dev": true
         },
         "whatwg-url": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-          "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-10.0.0.tgz",
+          "integrity": "sha512-CLxxCmdUby142H5FZzn4D8ikO1cmypvXVQktsgosNy4a4BHrDHeciBBGZhb0bNoR5/MltoCatso+vFjjGx8t0w==",
           "dev": true,
           "requires": {
             "tr46": "^3.0.0",
             "webidl-conversions": "^7.0.0"
           }
-        },
-        "ws": {
-          "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
-          "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
-          "dev": true
         }
       }
     },
@@ -13576,7 +13539,7 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "json5": {
@@ -13781,7 +13744,7 @@
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
     "lodash.merge": {
@@ -13793,7 +13756,7 @@
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -14161,7 +14124,7 @@
     "normalize-range": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA=="
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
     },
     "npm-run-path": {
       "version": "4.0.1",
@@ -14470,7 +14433,7 @@
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
     "performance-now": {
@@ -15856,9 +15819,9 @@
       }
     },
     "saxes": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
-      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
       "dev": true,
       "requires": {
         "xmlchars": "^2.2.0"
@@ -15889,9 +15852,9 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "selenium-webdriver": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.5.0.tgz",
-      "integrity": "sha512-9mSFii+lRwcnT2KUAB1kqvx6+mMiiQHH60Y0VUtr3kxxi3oZ3CV3B8e2nuJ7T4SPb+Q6VA0swswe7rYpez07Bg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.3.0.tgz",
+      "integrity": "sha512-9XFr8w95BO7jageR61AtiB83fJNem3fdtOQcUpqIIDHWSxihomyG/yBlL1H4y/shi/dO/Ai3PJMAOG+OW3+JHw==",
       "dev": true,
       "requires": {
         "jszip": "^3.10.0",
@@ -16889,6 +16852,15 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
+    "w3c-hr-time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "dev": true,
+      "requires": {
+        "browser-process-hrtime": "^1.0.0"
+      }
+    },
     "w3c-xmlserializer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-3.0.0.tgz",
@@ -17620,7 +17592,7 @@
     "yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {
         "buffer-crc32": "~0.2.3",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
                 "jest": "28.1.0",
                 "jest-environment-jsdom": "28.1.3",
                 "jest-canvas-mock": "2.4.0",
-
                 "jest-fetch-mock": "3.0.3",
                 "jest-sonar-reporter": "2.0.0",
                 "jest-watch-typeahead": "2.2.0",

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -102,9 +102,9 @@ class App extends Component<IAppProps, IAppState> {
     }
 
     const whiteListedDomains = [
-      'https://docs.microsoft.com',
-      'https://review.docs.microsoft.com',
-      'https://ppe.docs.microsoft.com',
+      'https://learn.microsoft.com',
+      'https://review.learn.microsoft.com',
+      'https://dev.learn.microsoft.com',
       'https://docs.azure.cn'
     ];
 

--- a/src/app/views/app-sections/TermsOfUseMessage.tsx
+++ b/src/app/views/app-sections/TermsOfUseMessage.tsx
@@ -26,7 +26,7 @@ const styledTermsOfUseMessage = () => {
         onClick={(e) =>
           telemetry.trackLinkClickEvent((e.currentTarget as HTMLAnchorElement).href,
             componentNames.MICROSOFT_APIS_TERMS_OF_USE_LINK)}
-        href={'https://docs.microsoft.com/' + geLocale +
+        href={'https://learn.microsoft.com/' + geLocale +
           '/legal/microsoft-apis/terms-of-use?context=graph/context'} target='_blank' rel='noopener noreferrer'>
         <FormattedMessage id='Terms of use' /></Link>.
       <FormattedMessage id='View the' />

--- a/src/app/views/main-header/Help.tsx
+++ b/src/app/views/main-header/Help.tsx
@@ -45,7 +45,7 @@ export const Help = () => {
       {
         key: 'ge-documentation',
         text: translateMessage('Get started with Graph Explorer'),
-        href: 'https://docs.microsoft.com/en-us/graph/graph-explorer/graph-explorer-overview?view=graph-rest-1.0',
+        href: 'https://learn.microsoft.com/en-us/graph/graph-explorer/graph-explorer-overview?view=graph-rest-1.0',
         target: '_blank',
         iconProps: {
           iconName: 'TextDocument'
@@ -55,7 +55,7 @@ export const Help = () => {
       {
         key: 'graph-documentation',
         text: translateMessage('Graph Documentation'),
-        href: ' https://docs.microsoft.com/en-us/graph/api/overview?view=graph-rest-1.0',
+        href: ' https://learn.microsoft.com/en-us/graph/api/overview?view=graph-rest-1.0',
         target: '_blank',
         iconProps: {
           iconName: 'Documentation'

--- a/src/app/views/query-response/adaptive-cards/AdaptiveCard.tsx
+++ b/src/app/views/query-response/adaptive-cards/AdaptiveCard.tsx
@@ -144,7 +144,7 @@ class AdaptiveCard extends Component<IAdaptiveCardProps> {
               <div id={'json-schema-tab'}>
                 <MessageBar messageBarType={MessageBarType.info}>
                   <FormattedMessage id='Get started with adaptive cards on' />
-                  <Link href={'https://docs.microsoft.com/en-us/adaptive-cards/templating/sdk'}
+                  <Link href={'https://learn.microsoft.com/en-us/adaptive-cards/templating/sdk'}
                     target='_blank'
                     rel='noopener noreferrer'
                     tabIndex={0}

--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -364,7 +364,7 @@ const UnstyledSampleQueries = (sampleProps?: ISampleQueriesProps): JSX.Element =
           rel="noopener noreferrer"
           onClick={(e) => telemetry.trackLinkClickEvent((e.currentTarget as HTMLAnchorElement).href,
             componentNames.MICROSOFT_GRAPH_API_REFERENCE_DOCS_LINK)}
-          href={`https://docs.microsoft.com/${geLocale}/graph/api/overview?view=graph-rest-1.0`}
+          href={`https://learn.microsoft.com/${geLocale}/graph/api/overview?view=graph-rest-1.0`}
         >
           <FormattedMessage id='Microsoft Graph API Reference docs' />
         </Link>

--- a/src/app/views/sidebar/sample-queries/queries.ts
+++ b/src/app/views/sidebar/sample-queries/queries.ts
@@ -7,7 +7,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'my profile',
     requestUrl: '/v1.0/me',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-get',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-get',
     skipTest: false
   },
   {
@@ -15,7 +15,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'my profile (beta)',
     requestUrl: '/beta/me/profile',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/profile-get?view=graph-rest-beta&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/profile-get?view=graph-rest-beta&tabs=http',
     skipTest: false
   },
   {
@@ -23,7 +23,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'my photo',
     requestUrl: '/v1.0/me/photo/$value',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/profilephoto-get?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/profilephoto-get?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -31,7 +31,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'my mail',
     requestUrl: '/v1.0/me/messages',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-list-messages?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-list-messages?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -39,7 +39,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'all the items in my drive',
     requestUrl: '/v1.0/me/drive/root/children',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/driveitem-list-children?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/driveitem-list-children?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -47,7 +47,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'items trending around me',
     requestUrl: '/beta/me/insights/trending',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/insights-list-trending?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/insights-list-trending?view=graph-rest-beta',
     skipTest: false
   },
   {
@@ -55,7 +55,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'my manager',
     requestUrl: '/v1.0/me/manager',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-list-manager?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-list-manager?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -64,7 +64,7 @@ export const queries: ISampleQuery[] = [
     humanName: 'my To Do task lists',
     requestUrl: '/v1.0/me/todo/lists',
     tip: 'This query requires the Tasks.ReadWrite permission',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/todo-list-lists?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/todo-list-lists?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -78,7 +78,7 @@ export const queries: ISampleQuery[] = [
         'value': 'eventual'
       }
     ],
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-list?view=graph-rest-beta&tabs=http#example-6-get-only-a-count-of-users',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-list?view=graph-rest-beta&tabs=http#example-6-get-only-a-count-of-users',
     tip: 'You are using the advanced query capabilities for Directory Objects, please send us feedback here: https://aka.ms/aadmgs',
     skipTest: false
   },
@@ -87,7 +87,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'my direct reports',
     requestUrl: '/v1.0/me/directReports',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-list-directreports?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-list-directreports?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -95,7 +95,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'all users in the organization',
     requestUrl: '/v1.0/users',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/users?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/users?view=graph-rest-1.0',
     tip: 'We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/UsersAPIFeedback',
     skipTest: false
   },
@@ -104,7 +104,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'all guest users in the organization',
     requestUrl: '/v1.0/users/?$filter=userType eq \'guest\'',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/users?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/users?view=graph-rest-1.0',
     tip: 'We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/UsersAPIFeedback',
     skipTest: false
   },
@@ -113,7 +113,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'count the guest users in your organization',
     requestUrl: '/v1.0/users/$count?$filter=userType eq \'guest\'',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-list?view=graph-rest-beta&tabs=http#example-6-get-only-a-count-of-users',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-list?view=graph-rest-beta&tabs=http#example-6-get-only-a-count-of-users',
     tip: 'We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/UsersAPIFeedback',
     skipTest: false
   },
@@ -128,7 +128,7 @@ export const queries: ISampleQuery[] = [
         'value': 'eventual'
       }
     ],
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/users?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/users?view=graph-rest-1.0',
     tip: 'You are using the advanced query capabilities for Directory Objects, please send us feedback here: https://aka.ms/aadmgs',
     skipTest: false
   },
@@ -143,7 +143,7 @@ export const queries: ISampleQuery[] = [
         'value': 'eventual'
       }
     ],
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/users?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/users?view=graph-rest-1.0',
     tip: 'You are using the advanced query capabilities for Directory Objects, please send us feedback here: https://aka.ms/aadmgs',
     skipTest: false
   },
@@ -152,7 +152,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'me',
     requestUrl: '/v1.0/me',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0',
     tip: 'We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/UsersAPIFeedback',
     skipTest: false
   },
@@ -161,7 +161,7 @@ export const queries: ISampleQuery[] = [
     method: 'PATCH',
     humanName: 'me',
     requestUrl: '/v1.0/me',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-update?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-update?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -177,7 +177,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'my skills',
     requestUrl: '/v1.0/me/?$select=displayName,skills',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -185,7 +185,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'user by email',
     requestUrl: '/v1.0/users/{user-mail}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0',
     tip: 'We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/UsersAPIFeedback',
     skipTest: false
   },
@@ -194,7 +194,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'user identities',
     requestUrl: '/v1.0/users/{id}/identities',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0',
     tip: 'We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/UsersAPIFeedback. You can also use \'userPrincipalName\' in place of \'id\'',
     skipTest: false
   },
@@ -203,7 +203,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'all my Planner tasks',
     requestUrl: '/beta/me/planner/tasks',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/planner-overview?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/planner-overview?view=graph-rest-beta',
     skipTest: false
   },
   {
@@ -211,7 +211,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create user',
     requestUrl: '/v1.0/users',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-post-users?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-post-users?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -227,7 +227,7 @@ export const queries: ISampleQuery[] = [
     method: 'PATCH',
     humanName: 'update user',
     requestUrl: '/v1.0/users/{id}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-update?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-update?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -243,7 +243,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'track user changes',
     requestUrl: '/v1.0/users/delta?$select=displayName,givenName,surname',
-    docLink: 'https://docs.microsoft.com/en-us/graph/delta-query-users',
+    docLink: 'https://learn.microsoft.com/en-us/graph/delta-query-users',
     skipTest: false
   },
   {
@@ -251,7 +251,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get my presence ',
     requestUrl: '/beta/me/presence',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/presence-get?view=graph-rest-beta&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/presence-get?view=graph-rest-beta&tabs=http',
     tip: 'This query requires Presence.Read permissions',
     skipTest: false
   },
@@ -260,7 +260,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get a user\'s presence ',
     requestUrl: '/beta/users/{user-id}/presence',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/cloudcommunications-getpresencesbyuserid?view=graph-rest-beta&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/cloudcommunications-getpresencesbyuserid?view=graph-rest-beta&tabs=http',
     tip: 'This query requires a user ID and the Presence.Read.All permission. Use the following call to get a user ID:  GET https://graph.microsoft.com/v1.0/users',
     skipTest: false
   },
@@ -269,7 +269,7 @@ export const queries: ISampleQuery[] = [
     method: 'DELETE',
     humanName: 'delete user',
     requestUrl: '/v1.0/users/{id}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-delete?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-delete?view=graph-rest-1.0',
     tip: 'We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/UsersAPIFeedback. You can also use \'userPrincipalName\' in place of \'id\'',
     skipTest: false
   },
@@ -278,7 +278,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'list all groups in my organization',
     requestUrl: '/v1.0/groups',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/group-list?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/group-list?view=graph-rest-1.0&tabs=http',
     tip: 'Please provide us with feedback on the groups API here: https://aka.ms/GroupsAPIFeedback',
     skipTest: false
   },
@@ -287,7 +287,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get properties and relationships of group',
     requestUrl: '/v1.0/groups/{group-id}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/group-get?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/group-get?view=graph-rest-1.0&tabs=http',
     tip: 'Please provide us with feedback on the groups API here: https://aka.ms/GroupsAPIFeedback. To get group-id run https://graph.microsoft.com/v1.0/groups/',
     skipTest: false
   },
@@ -296,7 +296,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create a new group',
     requestUrl: '/v1.0/groups',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/group-post-groups?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/group-post-groups?view=graph-rest-1.0&tabs=http',
     headers: [
       {
         'name': 'Content-type',
@@ -312,7 +312,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'add member to group',
     requestUrl: '/v1.0/groups/{group-id}/members/$ref',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/group-post-members?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/group-post-members?view=graph-rest-1.0&tabs=http',
     headers: [
       {
         'name': 'Content-type',
@@ -328,7 +328,7 @@ export const queries: ISampleQuery[] = [
     method: 'DELETE',
     humanName: 'remove member from group',
     requestUrl: '/v1.0/groups/{group-id}/members/{member-id}/$ref',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/group-delete-members?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/group-delete-members?view=graph-rest-1.0&tabs=http',
     tip: 'Please provide us with feedback on the groups API here: https://aka.ms/GroupsAPIFeedback. To get group-id run https://graph.microsoft.com/v1.0/groups/. To get member-id https://graph.microsoft.com/v1.0/groups/{id}/members',
     skipTest: false
   },
@@ -337,7 +337,7 @@ export const queries: ISampleQuery[] = [
     method: 'DELETE',
     humanName: 'delete group',
     requestUrl: '/v1.0/groups/{group-id}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/group-delete?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/group-delete?view=graph-rest-1.0&tabs=http',
     tip: 'Please provide us with feedback on the groups API here: https://aka.ms/GroupsAPIFeedback. To get group-id run https://graph.microsoft.com/v1.0/groups/',
     skipTest: false
   },
@@ -352,7 +352,7 @@ export const queries: ISampleQuery[] = [
         'value': 'eventual'
       }
     ],
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-list-memberof?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-list-memberof?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -366,7 +366,7 @@ export const queries: ISampleQuery[] = [
         'value': 'eventual'
       }
     ],
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/group-list-members?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/group-list-members?view=graph-rest-1.0',
     tip: 'This query requires a group id.  To find the ID of a group you belong to, you can run: GET https://graph.microsoft.com/v1.0/me/memberOf',
     skipTest: false
   },
@@ -375,7 +375,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'group\'s conversations',
     requestUrl: '/v1.0/groups/{group-id}/conversations',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/group-list-conversations?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/group-list-conversations?view=graph-rest-1.0',
     tip: 'This query requires a group id.  To find the ID of a group you belong to, you can run: GET https://graph.microsoft.com/v1.0/me/memberOf',
     skipTest: false
   },
@@ -384,7 +384,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'group\'s events',
     requestUrl: '/v1.0/groups/{group-id}/events',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/group-list-events?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/group-list-events?view=graph-rest-1.0',
     tip: 'This query requires a group id.  To find the ID of a group you belong to, you can run: GET https://graph.microsoft.com/v1.0/me/memberOf',
     skipTest: false
   },
@@ -393,7 +393,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'add favorite group',
     requestUrl: '/v1.0/groups/{group-id}/addFavorite',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/group-addfavorite?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/group-addfavorite?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -408,7 +408,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'items in a group drive',
     requestUrl: '/v1.0/groups/{group-id}/drive/items/root/children',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/driveitem-list-children?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/driveitem-list-children?view=graph-rest-1.0&tabs=http',
     tip: 'This query requires a group id.  To find the ID of a group you belong to, you can run: GET https://graph.microsoft.com/v1.0/me/memberOf',
     skipTest: false
   },
@@ -417,7 +417,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'track group changes',
     requestUrl: '/v1.0/groups/delta?$select=displayName,description',
-    docLink: 'https://docs.microsoft.com/en-us/graph/delta-query-groups',
+    docLink: 'https://learn.microsoft.com/en-us/graph/delta-query-groups',
     skipTest: false
   },
   {
@@ -425,7 +425,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'my high important mail',
     requestUrl: '/v1.0/me/messages?$filter=importance eq \'high\'',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-list-messages?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-list-messages?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -433,7 +433,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'my mails from an address',
     requestUrl: '/v1.0/me/messages?$filter=(from/emailAddress/address) eq \'{user-mail}\'',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-list-messages?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-list-messages?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -441,7 +441,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'my mail that has \'Hello World\'',
     requestUrl: '/v1.0/me/messages?$search="hello world"',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-list-messages?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-list-messages?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -449,7 +449,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'send an email',
     requestUrl: '/v1.0/me/sendMail',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-sendmail?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-sendmail?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -465,7 +465,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'forward mail',
     requestUrl: '/v1.0/me/messages/{message-id}/forward',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/message-forward?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/message-forward?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -481,7 +481,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'track email changes',
     requestUrl: '/v1.0/me/mailFolders/Inbox/messages/delta',
-    docLink: 'https://docs.microsoft.com/en-us/graph/delta-query-messages',
+    docLink: 'https://learn.microsoft.com/en-us/graph/delta-query-messages',
     skipTest: false
   },
   {
@@ -489,7 +489,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'my inbox rules',
     requestUrl: '/beta/me/mailFolders/inbox/messagerules',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/messagerule?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/messagerule?view=graph-rest-beta',
     skipTest: false
   },
   {
@@ -497,7 +497,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'my outlook categories',
     requestUrl: '/beta/me/outlook/masterCategories',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/outlookuser-list-mastercategories?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/outlookuser-list-mastercategories?view=graph-rest-beta',
     skipTest: false
   },
   {
@@ -505,7 +505,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get email headers',
     requestUrl: '/beta/me/messages?$select=internetMessageHeaders&$top=1',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/message?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/message?view=graph-rest-beta',
     skipTest: false
   },
   {
@@ -513,7 +513,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'list conference rooms',
     requestUrl: '/beta/me/findRooms',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-findrooms?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-findrooms?view=graph-rest-beta',
     skipTest: false
   },
   {
@@ -521,7 +521,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'email I\'m @ mentioned',
     requestUrl: '/beta/me/messages?$filter=mentionsPreview/isMentioned eq true&$select=subject,sender,receivedDateTime',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-list-messages?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-list-messages?view=graph-rest-beta',
     skipTest: false
   },
   {
@@ -529,7 +529,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'my events for the next week',
     requestUrl: '/v1.0/me/calendarview?startdatetime={today}&enddatetime={next-week}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-list-calendarview?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-list-calendarview?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -537,7 +537,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'all events in my calendar',
     requestUrl: '/v1.0/me/events?$select=subject,body,bodyPreview,organizer,attendees,start,end,location',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-list-events?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-list-events?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -545,7 +545,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'all my calendars',
     requestUrl: '/v1.0/me/calendars',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-list-calendars?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-list-calendars?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -553,7 +553,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'find meeting time',
     requestUrl: '/v1.0/me/findMeetingTimes',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-findmeetingtimes?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-findmeetingtimes?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -569,7 +569,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'schedule a meeting',
     requestUrl: '/v1.0/me/events',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-post-events?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-post-events?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -585,7 +585,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'add graph community call',
     requestUrl: '/v1.0/me/events',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-post-events?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-post-events?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -601,7 +601,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'track changes on my events for the next week',
     requestUrl: '/v1.0/me/calendarView/delta?startDateTime={today}&endDateTime={next-week}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/delta-query-events',
+    docLink: 'https://learn.microsoft.com/en-us/graph/delta-query-events',
     tip: 'This query uses date and time parameters. Use an ISO 8601 format. For example, "2017-04-30T19:00:00.0000000".',
     skipTest: false
   },
@@ -610,7 +610,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'my contacts',
     requestUrl: '/v1.0/me/contacts',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-list-contacts?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-list-contacts?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -618,7 +618,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'add contact',
     requestUrl: '/v1.0/me/contacts',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-post-contacts?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-post-contacts?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -634,7 +634,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'all the items in my drive',
     requestUrl: '/v1.0/me/drive/root/children',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/driveitem-list-children?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/driveitem-list-children?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -642,7 +642,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'my recent files',
     requestUrl: '/v1.0/me/drive/recent',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/drive-recent?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/drive-recent?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -650,7 +650,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'files shared with me',
     requestUrl: '/v1.0/me/drive/sharedWithMe',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/drive-sharedwithme?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/drive-sharedwithme?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -658,7 +658,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'search my OneDrive',
     requestUrl: '/v1.0/me/drive/root/search(q=\'finance\')?select=name,id,webUrl',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/driveitem-search?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/driveitem-search?view=graph-rest-1.0&tabs=http',
     skipTest: false
   },
   {
@@ -666,7 +666,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create a folder',
     requestUrl: '/v1.0/me/drive/root/children',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/driveitem-post-children?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/driveitem-post-children?view=graph-rest-1.0&tabs=http',
     headers: [
       {
         'name': 'Content-type',
@@ -682,7 +682,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create session',
     requestUrl: '/v1.0/me/drive/items/{drive-item-id}/workbook/createSession',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/excel?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/excel?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -698,7 +698,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'worksheets in a workbook',
     requestUrl: '/v1.0/me/drive/items/{drive-item-id}/workbook/worksheets',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/workbook-list-worksheets?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/workbook-list-worksheets?view=graph-rest-1.0',
     tip: 'This query requires a driveItem id.  To find the ID of the driveItem that corresponds to an Excel Workbook, you can run: GET https://graph.microsoft.com/v1.0/me/drive/root/search(q=\'.xlsx\')?select=name,id,webUrl.',
     skipTest: false
   },
@@ -707,7 +707,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'add a new worksheet',
     requestUrl: '/v1.0/me/drive/items/{drive-item-id}/workbook/worksheets',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/worksheetcollection-add?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/worksheetcollection-add?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -723,7 +723,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'calculate loan payment',
     requestUrl: '/v1.0/me/drive/items/{drive-item-id}/workbook/functions/pmt',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/workbook#functions?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/workbook#functions?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -739,7 +739,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'used range in worksheet',
     requestUrl: '/v1.0/me/drive/items/{drive-item-id}/workbook/worksheets(\'Sheet1\')/usedRange',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/worksheet-usedrange?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/worksheet-usedrange?view=graph-rest-1.0',
     tip: 'This query requires a driveItem id.  To find the ID of the driveItem that corresponds to an Excel Workbook, you can run: GET https://graph.microsoft.com/v1.0/me/drive/root/search(q=\'.xlsx\')?select=name,id,webUrl.',
     skipTest: false
   },
@@ -748,7 +748,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'tables in worksheet',
     requestUrl: '/v1.0/me/drive/items/{drive-item-id}/workbook/worksheets/Sheet1/tables',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/worksheet-list-tables?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/worksheet-list-tables?view=graph-rest-1.0',
     tip: 'This query requires a driveItem id.  To find the ID of the driveItem that corresponds to an Excel Workbook, you can run: GET https://graph.microsoft.com/v1.0/me/drive/root/search(q=\'.xlsx\')?select=name,id,webUrl.',
     skipTest: false
   },
@@ -757,7 +757,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'charts in worksheet',
     requestUrl: '/v1.0/me/drive/items/{drive-item-id}/workbook/worksheets(\'Sheet1\')/charts',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/worksheet-list-charts?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/worksheet-list-charts?view=graph-rest-1.0',
     tip: 'This query requires a driveItem id.  To find the ID of the driveItem that corresponds to an Excel Workbook, you can run: GET https://graph.microsoft.com/v1.0/me/drive/root/search(q=\'.xlsx\')?select=name,id,webUrl.',
     skipTest: false
   },
@@ -766,7 +766,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'all Planner plans associated with a group',
     requestUrl: '/v1.0/groups/{group-id-with-plan}/planner/plans',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/plannergroup-list-plans?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/plannergroup-list-plans?view=graph-rest-1.0',
     tip: 'This query requires a group id.  To find the ID of a group you belong to, you can run: GET https://graph.microsoft.com/v1.0/me/memberOf',
     skipTest: false
   },
@@ -775,7 +775,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get Planner plan',
     requestUrl: '/v1.0/planner/plans/{plan-id}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/plannerplan-get?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/plannerplan-get?view=graph-rest-1.0',
     tip: 'This query requires a plan id.  To find the ID of the plan you can run: GET https://graph.microsoft.com/v1.0/me/groups/{group-id}/plans.',
     skipTest: false
   },
@@ -784,7 +784,7 @@ export const queries: ISampleQuery[] = [
     method: 'PATCH',
     humanName: 'update a Planner plan',
     requestUrl: '/v1.0/planner/plans/{plan-id}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/plannerplan-update?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/plannerplan-update?view=graph-rest-1.0',
     headers: [
       {
         'name': 'If-Match',
@@ -800,7 +800,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'all buckets in Planner plan',
     requestUrl: '/v1.0/planner/plans/{plan-id}/buckets',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/plannerplan-list-buckets?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/plannerplan-list-buckets?view=graph-rest-1.0',
     tip: 'This query requires a plan id.  To find the ID of the plan you can run: GET https://graph.microsoft.com/v1.0/me/groups/{group-id}/plans.',
     skipTest: false
   },
@@ -809,7 +809,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create a bucket in Planner plan',
     requestUrl: '/v1.0/planner/buckets',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/planner-post-buckets?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/planner-post-buckets?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -825,7 +825,7 @@ export const queries: ISampleQuery[] = [
     method: 'PATCH',
     humanName: 'update a bucket in Planner plan',
     requestUrl: '/v1.0/planner/buckets/{bucket-id}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/plannerbucket-update?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/plannerbucket-update?view=graph-rest-1.0',
     headers: [
       {
         'name': 'If-Match',
@@ -841,7 +841,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'all Planner tasks for a plan',
     requestUrl: '/v1.0/planner/plans/{plan-id}/tasks',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/plannerplan-list-tasks?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/plannerplan-list-tasks?view=graph-rest-1.0',
     tip: 'This query requires a plan id.  To find the ID of the plan you can run: GET https://graph.microsoft.com/v1.0/me/groups/{group-id}/plans.',
     skipTest: false
   },
@@ -850,7 +850,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'all my Planner tasks',
     requestUrl: '/v1.0/me/planner/tasks',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/planneruser-list-tasks',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/planneruser-list-tasks',
     skipTest: false
   },
   {
@@ -858,7 +858,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'all Planner tasks for user',
     requestUrl: '/v1.0/users/{coworker-mail}/planner/tasks',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/planneruser-list-tasks?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/planneruser-list-tasks?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -866,7 +866,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get Planner task by id',
     requestUrl: '/v1.0/planner/tasks/{task-id}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/plannertask-get?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/plannertask-get?view=graph-rest-1.0',
     tip: 'This query requires a task id.  To find the ID of the task you can run: GET https://graph.microsoft.com/v1.0/me/planner/tasks',
     skipTest: false
   },
@@ -875,7 +875,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create a Planner task',
     requestUrl: '/v1.0/planner/tasks',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/planner-post-tasks?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/planner-post-tasks?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -891,7 +891,7 @@ export const queries: ISampleQuery[] = [
     method: 'PATCH',
     humanName: 'update a Planner task',
     requestUrl: '/v1.0/planner/tasks/{task-id}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/plannertask-update?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/plannertask-update?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-Type',
@@ -907,7 +907,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'details for Planner task',
     requestUrl: '/v1.0/planner/tasks/{task-id}/details',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/plannertaskdetails-get?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/plannertaskdetails-get?view=graph-rest-1.0',
     tip: 'This query requires a task id.  To find the ID of the task you can run: GET https://graph.microsoft.com/v1.0/me/planner/tasks',
     skipTest: false
   },
@@ -916,7 +916,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'my recent files',
     requestUrl: '/v1.0/me/drive/recent',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/drive-recent?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/drive-recent?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -924,7 +924,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'items trending around me',
     requestUrl: '/v1.0/me/insights/trending',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/insights-list-trending?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/insights-list-trending?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -932,7 +932,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'items shared with me',
     requestUrl: '/v1.0/me/insights/shared',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/insights-list-shared?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/insights-list-shared?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -940,7 +940,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'items viewed and modified by me',
     requestUrl: '/v1.0/me/insights/used',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/insights-list-used?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/insights-list-used?view=graph-rest-1.0&tabs=http',
     skipTest: false
   },
   {
@@ -948,7 +948,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'people I work with',
     requestUrl: '/v1.0/me/people',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-list-people?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-list-people?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -956,7 +956,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'people whose name starts with J',
     requestUrl: '/v1.0/me/people/?$search=j',
-    docLink: 'https://docs.microsoft.com/en-us/graph/people-example',
+    docLink: 'https://learn.microsoft.com/en-us/graph/people-example',
     skipTest: false
   },
   {
@@ -964,7 +964,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get an open extension',
     requestUrl: '/v1.0/me?$select=id,displayName,mail,mobilePhone&$expand=extensions',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/opentypeextension?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/opentypeextension?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -972,7 +972,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create an open extension',
     requestUrl: '/v1.0/me/extensions',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/opentypeextension-post-opentypeextension?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/opentypeextension-post-opentypeextension?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -987,7 +987,7 @@ export const queries: ISampleQuery[] = [
     method: 'PATCH',
     humanName: 'update an open extension',
     requestUrl: '/v1.0/me/extensions/{extension-id}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/opentypeextension-update?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/opentypeextension-update?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-Type',
@@ -1002,7 +1002,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get available schema extensions',
     requestUrl: '/v1.0/schemaExtensions',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/schemaextension-get?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/schemaextension-get?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -1010,7 +1010,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'filter groups by extension property value',
     requestUrl: '/v1.0/groups?$filter=adatumisv_courses/id eq \'123\'&$select=id,displayName,adatumisv_courses',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/schemaextension-post-schemaextensions?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/schemaextension-post-schemaextensions?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -1018,7 +1018,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create a group with extension data',
     requestUrl: '/v1.0/groups',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/schemaextension-post-schemaextensions?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/schemaextension-post-schemaextensions?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -1033,7 +1033,7 @@ export const queries: ISampleQuery[] = [
     method: 'PATCH',
     humanName: 'update a group with extension data',
     requestUrl: '/v1.0/groups/{group-id}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/schemaextension-post-schemaextensions?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/schemaextension-post-schemaextensions?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-Type',
@@ -1048,7 +1048,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'my notebooks',
     requestUrl: '/v1.0/me/onenote/notebooks',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/onenote?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/onenote?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -1056,7 +1056,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'my sections',
     requestUrl: '/v1.0/me/onenote/sections',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/section?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/section?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -1064,7 +1064,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'my pages',
     requestUrl: '/v1.0/me/onenote/pages',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/section-list-pages?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/section-list-pages?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -1072,7 +1072,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create notebook',
     requestUrl: '/v1.0/me/onenote/notebooks',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/onenote-post-notebooks?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/onenote-post-notebooks?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -1088,7 +1088,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create section',
     requestUrl: '/v1.0/me/onenote/notebooks/{notebook-id}/sections',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/notebook-post-sections?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/notebook-post-sections?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -1104,7 +1104,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create page',
     requestUrl: '/v1.0/me/onenote/sections/{section-id}/pages',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/section-post-pages?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/section-post-pages?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -1120,7 +1120,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'my organization\'s default SharePoint site',
     requestUrl: '/v1.0/sites/root',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/site-get?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/site-get?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -1128,7 +1128,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'enumerate the document libraries under the root site',
     requestUrl: '/v1.0/sites/root/drives',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/drive-list#list-a-sites-drives?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/drive-list#list-a-sites-drives?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -1136,7 +1136,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get SharePoint site based on relative path of the site',
     requestUrl: '/v1.0/sites/{host-name}:/{server-relative-path}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/site-getbypath?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/site-getbypath?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -1144,7 +1144,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'search for a SharePoint site by keyword',
     requestUrl: '/v1.0/sites?search=contoso',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/site-search?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/site-search?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -1152,7 +1152,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'enumerate subsites of the root site',
     requestUrl: '/v1.0/sites/root/sites',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/site-list-subsites?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/site-list-subsites?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -1160,7 +1160,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'enumerate site columns of the root site',
     requestUrl: '/v1.0/sites/root/columns',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/site?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/site?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -1168,7 +1168,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'enumerate site content types of the root site',
     requestUrl: '/v1.0/sites/root/contentTypes',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/site?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/site?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -1176,7 +1176,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'enumerate the lists in the root site',
     requestUrl: '/v1.0/sites/root/lists',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/list-list?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/list-list?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -1184,7 +1184,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'enumerate list columns',
     requestUrl: '/v1.0/sites/root/lists/{list-id}/columns',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/listitem?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/listitem?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -1192,7 +1192,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'enumerate list content types',
     requestUrl: '/v1.0/sites/root/lists/{list-id}/contentTypes',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/listitem?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/listitem?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -1200,7 +1200,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'enumerate the list items in a list',
     requestUrl: '/v1.0/sites/root/lists/{list-id}/items',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/listitem-list?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/listitem-list?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -1208,7 +1208,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'enumerate list items with specific column values',
     requestUrl: '/v1.0/sites/root/lists/{list-id}/items?$filter=fields/Title eq \'{list-title}\'',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/listitem-list?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/listitem-list?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Prefer',
@@ -1222,7 +1222,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'perform parallel GETs',
     requestUrl: '/v1.0/$batch',
-    docLink: 'https://docs.microsoft.com/en-us/graph/json-batching',
+    docLink: 'https://learn.microsoft.com/en-us/graph/json-batching',
     headers: [
       {
         'name': 'Content-type',
@@ -1238,7 +1238,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'combine a POST and a GET',
     requestUrl: '/v1.0/$batch',
-    docLink: 'https://docs.microsoft.com/en-us/graph/json-batching',
+    docLink: 'https://learn.microsoft.com/en-us/graph/json-batching',
     headers: [
       {
         'name': 'Content-type',
@@ -1254,7 +1254,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create team',
     requestUrl: '/v1.0/teams',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/team-post?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/team-post?view=graph-rest-1.0&tabs=http',
     headers: [
       {
         'name': 'Content-Type',
@@ -1269,7 +1269,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'my joined teams',
     requestUrl: '/v1.0/me/joinedTeams',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-list-joinedteams?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-list-joinedteams?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -1277,7 +1277,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'members of a team',
     requestUrl: '/v1.0/groups/{group-id-for-teams}/members',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/group-list-memberof?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/group-list-memberof?view=graph-rest-1.0',
     tip: 'This query requires a group id of the Team.  To find the group id of teams you belong to, you can run: GET https://graph.microsoft.com/v1.0/me/joinedTeams',
     skipTest: false
   },
@@ -1286,7 +1286,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'channels of a team which I am member of',
     requestUrl: '/v1.0/teams/{team-id}/channels',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/channel-list?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/channel-list?view=graph-rest-1.0',
     tip: 'This query requires a team id.  To find the team id of teams you belong to, you can run: GET https://graph.microsoft.com/v1.0/me/joinedTeams',
     skipTest: false
   },
@@ -1295,7 +1295,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'channel info',
     requestUrl: '/v1.0/teams/{team-id}/channels/{channel-id}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/channel-get?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/channel-get?view=graph-rest-1.0',
     tip: 'This query requires a team id and a channel id from that team. To find the team id  & channel id, you can run: 1) GET https://graph.microsoft.com/v1.0/me/joinedTeams 2) GET https://graph.microsoft.com/v1.0/teams/{team-id}/channels',
     skipTest: false
   },
@@ -1304,7 +1304,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create channel',
     requestUrl: '/v1.0/teams/{team-id}/channels',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/channel-post?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/channel-post?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -1320,7 +1320,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'apps in a team',
     requestUrl: '/v1.0/teams/{team-id}/installedApps?$expand=teamsAppDefinition',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/team-list-installedapps?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/team-list-installedapps?view=graph-rest-1.0',
     tip: 'This query requires a team id. To find the team id, you can run: GET https://graph.microsoft.com/v1.0/me/joinedTeams',
     skipTest: false
   },
@@ -1329,7 +1329,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'tabs in a channel',
     requestUrl: '/v1.0/teams/{team-id}/channels/{channel-id}/tabs?$expand=teamsApp',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/channel-list-tabs?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/channel-list-tabs?view=graph-rest-1.0',
     tip: 'This query requires a team id and a channel id from that team. To find the team id  & channel id, you can run: 1) GET https://graph.microsoft.com/v1.0/me/joinedTeams 2) GET https://graph.microsoft.com/v1.0/teams/{team-id}/channels',
     skipTest: false
   },
@@ -1338,7 +1338,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'items in a team drive',
     requestUrl: '/v1.0/groups/{group-id-for-teams}/drive/items/root/children',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/driveitem-list-children?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/driveitem-list-children?view=graph-rest-1.0&tabs=http',
     tip: 'This query requires a group id of the Team.  To find the group id of Teams you belong to, you can run: GET https://graph.microsoft.com/v1.0/me/joinedTeams',
     skipTest: false
   },
@@ -1347,7 +1347,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create chat',
     requestUrl: '/v1.0/chats',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/chat-post?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/chat-post?view=graph-rest-1.0&tabs=http',
     headers: [
       {
         'name': 'Content-Type',
@@ -1363,7 +1363,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'messages (without replies) in a channel',
     requestUrl: '/beta/teams/{group-id-for-teams}/channels/{channel-id}/messages',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/channel-list-messages?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/channel-list-messages?view=graph-rest-beta',
     tip: 'This query requires a group id of the Team and channel id of the corresponding channel of that Team. To find the group id  & channel id, you can run: 1) GET https://graph.microsoft.com/beta/me/joinedTeams 2) GET https://graph.microsoft.com/beta/groups/{group-id-for-teams}/channels',
     skipTest: false
   },
@@ -1372,7 +1372,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'message in a channel',
     requestUrl: '/beta/teams/{group-id-for-teams}/channels/{channel-id}/messages/{message-id}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/chatmessage-get?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/chatmessage-get?view=graph-rest-beta',
     tip: 'This query requires a group id of the Team, channel id of the corresponding channel of that Team and message id of the message you want to retrieve. To find the group id, channel id and message-id you can run: 1) GET https://graph.microsoft.com/beta/me/joinedTeams 2) GET https://graph.microsoft.com/beta/groups/{group-id-for-teams}/channels 3) GET https://graph.microsoft.com/beta/teams/{group-id-for-teams}/channels/{channel-id}/messages',
     skipTest: false
   },
@@ -1381,7 +1381,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'replies to a message in channel',
     requestUrl: '/beta/teams/{group-id-for-teams}/channels/{channel-id}/messages/{message-id}/replies',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/chatmessage-get?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/chatmessage-get?view=graph-rest-beta',
     tip: 'This query requires a group id of the Team, channel id of the corresponding channel of that Team and message id of the message of which you need the replies. To find the group id, channel id and message-id you can run: 1) GET https://graph.microsoft.com/beta/me/joinedTeams 2) GET https://graph.microsoft.com/beta/groups/{group-id-for-teams}/channels 3) GET https://graph.microsoft.com/beta/teams/{group-id-for-teams}/channels/{channel-id}/messages',
     skipTest: false
   },
@@ -1390,7 +1390,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'reply of a message',
     requestUrl: '/beta/teams/{group-id-for-teams}/channels/{channel-id}/messages/{message-id}/replies/{reply-id}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/chatmessage-get?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/chatmessage-get?view=graph-rest-beta',
     tip: 'This query requires a group id of the Team, channel id of the corresponding channel of that Team, message id of the message of which you need the reply and the id of the specific reply. To find the group id, channel id, message-id and reply-id you can run: 1) GET https://graph.microsoft.com/beta/me/joinedTeams 2) GET https://graph.microsoft.com/beta/groups/{group-id-for-teams}/channels 3) GET https://graph.microsoft.com/beta/teams/{group-id-for-teams}/channels/{channel-id}/messages 4) GET https://graph.microsoft.com/beta/teams/{group-id-for-teams}/channels/{channel-id}/messages/{message-id}/replies',
     skipTest: false
   },
@@ -1399,7 +1399,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'apps installed for user',
     requestUrl: '/beta/me/teamwork/installedApps?$expand=teamsApp',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/userteamwork-list-installedapps?view=graph-rest-beta&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/userteamwork-list-installedapps?view=graph-rest-beta&tabs=http',
     skipTest: false
   },
   {
@@ -1407,7 +1407,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'list members of a chat',
     requestUrl: '/beta/chats/{chat-id}/members',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/chat-list-members?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/chat-list-members?view=graph-rest-beta',
     tip: 'This query requires a chat ID. Use the following call to find a list of chats and their corresponding IDs: GET https://graph.microsoft.com/beta/me/chats/',
     skipTest: false
   },
@@ -1416,7 +1416,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'member in a chat',
     requestUrl: '/beta/chats/{chat-id}/members/{membership-id}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/chat-get-members?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/chat-get-members?view=graph-rest-beta',
     tip: 'This query requires a chat ID and a membership ID. Use the following calls to get the IDs: 1) GET https://graph.microsoft.com/beta/me/chats/ and 2) GET https://graph.microsoft.com/beta/me/chats/{chat-id}/members/',
     skipTest: false
   },
@@ -1425,7 +1425,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'send channel message',
     requestUrl: '/v1.0/teams/{team-id}/channels/{channel-id}/messages',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/channel-post-messages?view=graph-rest-beta&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/channel-post-messages?view=graph-rest-beta&tabs=http',
     headers: [
       {
         'name': 'Content-type',
@@ -1441,7 +1441,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'alerts',
     requestUrl: '/v1.0/security/alerts?$top=1',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/alert-list?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/alert-list?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -1449,7 +1449,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'alerts with \'High\' severity',
     requestUrl: '/v1.0/security/alerts?$filter=Severity eq \'High\'&$top=5',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/alert-list?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/alert-list?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -1457,7 +1457,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'alerts from \'Azure Security Center\'',
     requestUrl: '/v1.0/security/alerts?$filter=vendorInformation/provider eq \'ASC\'&$top=5',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/alert-list?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/alert-list?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -1465,7 +1465,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'alerts filter by \'Category\'',
     requestUrl: '/v1.0/security/alerts?$filter=Category eq \'ransomware\'&$top=5',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/alert-list?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/alert-list?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -1473,7 +1473,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'alerts filter by destination address',
     requestUrl: '/v1.0/security/alerts?$filter=networkConnections/any(d:d/destinationAddress eq \'{destination-address}\')',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/alert-list?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/alert-list?view=graph-rest-1.0',
     tip: 'This query requires a destination address. Run https://graph.microsoft.com/v1.0/security/alerts?$top=1 and search the results for a destinationAddress property.',
     skipTest: false
   },
@@ -1482,7 +1482,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'alerts filter by \'Status\'',
     requestUrl: '/v1.0/security/alerts?$filter=Status eq \'NewAlert\'&$top=1',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/alert-list?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/alert-list?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -1490,7 +1490,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'secure scores (beta)',
     requestUrl: '/beta/security/secureScores?$top=5',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/securescores-list?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/securescores-list?view=graph-rest-beta',
     skipTest: false
   },
   {
@@ -1498,7 +1498,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'secure score control profiles (beta)',
     requestUrl: '/beta/security/secureScoreControlProfiles?$top=5',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/securescorecontrolprofiles-list?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/securescorecontrolprofiles-list?view=graph-rest-beta',
     skipTest: false
   },
   {
@@ -1506,7 +1506,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'list TI indicators (beta)',
     requestUrl: '/beta/security/tiIndicators',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/tiindicators-list',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/tiindicators-list',
     skipTest: false
   },
   {
@@ -1514,7 +1514,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'security actions (beta)',
     requestUrl: '/beta/security/securityActions',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/securityactions-list',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/securityactions-list',
     skipTest: false
   },
   {
@@ -1522,7 +1522,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get all Conditional Access policies',
     requestUrl: '/v1.0/identity/conditionalAccess/policies',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/conditionalaccessroot-list-policies?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/conditionalaccessroot-list-policies?view=graph-rest-1.0&tabs=http',
     tip: 'We’d like to hear from you. Please leave your feedback on Conditional Access API here: https://aka.ms/caapifeedback',
     skipTest: false
   },
@@ -1531,7 +1531,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get all Named Locations',
     requestUrl: '/v1.0/identity/conditionalAccess/namedLocations',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/conditionalaccessroot-list-namedlocations?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/conditionalaccessroot-list-namedlocations?view=graph-rest-1.0&tabs=http',
     tip: 'We’d like to hear from you. Please leave your feedback on Conditional Access API here: https://aka.ms/caapifeedback',
     skipTest: false
   },
@@ -1540,7 +1540,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get all Conditional Access policies (beta)',
     requestUrl: '/beta/identity/conditionalAccess/policies',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/conditionalaccessroot-list-policies?view=graph-rest-beta&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/conditionalaccessroot-list-policies?view=graph-rest-beta&tabs=http',
     tip: 'We’d like to hear from you. Please leave your feedback on Conditional Access API here: https://aka.ms/caapifeedback',
     skipTest: false
   },
@@ -1549,7 +1549,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get all Named Locations (beta)',
     requestUrl: '/beta/identity/conditionalAccess/namedLocations',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/conditionalaccessroot-list-namedlocations?view=graph-rest-beta&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/conditionalaccessroot-list-namedlocations?view=graph-rest-beta&tabs=http',
     tip: 'We’d like to hear from you. Please leave your feedback on Conditional Access API here: https://aka.ms/caapifeedback',
     skipTest: false
   },
@@ -1558,7 +1558,7 @@ export const queries: ISampleQuery[] = [
     method: 'PATCH',
     humanName: 'update alert',
     requestUrl: '/v1.0/security/alerts/{alert-id}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/alert-update?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/alert-update?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-Type',
@@ -1574,7 +1574,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create TI indicator (beta)',
     requestUrl: '/beta/security/tiIndicators',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/tiindicators-post',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/tiindicators-post',
     headers: [
       {
         'name': 'Content-type',
@@ -1589,7 +1589,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create multiple TI indicators (beta)',
     requestUrl: '/beta/security/tiIndicators/microsoft.graph.submitTiIndicators',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/tiindicator-submittiindicators',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/tiindicator-submittiindicators',
     headers: [
       {
         'name': 'Content-type',
@@ -1604,7 +1604,7 @@ export const queries: ISampleQuery[] = [
     method: 'PATCH',
     humanName: 'update a TI indicator (beta)',
     requestUrl: '/beta/security/tiIndicators/{id}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/tiindicator-update',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/tiindicator-update',
     headers: [
       {
         'name': 'Content-Type',
@@ -1620,7 +1620,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'update multiple TI indicators (beta)',
     requestUrl: '/beta/security/tiIndicators/microsoft.graph.updateTiIndicators',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/tiindicator-updatetiindicators',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/tiindicator-updatetiindicators',
     headers: [
       {
         'name': 'Content-type',
@@ -1636,7 +1636,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create security action (beta)',
     requestUrl: '/beta/security/securityActions',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/securityactions-post',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/securityactions-post',
     headers: [
       {
         'name': 'Content-type',
@@ -1652,7 +1652,7 @@ export const queries: ISampleQuery[] = [
     method: 'DELETE',
     humanName: 'delete TI indicator (beta)',
     requestUrl: '/beta/security/tiIndicators/{id}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/tiindicator-delete',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/tiindicator-delete',
     tip: 'This query requires the TI indicator id. To find the ID, you can run: GET https://graph.microsoft.com/beta/security/tiIndicators?$top=1',
     skipTest: false
   },
@@ -1661,7 +1661,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'delete multiple TI indicators (beta)',
     requestUrl: '/beta/security/tiIndicators/microsoft.graph.deleteTiIndicators',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/tiindicator-deletetiindicators',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/tiindicator-deletetiindicators',
     headers: [
       {
         'name': 'Content-type',
@@ -1677,7 +1677,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'delete multiple TI indicators by external Id (beta)',
     requestUrl: '/beta/security/tiIndicators/microsoft.graph.deleteTiIndicatorsByExternalId',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/tiindicator-deletetiindicatorsbyexternalid',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/tiindicator-deletetiindicatorsbyexternalid',
     headers: [
       {
         'name': 'Content-type',
@@ -1693,7 +1693,7 @@ export const queries: ISampleQuery[] = [
     method: 'PUT',
     humanName: 'create a user activity and history item',
     requestUrl: '/v1.0/me/activities/uniqueIdInAppContext',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/projectrome-put-activity#example-2---deep-insert?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/projectrome-put-activity#example-2---deep-insert?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-Type',
@@ -1708,7 +1708,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get recent user activities',
     requestUrl: '/v1.0/me/activities/recent',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/projectrome-get-recent-activities?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/projectrome-get-recent-activities?view=graph-rest-1.0',
     skipTest: false
   },
   {
@@ -1722,7 +1722,7 @@ export const queries: ISampleQuery[] = [
         'value': 'eventual'
       }
     ],
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/application-list?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/application-list?view=graph-rest-1.0&tabs=http',
     tip: 'You are using the advanced query capabilities for Directory Objects, please send us feedback here: https://aka.ms/aadmgs',
     skipTest: false
   },
@@ -1737,7 +1737,7 @@ export const queries: ISampleQuery[] = [
         'value': 'eventual'
       }
     ],
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/serviceprincipal-list?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/serviceprincipal-list?view=graph-rest-1.0&tabs=http',
     tip: 'You are using the advanced query capabilities for Directory Objects, please send us feedback here: https://aka.ms/aadmgs',
     skipTest: false
   },
@@ -1746,7 +1746,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create a new application',
     requestUrl: '/v1.0/applications',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/application-post-applications?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/application-post-applications?view=graph-rest-1.0&tabs=http',
     headers: [
       {
         'name': 'Content-type',
@@ -1761,7 +1761,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'retrieve application properties',
     requestUrl: '/v1.0/applications/{application-id}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/application-get?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/application-get?view=graph-rest-1.0&tabs=http',
     tip: 'This query requires an application id. To find the ID of an application&#44; you can run: GET https://graph.microsoft.com/v1.0/applications',
     skipTest: false
   },
@@ -1770,7 +1770,7 @@ export const queries: ISampleQuery[] = [
     method: 'PATCH',
     humanName: 'update application properties',
     requestUrl: '/v1.0/applications/{application-id}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/application-update?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/application-update?view=graph-rest-1.0&tabs=http',
     headers: [
       {
         'name': 'Content-type',
@@ -1786,7 +1786,7 @@ export const queries: ISampleQuery[] = [
     method: 'DELETE',
     humanName: 'delete an application',
     requestUrl: '/v1.0/applications/{application-id}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/application-delete?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/application-delete?view=graph-rest-1.0&tabs=http',
     tip: 'This query requires an application id. To find the ID of an application; you can run: GET https://graph.microsoft.com/v1.0/applications',
     skipTest: false
   },
@@ -1795,7 +1795,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'retrieve a list of owners',
     requestUrl: '/v1.0/applications/{application-id}/owners',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/application-list-owners?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/application-list-owners?view=graph-rest-1.0&tabs=http',
     tip: 'This query requires an application id. To find the ID of an application; you can run: GET https://graph.microsoft.com/beta/applications',
     skipTest: false
   },
@@ -1804,7 +1804,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create a new owner',
     requestUrl: '/v1.0/applications/{application-id}/owners',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/application-post-owners?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/application-post-owners?view=graph-rest-1.0&tabs=http',
     headers: [
       {
         'name': 'Content-type',
@@ -1820,7 +1820,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create a raw notification',
     requestUrl: '/beta/me/notifications',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-post-notifications?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-post-notifications?view=graph-rest-beta',
     headers: [
       {
         'name': 'Content-Type',
@@ -1836,7 +1836,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create a visual notification',
     requestUrl: '/beta/me/notifications',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/user-post-notifications?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/user-post-notifications?view=graph-rest-beta',
     headers: [
       {
         'name': 'Content-Type',
@@ -1852,7 +1852,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'search messages',
     requestUrl: '/v1.0/search/query',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/search-api-overview',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/search-api-overview',
     headers: [
       {
         'name': 'Content-Type',
@@ -1868,7 +1868,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: '(beta) search Teams message',
     requestUrl: '/beta/search/query',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/search-api-overview',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/search-api-overview',
     headers: [
       {
         'name': 'Content-Type',
@@ -1884,7 +1884,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'search events',
     requestUrl: '/v1.0/search/query',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/search-api-overview',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/search-api-overview',
     headers: [
       {
         'name': 'Content-Type',
@@ -1900,7 +1900,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'search driveitems',
     requestUrl: '/v1.0/search/query',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/search-api-overview',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/search-api-overview',
     headers: [
       {
         'name': 'Content-Type',
@@ -1916,7 +1916,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: '(beta) search people',
     requestUrl: '/beta/search/query',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/search-api-overview',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/search-api-overview',
     headers: [
       {
         'name': 'Content-Type',
@@ -1932,7 +1932,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'search lists',
     requestUrl: '/v1.0/search/query',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/search-api-overview',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/search-api-overview',
     headers: [
       {
         'name': 'Content-Type',
@@ -1948,7 +1948,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'search listItems',
     requestUrl: '/v1.0/search/query',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/search-api-overview',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/search-api-overview',
     headers: [
       {
         'name': 'Content-Type',
@@ -1964,7 +1964,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'search sites',
     requestUrl: '/v1.0/search/query',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/search-api-overview',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/search-api-overview',
     headers: [
       {
         'name': 'Content-Type',
@@ -1980,7 +1980,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'search external items',
     requestUrl: '/v1.0/search/query',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/search-api-overview',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/search-api-overview',
     headers: [
       {
         'name': 'Content-Type',
@@ -1996,7 +1996,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'page search results',
     requestUrl: '/v1.0/search/query',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/search-api-overview?view=graph-rest-1.0#page-search-results',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/search-api-overview?view=graph-rest-1.0#page-search-results',
     headers: [
       {
         'name': 'Content-Type',
@@ -2012,7 +2012,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'sort search results',
     requestUrl: '/v1.0/search/query',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/search-api-overview?view=graph-rest-v1.0#sort-search-results',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/search-api-overview?view=graph-rest-v1.0#sort-search-results',
     headers: [
       {
         'name': 'Content-Type',
@@ -2028,7 +2028,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'refine results with string aggregations',
     requestUrl: '/v1.0/search/query',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/search-api-overview?view=graph-rest-v1.0#refine-results-using-aggregations',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/search-api-overview?view=graph-rest-v1.0#refine-results-using-aggregations',
     headers: [
       {
         'name': 'Content-Type',
@@ -2044,7 +2044,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'refine results with numeric aggregations',
     requestUrl: '/v1.0/search/query',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/search-api-overview?view=graph-rest-v1.0#refine-results-using-aggregationsw',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/search-api-overview?view=graph-rest-v1.0#refine-results-using-aggregationsw',
     headers: [
       {
         'name': 'Content-Type',
@@ -2060,7 +2060,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'apply refined query passing the aggregationToken',
     requestUrl: '/v1.0/search/query',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/search-api-overview?view=graph-rest-v1.0#refine-results-using-aggregations',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/search-api-overview?view=graph-rest-v1.0#refine-results-using-aggregations',
     headers: [
       {
         'name': 'Content-Type',
@@ -2076,7 +2076,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'request spelling correction',
     requestUrl: '/v1.0/search/query',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/search-api-overview?view=graph-rest-1.0#request-spelling-correction',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/search-api-overview?view=graph-rest-1.0#request-spelling-correction',
     headers: [
       {
         'name': 'Content-Type',
@@ -2092,7 +2092,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: '(beta) Trim Duplicated SharePoint Search Results',
     requestUrl: '/beta/search/query',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/search-api-overview?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/search-api-overview?view=graph-rest-beta',
     headers: [
       {
         'name': 'Content-Type',
@@ -2108,7 +2108,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: '(beta) Search with queryTemplate',
     requestUrl: '/beta/search/query',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/search-api-overview?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/search-api-overview?view=graph-rest-beta',
     headers: [
       {
         'name': 'Content-Type',
@@ -2124,7 +2124,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'request result template',
     requestUrl: '/v1.0/search/query',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/resources/search-api-overview?view=graph-rest-1.0#search-display-layout',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/resources/search-api-overview?view=graph-rest-1.0#search-display-layout',
     headers: [
       {
         'name': 'Content-Type',
@@ -2140,7 +2140,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'list ediscovery cases',
     requestUrl: '/beta/compliance/ediscovery/cases',
-    docLink: 'https://docs.microsoft.com/graph/api/ediscovery-case-list?view=graph-rest-beta&tabs=http',
+    docLink: 'https://learn.microsoft.com/graph/api/ediscovery-case-list?view=graph-rest-beta&tabs=http',
     tip: 'Go to Modify Permissions tab and consent to eDiscovery.Read.All or eDiscovery.ReadWrite.All permission to run this query',
     skipTest: false
   },
@@ -2149,7 +2149,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get ediscovery case',
     requestUrl: '/beta/compliance/ediscovery/cases/{caseId}',
-    docLink: 'https://docs.microsoft.com/graph/api/ediscovery-case-get?view=graph-rest-beta&tabs=http',
+    docLink: 'https://learn.microsoft.com/graph/api/ediscovery-case-get?view=graph-rest-beta&tabs=http',
     tip: 'Go to Modify Permissions tab and consent to eDiscovery.Read.All or eDiscovery.ReadWrite.All permission to run this query. This query requires a case id. To find the id of a case; you can run: GET https://graph.microsoft.com/beta/compliance/ediscovery/cases.',
     skipTest: false
   },
@@ -2158,7 +2158,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create ediscovery case',
     requestUrl: '/beta/compliance/ediscovery/cases',
-    docLink: 'https://docs.microsoft.com/graph/api/ediscovery-case-post?view=graph-rest-beta&tabs=http',
+    docLink: 'https://learn.microsoft.com/graph/api/ediscovery-case-post?view=graph-rest-beta&tabs=http',
     headers: [
       {
         'name': 'Content-type',
@@ -2174,7 +2174,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'list review sets',
     requestUrl: '/beta/compliance/ediscovery/cases/{caseId}/reviewSets',
-    docLink: 'https://docs.microsoft.com/graph/api/ediscovery-case-list-reviewsets?view=graph-rest-beta&tabs=http',
+    docLink: 'https://learn.microsoft.com/graph/api/ediscovery-case-list-reviewsets?view=graph-rest-beta&tabs=http',
     tip: 'Go to Modify Permissions tab and consent to eDiscovery.Read.All or eDiscovery.ReadWrite.All permission to run this query. To find the id of a case; you can run: GET https://graph.microsoft.com/beta/compliance/ediscovery/cases.',
     skipTest: false
   },
@@ -2183,7 +2183,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'list review set queries',
     requestUrl: '/beta/compliance/ediscovery/cases/{caseId}/reviewSets/{reviewSetId}/queries',
-    docLink: 'https://docs.microsoft.com/graph/api/ediscovery-reviewsetquery-list?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/ediscovery-reviewsetquery-list?view=graph-rest-beta',
     tip: 'Replace {caseId} with the ID from an eDiscovery Case (https://graph.microsoft.com/beta/compliance/ediscovery/cases) and {reviewSetId} with the ID from a review set that exists in that case (https://graph.microsoft.com/beta/compliance/ediscovery/cases/{caseid}/reviewSets). Then go to Modify Permissions tab and consent to eDiscovery.Read.All or eDiscovery.ReadWrite.All permission to run this query.',
     skipTest: false
   },
@@ -2192,7 +2192,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create review set query',
     requestUrl: '/beta/compliance/ediscovery/cases/{caseId}/reviewSets/{reviewSetId}/queries',
-    docLink: 'https://docs.microsoft.com/graph/api/ediscovery-reviewsetquery-post?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/ediscovery-reviewsetquery-post?view=graph-rest-beta',
     headers: [
       {
         'name': 'Content-Type',
@@ -2208,7 +2208,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get a list of custodians for a case',
     requestUrl: '/beta/compliance/ediscovery/cases/{caseId}/custodians',
-    docLink: 'https://docs.microsoft.com/graph/api/resources/ediscovery-custodian?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/resources/ediscovery-custodian?view=graph-rest-beta',
     tip: 'Replace {caseId} with the ID from an eDiscovery Case (https://graph.microsoft.com/beta/compliance/ediscovery/cases). Then go to Modify Permissions tab and consent to eDiscovery.Read.All or eDiscovery.ReadWrite.All permission to run this query.',
     skipTest: false
   },
@@ -2217,7 +2217,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'add custodian',
     requestUrl: '/beta/compliance/ediscovery/cases/{caseId}/custodians',
-    docLink: 'https://docs.microsoft.com/graph/api/ediscovery-case-post-custodians?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/ediscovery-case-post-custodians?view=graph-rest-beta',
     headers: [
       {
         'name': 'Content-Type',
@@ -2233,7 +2233,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get a list of source collections for a case',
     requestUrl: '/beta/compliance/ediscovery/cases/{caseId}/sourceCollections',
-    docLink: 'https://docs.microsoft.com/graph/api/ediscovery-case-list-sourcecollections?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/ediscovery-case-list-sourcecollections?view=graph-rest-beta',
     tip: 'Replace {caseId} with the ID from an eDiscovery Case (https://graph.microsoft.com/beta/compliance/ediscovery/cases). Then go to Modify Permissions tab and consent to eDiscovery.Read.All or eDiscovery.ReadWrite.All permission to run this query.',
     skipTest: false
   },
@@ -2242,7 +2242,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'add source collection',
     requestUrl: '/beta/compliance/ediscovery/cases/{caseId}/sourceCollections',
-    docLink: 'https://docs.microsoft.com/graph/api/ediscovery-case-post-sourcecollections?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/ediscovery-case-post-sourcecollections?view=graph-rest-beta',
     headers: [
       {
         'name': 'Content-Type',
@@ -2250,7 +2250,7 @@ export const queries: ISampleQuery[] = [
       }
     ],
     postBody: '{\r\n  "displayName": "Quarterly Financials search",\r\n  "contentQuery": "subject:\'Quarterly Financials\'",\r\n "custodianSources@odata.bind": "user source url"\r\n}',
-    tip: 'Replace {caseId} with the ID from an eDiscovery Case (https://graph.microsoft.com/beta/compliance/ediscovery/cases) and {user source url} odata url for the user source - see [Create sourceCollection](https://docs.microsoft.com/graph/api/ediscovery-case-post-sourcecollections?view=graph-rest-beta) for more details.',
+    tip: 'Replace {caseId} with the ID from an eDiscovery Case (https://graph.microsoft.com/beta/compliance/ediscovery/cases) and {user source url} odata url for the user source - see [Create sourceCollection](https://learn.microsoft.com/graph/api/ediscovery-case-post-sourcecollections?view=graph-rest-beta) for more details.',
     skipTest: false
   },
   {
@@ -2258,7 +2258,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get To Do task lists',
     requestUrl: '/v1.0/me/todo/lists',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/todo-list-lists?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/todo-list-lists?view=graph-rest-1.0',
     tip: 'This query requires the Tasks.ReadWrite permission',
     skipTest: false
   },
@@ -2274,7 +2274,7 @@ export const queries: ISampleQuery[] = [
       }
     ],
     postBody: '{\r\n  "displayName": "List created from Microsoft Graph Explorer"\r\n}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/todo-post-lists?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/todo-post-lists?view=graph-rest-1.0',
     tip: 'This query requires the Tasks.ReadWrite permission and a value for the displayName parameter',
     skipTest: false
   },
@@ -2290,7 +2290,7 @@ export const queries: ISampleQuery[] = [
       }
     ],
     postBody: '{\r\n  "title": "Task created from Microsoft Graph Explorer"\r\n}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/todotasklist-post-tasks?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/todotasklist-post-tasks?view=graph-rest-1.0',
     tip: 'This query requires the Tasks.ReadWrite permission. To find a value for the taskListId parameter, you can run: GET https://graph.microsoft.com/beta/me/todo/lists',
     skipTest: false
   },
@@ -2305,7 +2305,7 @@ export const queries: ISampleQuery[] = [
         'value': 'application/json'
       }
     ],
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/todotask-post-linkedresources?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/todotask-post-linkedresources?view=graph-rest-1.0',
     postBody: '{\r\n  "applicationName": "LinkedResource created from Microsoft Graph Explorer"\r\n}',
     tip: 'This query requires the Tasks.ReadWrite permission. To find a value for the taskListId parameter, you can run: GET https://graph.microsoft.com/beta/me/todo/lists. to find a value for the taskId, you can run: GET https://graph.microsoft.com/beta/me/todo/lists/{taskListId}',
     skipTest: false
@@ -2315,7 +2315,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'list Azure AD gallery apps',
     requestUrl: '/beta/applicationTemplates',
-    docLink: 'https://docs.microsoft.com/graph/api/applicationtemplate-list?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/applicationtemplate-list?view=graph-rest-beta',
     tip: 'We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/appTemplateAPISurvey',
     skipTest: false
   },
@@ -2324,7 +2324,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'instantiate an Azure AD gallery app',
     requestUrl: '/beta/applicationTemplates/{id}/instantiate',
-    docLink: 'https://docs.microsoft.com/graph/api/applicationtemplate-instantiate?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/applicationtemplate-instantiate?view=graph-rest-beta',
     headers: [
       {
         'name': 'Content-type',
@@ -2340,7 +2340,7 @@ export const queries: ISampleQuery[] = [
     method: 'PATCH',
     humanName: 'update properties on the servicePrincipal',
     requestUrl: '/v1.0/servicePrincipals/{id}',
-    docLink: 'https://docs.microsoft.com/graph/api/serviceprincipal-update?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/graph/api/serviceprincipal-update?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-Type',
@@ -2356,7 +2356,7 @@ export const queries: ISampleQuery[] = [
     method: 'PATCH',
     humanName: 'update properties on the application',
     requestUrl: '/v1.0/applications/{id}',
-    docLink: 'https://docs.microsoft.com/graph/api/application-update?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/graph/api/application-update?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-Type',
@@ -2372,7 +2372,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'create a claim mapping policy',
     requestUrl: '/v1.0/policies/claimsMappingPolicies',
-    docLink: 'https://docs.microsoft.com/graph/api/claimsmappingpolicy-post-claimsmappingpolicies?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/graph/api/claimsmappingpolicy-post-claimsmappingpolicies?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -2388,7 +2388,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'assign a claims mapping policy to a serviceprincipal',
     requestUrl: '/v1.0/servicePrincipals/{id}/claimsMappingPolicies/$ref',
-    docLink: 'https://docs.microsoft.com/graph/api/serviceprincipal-post-claimsmappingpolicies?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/graph/api/serviceprincipal-post-claimsmappingpolicies?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -2404,7 +2404,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'assign an appRoleAssignment to a serviceprincipal',
     requestUrl: '/v1.0/servicePrincipals/{id}/appRoleAssignments',
-    docLink: 'https://docs.microsoft.com/graph/api/serviceprincipal-post-approleassignments?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/graph/api/serviceprincipal-post-approleassignments?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -2420,7 +2420,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'list azure ad application proxy connectors',
     requestUrl: '/beta/onPremisesPublishingProfiles/applicationProxy/connectors',
-    docLink: 'https://docs.microsoft.com/graph/api/connector-get?view=graph-rest-beta&tabs=http',
+    docLink: 'https://learn.microsoft.com/graph/api/connector-get?view=graph-rest-beta&tabs=http',
     tip: 'We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/msgraphaadsurveyconnectors',
     skipTest: false
   },
@@ -2429,7 +2429,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'list azure ad application proxy connector groups',
     requestUrl: '/beta/onPremisesPublishingProfiles/applicationProxy/connectorgroups',
-    docLink: 'https://docs.microsoft.com/graph/api/connectorgroup-get?view=graph-rest-beta&tabs=http',
+    docLink: 'https://learn.microsoft.com/graph/api/connectorgroup-get?view=graph-rest-beta&tabs=http',
     tip: 'We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/msgraphaadsurveyconnectorgroups',
     skipTest: false
   },
@@ -2438,7 +2438,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'list azure ad devices',
     requestUrl: '/v1.0/devices',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/device-list?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/device-list?view=graph-rest-1.0&tabs=http',
     tip: 'We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/deviceAPIFeedback',
     skipTest: false
   },
@@ -2447,7 +2447,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get a specified azure ad device',
     requestUrl: '/v1.0/devices/{id}',
-    docLink: 'https://docs.microsoft.com/en-us/graph/api/device-get?view=graph-rest-1.0&tabs=http',
+    docLink: 'https://learn.microsoft.com/en-us/graph/api/device-get?view=graph-rest-1.0&tabs=http',
     tip: 'We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/deviceAPIFeedback',
     skipTest: false
   },
@@ -2456,7 +2456,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get high risk users',
     requestUrl: '/v1.0/identityProtection/riskyUsers?$filter=riskLevel eq \'high\'',
-    docLink: 'https://docs.microsoft.com/graph/api/riskyuser-get?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/graph/api/riskyuser-get?view=graph-rest-1.0',
     tip: 'We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/IdentityProtectionAPIFeedback',
     skipTest: false
   },
@@ -2465,7 +2465,7 @@ export const queries: ISampleQuery[] = [
     method: 'POST',
     humanName: 'confirm a user as compromised',
     requestUrl: '/v1.0/identityProtection/riskyUsers/confirmCompromised',
-    docLink: 'https://docs.microsoft.com/graph/api/riskyuser-confirmcompromised?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/graph/api/riskyuser-confirmcompromised?view=graph-rest-1.0',
     headers: [
       {
         'name': 'Content-type',
@@ -2481,7 +2481,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get risk detections',
     requestUrl: '/v1.0/identityProtection/riskDetections',
-    docLink: 'https://docs.microsoft.com/graph/api/riskdetection-get?view=graph-rest-1.0',
+    docLink: 'https://learn.microsoft.com/graph/api/riskdetection-get?view=graph-rest-1.0',
     tip: 'We’d like to hear from you. Please leave your feedback on this API here: https://aka.ms/IdentityProtectionAPIFeedback',
     skipTest: false
   },
@@ -2490,7 +2490,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'list catalog entries',
     requestUrl: '/beta/admin/windows/updates/catalog/entries',
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-catalog-list-entries?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-catalog-list-entries?view=graph-rest-beta',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query.',
     skipTest: false
   },
@@ -2499,7 +2499,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'list deployments',
     requestUrl: '/beta/admin/windows/updates/deployments',
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-updates-list-deployments?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-updates-list-deployments?view=graph-rest-beta',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query.',
     skipTest: false
   },
@@ -2514,7 +2514,7 @@ export const queries: ISampleQuery[] = [
         'value': 'application/json'
       }
     ],
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-updates-post-deployments?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-updates-post-deployments?view=graph-rest-beta',
     postBody: '{\r\n    "content": {\r\n        "@odata.type": "#microsoft.graph.windowsUpdates.featureUpdateReference",\r\n        "version": "{featureUpdateVersion}"\r\n    }\r\n}',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query. To find a value for the featureUpdateVersion parameter, you can run: GET https://graph.microsoft.com/beta/admin/windows/updates/catalog/entries.',
     skipTest: false
@@ -2530,7 +2530,7 @@ export const queries: ISampleQuery[] = [
         'value': 'application/json'
       }
     ],
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-updates-post-deployments?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-updates-post-deployments?view=graph-rest-beta',
     postBody: '{\r\n    "content": {\r\n        "@odata.type": "microsoft.graph.windowsUpdates.expeditedQualityUpdateReference",\r\n        "releaseDate": "{qualityUpdateReleaseDate}"\r\n    }\r\n}',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query. To find a value for the qualityUpdateReleaseDate parameter, you can run: GET https://graph.microsoft.com/beta/admin/windows/updates/catalog/entries.',
     skipTest: false
@@ -2546,7 +2546,7 @@ export const queries: ISampleQuery[] = [
         'value': 'application/json'
       }
     ],
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-updates-post-deployments?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-updates-post-deployments?view=graph-rest-beta',
     postBody: '{\r\n    "content": {\r\n        "@odata.type": "#microsoft.graph.windowsUpdates.featureUpdateReference",\r\n        "version": "{featureUpdateVersion}"\r\n    },\r\n    "settings": {\r\n        "@odata.type": "microsoft.graph.windowsUpdates.windowsDeploymentSettings",\r\n        "rollout": {\r\n            "devicesPerOffer": 100,\r\n            "durationBetweenOffers": "P7D"\r\n        },\r\n        "monitoring": {\r\n            "monitoringRules": [\r\n                {\r\n                    "@odata.type": "#microsoft.graph.windowsUpdates.monitoringRule",\r\n                    "signal": "rollback",\r\n                    "threshold": 5,\r\n                    "action": "pauseDeployment"\r\n                }\r\n            ]\r\n        }\r\n    }\r\n}',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query. To find a value for the featureUpdateVersion parameter, you can run: GET https://graph.microsoft.com/beta/admin/windows/updates/catalog/entries.',
     skipTest: false
@@ -2562,7 +2562,7 @@ export const queries: ISampleQuery[] = [
         'value': 'application/json'
       }
     ],
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-updates-post-deployments?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-updates-post-deployments?view=graph-rest-beta',
     postBody: '{\r\n    "content": {\r\n        "@odata.type": "#microsoft.graph.windowsUpdates.featureUpdateReference",\r\n        "version": "{featureUpdateVersion}"\r\n    },\r\n    "settings": {\r\n        "@odata.type": "microsoft.graph.windowsUpdates.windowsDeploymentSettings",\r\n        "rollout": {\r\n            "startDateTime": "{deploymentStartDateTime}",\r\n            "endDateTime": "{deploymentEndDateTime}",\r\n            "durationBetweenOffers": "P7D"\r\n        },\r\n        "monitoring": {\r\n            "monitoringRules": [\r\n                {\r\n                    "@odata.type": "#microsoft.graph.windowsUpdates.monitoringRule",\r\n                    "signal": "rollback",\r\n                    "threshold": 5,\r\n                    "action": "pauseDeployment"\r\n                }\r\n            ]\r\n        }\r\n    }\r\n}',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query. To find a value for the featureUpdateVersion parameter, you can run: GET https://graph.microsoft.com/beta/admin/windows/updates/catalog/entries.',
     skipTest: false
@@ -2572,7 +2572,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get deployment',
     requestUrl: '/beta/admin/windows/updates/deployments/{deploymentId}',
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-deployment-get?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-deployment-get?view=graph-rest-beta',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query. To find a value for the deploymentId parameter, you can run: GET https://graph.microsoft.com/beta/admin/windows/updates/deployments.',
     skipTest: false
   },
@@ -2587,7 +2587,7 @@ export const queries: ISampleQuery[] = [
         'value': 'application/json'
       }
     ],
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-deployment-update?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-deployment-update?view=graph-rest-beta',
     postBody: '{\r\n    "settings": {\r\n        "@odata.type": "microsoft.graph.windowsUpdates.windowsDeploymentSettings",\r\n        "monitoring": {\r\n            "monitoringRules": [\r\n                {\r\n                    "signal": "rollback",\r\n                    "threshold": 5,\r\n                    "action": "pauseDeployment"\r\n                }\r\n            ]\r\n        }\r\n    }\r\n}',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query. To find a value for the deploymentId parameter, you can run: GET https://graph.microsoft.com/beta/admin/windows/updates/deployments.',
     skipTest: false
@@ -2603,7 +2603,7 @@ export const queries: ISampleQuery[] = [
         'value': 'application/json'
       }
     ],
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-deployment-update?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-deployment-update?view=graph-rest-beta',
     postBody: '{\r\n    "state": {\r\n        "@odata.type": "#microsoft.graph.windowsUpdates.deploymentState",\r\n        "requestedValue": "paused"\r\n    }\r\n}',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query. To find a value for the deploymentId parameter, you can run: GET https://graph.microsoft.com/beta/admin/windows/updates/deployments.',
     skipTest: false
@@ -2619,7 +2619,7 @@ export const queries: ISampleQuery[] = [
         'value': 'application/json'
       }
     ],
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-deployment-update?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-deployment-update?view=graph-rest-beta',
     postBody: '{\r\n    "state": {\r\n        "@odata.type": "#microsoft.graph.windowsUpdates.deploymentState",\r\n        "requestedValue": "none"\r\n    }\r\n}',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query. To find a value for the deploymentId parameter, you can run: GET https://graph.microsoft.com/beta/admin/windows/updates/deployments.',
     skipTest: false
@@ -2629,7 +2629,7 @@ export const queries: ISampleQuery[] = [
     method: 'DELETE',
     humanName: 'delete deployment',
     requestUrl: '/beta/admin/windows/updates/deployments/{deploymentId}',
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-deployment-delete?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-deployment-delete?view=graph-rest-beta',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query. To find a value for the deploymentId parameter, you can run: GET https://graph.microsoft.com/beta/admin/windows/updates/deployments.',
     skipTest: false
   },
@@ -2638,7 +2638,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'list deployment audience members',
     requestUrl: '/beta/admin/windows/updates/deployments/{deploymentId}/audience/members',
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-deploymentaudience-list-members?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-deploymentaudience-list-members?view=graph-rest-beta',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query. To find a value for the deploymentId parameter, you can run: GET https://graph.microsoft.com/beta/admin/windows/updates/deployments.',
     skipTest: false
   },
@@ -2647,7 +2647,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'list deployment audience exclusions',
     requestUrl: '/beta/admin/windows/updates/deployments/{deploymentId}/audience/exclusions',
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-deploymentaudience-list-exclusions?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-deploymentaudience-list-exclusions?view=graph-rest-beta',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query. To find a value for the deploymentId parameter, you can run: GET https://graph.microsoft.com/beta/admin/windows/updates/deployments.',
     skipTest: false
   },
@@ -2662,7 +2662,7 @@ export const queries: ISampleQuery[] = [
         'value': 'application/json'
       }
     ],
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-deploymentaudience-updateaudience?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-deploymentaudience-updateaudience?view=graph-rest-beta',
     postBody: '{\r\n    "addMembers": [\r\n        {\r\n            "@odata.type": "#microsoft.graph.windowsUpdates.azureADDevice",\r\n            "id": "{azureAdDeviceId}"\r\n        }\r\n    ]\r\n}',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query. To find a value for the deploymentId parameter, you can run: GET https://graph.microsoft.com/beta/admin/windows/updates/deployments.',
     skipTest: false
@@ -2678,7 +2678,7 @@ export const queries: ISampleQuery[] = [
         'value': 'application/json'
       }
     ],
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-deploymentaudience-updateaudience?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-deploymentaudience-updateaudience?view=graph-rest-beta',
     postBody: '{\r\n    "addExclusions": [\r\n        {\r\n            "@odata.type": "#microsoft.graph.windowsUpdates.azureADDevice",\r\n            "id": "{azureAdDeviceId}"\r\n        }\r\n    ]\r\n}',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query. To find a value for the deploymentId parameter, you can run: GET https://graph.microsoft.com/beta/admin/windows/updates/deployments.',
     skipTest: false
@@ -2694,7 +2694,7 @@ export const queries: ISampleQuery[] = [
         'value': 'application/json'
       }
     ],
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-deploymentaudience-updateaudience?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-deploymentaudience-updateaudience?view=graph-rest-beta',
     postBody: '{\r\n    "removeMembers": [\r\n        {\r\n            "@odata.type": "#microsoft.graph.windowsUpdates.azureADDevice",\r\n            "id": "{azureAdDeviceId}"\r\n        }\r\n    ]\r\n}',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query. To find a value for the deploymentId parameter, you can run: GET https://graph.microsoft.com/beta/admin/windows/updates/deployments.',
     skipTest: false
@@ -2710,7 +2710,7 @@ export const queries: ISampleQuery[] = [
         'value': 'application/json'
       }
     ],
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-deploymentaudience-updateaudience?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-deploymentaudience-updateaudience?view=graph-rest-beta',
     postBody: '{\r\n    "removeExclusions": [\r\n        {\r\n            "@odata.type": "#microsoft.graph.windowsUpdates.azureADDevice",\r\n            "id": "{azureAdDeviceId}"\r\n        }\r\n    ]\r\n}',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query. To find a value for the deploymentId parameter, you can run: GET https://graph.microsoft.com/beta/admin/windows/updates/deployments.',
     skipTest: false
@@ -2720,7 +2720,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'list updatable assets',
     requestUrl: '/beta/admin/windows/updates/updatableAssets',
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-updates-list-updatableassets?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-updates-list-updatableassets?view=graph-rest-beta',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query.',
     skipTest: false
   },
@@ -2729,7 +2729,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get updatable asset',
     requestUrl: '/beta/admin/windows/updates/updatableAssets/{updatableAssetId}',
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-updatableasset-get?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-updatableasset-get?view=graph-rest-beta',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query. To find a value for the updatableAssetId parameter, you can run: GET https://graph.microsoft.com/beta/admin/windows/updatableAssets.',
     skipTest: false
   },
@@ -2738,7 +2738,7 @@ export const queries: ISampleQuery[] = [
     method: 'DELETE',
     humanName: 'delete updatable asset',
     requestUrl: '/beta/admin/windows/updates/updatableAssets/{updatableAssetId}',
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-updatableasset-delete?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-updatableasset-delete?view=graph-rest-beta',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query. To find a value for the updatableAssetId parameter, you can run: GET https://graph.microsoft.com/beta/admin/windows/updatableAssets.',
     skipTest: false
   },
@@ -2747,7 +2747,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'list Azure AD devices',
     requestUrl: '/beta/admin/windows/updates/updatableAssets/?$filter=isof(\'microsoft.graph.windowsUpdates.azureADDevice\')',
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-updates-list-updatableassets-azureaddevice?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-updates-list-updatableassets-azureaddevice?view=graph-rest-beta',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query.',
     skipTest: false
   },
@@ -2756,7 +2756,7 @@ export const queries: ISampleQuery[] = [
     method: 'GET',
     humanName: 'get Azure AD device',
     requestUrl: '/beta/admin/windows/updates/updatableAssets/{updatableAssetId}',
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-azureaddevice-get?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-azureaddevice-get?view=graph-rest-beta',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query. To find a value for the updatableAssetId parameter, you can run: GET https://graph.microsoft.com/beta/admin/windows/updatableAssets.',
     skipTest: false
   },
@@ -2765,7 +2765,7 @@ export const queries: ISampleQuery[] = [
     method: 'DELETE',
     humanName: 'delete Azure AD device',
     requestUrl: '/beta/admin/windows/updates/updatableAssets/{updatableAssetId}',
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-azureaddevice-delete?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-azureaddevice-delete?view=graph-rest-beta',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query. To find a value for the updatableAssetId parameter, you can run: GET https://graph.microsoft.com/beta/admin/windows/updatableAssets.',
     skipTest: false
   },
@@ -2780,7 +2780,7 @@ export const queries: ISampleQuery[] = [
         'value': 'application/json'
       }
     ],
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-updatableasset-enrollassets?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-updatableasset-enrollassets?view=graph-rest-beta',
     postBody: '{\r\n    "updateCategory": "feature",\r\n    "assets": [\r\n        {\r\n            "@odata.type": "#microsoft.graph.windowsUpdates.azureADDevice",\r\n            "id": "{azureAdDeviceId}"\r\n        }\r\n    ]\r\n}',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query.',
     skipTest: false
@@ -2796,7 +2796,7 @@ export const queries: ISampleQuery[] = [
         'value': 'application/json'
       }
     ],
-    docLink: 'https://docs.microsoft.com/graph/api/windowsupdates-updatableasset-unenrollassets?view=graph-rest-beta',
+    docLink: 'https://learn.microsoft.com/graph/api/windowsupdates-updatableasset-unenrollassets?view=graph-rest-beta',
     postBody: '{\r\n    "updateCategory": "feature",\r\n    "assets": [\r\n        {\r\n            "@odata.type": "#microsoft.graph.windowsUpdates.azureADDevice",\r\n            "id": "{azureAdDeviceId}"\r\n        }\r\n    ]\r\n}',
     tip: 'Please enable the WindowsUpdates.ReadWrite.All permission to use this query.',
     skipTest: false


### PR DESCRIPTION
## Overview

fixes #2147 
With the new Microsoft Learn Platform rebrand, the link changes from `docs.microsoft` to `learn.microsoft`.
This, therefore, makes it necessary to update the doc links on GE to prevent redirection failures in the future and fix the issue above.

