### PR TITLE
Fix: Reloading of permissions tab when permissions panel is opened

### DIFF
--- a/src/app/views/authentication/profile/Profile.tsx
+++ b/src/app/views/authentication/profile/Profile.tsx
@@ -175,7 +175,7 @@ const Profile = (props: any) => {
   return (
     <div className={classes.profile} style={profileContainerStyles}>
       {showProfileComponent(persona)}
-      {permissionsPanelOpen && <Permission/>}
+      {permissionsPanelOpen && <Permission panel={true}/>}
     </div>
   );
 }

--- a/src/app/views/query-runner/request/permissions/Permission.tsx
+++ b/src/app/views/query-runner/request/permissions/Permission.tsx
@@ -27,12 +27,12 @@ import messages from '../../../../../messages';
 
 export const Permission = ( permissionProps?: IPermissionProps ) : JSX.Element => {
 
-  const { sampleQuery, scopes, dimensions, authToken, permissionsPanelOpen } =
+  const { sampleQuery, scopes, dimensions, authToken } =
   useSelector( (state: IRootState) => state );
   const { pending: loading } = scopes;
   const tokenPresent = !!authToken.token;
   const dispatch = useDispatch();
-  const panel = permissionsPanelOpen
+  const panel = permissionProps?.panel;
 
   const classProps = {
     styles: permissionProps!.styles,
@@ -240,7 +240,7 @@ export const Permission = ( permissionProps?: IPermissionProps ) : JSX.Element =
 
   return(
     <>
-      {permissionsPanelOpen ? displayPermissionsPanel() : displayPermissionsAsTab()}
+      {panel ? displayPermissionsPanel() : displayPermissionsAsTab()}
     </>
   );
 }


### PR DESCRIPTION
## Overview
Fixes #2153 

### Demo


### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
Sign in to the app
Click on the Modify Permissions tab
Now click on your Profile on the top right, then click on 'Consent to permissions'
Notice that the Modify Permissions tab no longer reloads