### PR TITLE
Fix: Pass empty string to signOutSuccess when signing out

### DIFF
--- a/src/app/services/actions/auth-action-creators.spec.ts
+++ b/src/app/services/actions/auth-action-creators.spec.ts
@@ -72,7 +72,7 @@ describe('Auth Action Creators', () => {
 
   it('should dispatch LOGOUT_SUCCESS when signOutSuccess() is called', () => {
     // Arrange
-    const response: boolean = true;
+    const response: string[] = [];
     const expectedAction = {
       type: LOGOUT_SUCCESS,
       response
@@ -123,7 +123,7 @@ describe('Auth Action Creators', () => {
 
   it('should dispatch LOGOUT_SUCCESS when signOutSuccess() is called', () => {
     // Arrange
-    const response: boolean = false;
+    const response: string[] = [];
     const expectedAction = {
       type: LOGOUT_SUCCESS,
       response

--- a/src/app/services/actions/auth-action-creators.spec.ts
+++ b/src/app/services/actions/auth-action-creators.spec.ts
@@ -72,7 +72,7 @@ describe('Auth Action Creators', () => {
 
   it('should dispatch LOGOUT_SUCCESS when signOutSuccess() is called', () => {
     // Arrange
-    const response: string[] = [];
+    const response: boolean = true;
     const expectedAction = {
       type: LOGOUT_SUCCESS,
       response
@@ -123,7 +123,7 @@ describe('Auth Action Creators', () => {
 
   it('should dispatch LOGOUT_SUCCESS when signOutSuccess() is called', () => {
     // Arrange
-    const response: string[] = [];
+    const response: boolean = true;
     const expectedAction = {
       type: LOGOUT_SUCCESS,
       response

--- a/src/app/services/actions/auth-action-creators.ts
+++ b/src/app/services/actions/auth-action-creators.ts
@@ -20,7 +20,7 @@ export function getConsentedScopesSuccess(response: string[]): IAction {
   };
 }
 
-export function signOutSuccess(response: boolean): any {
+export function signOutSuccess(response: string []): any {
   return {
     type: LOGOUT_SUCCESS,
     response
@@ -43,7 +43,7 @@ export function signOut() {
     } else {
       authenticationWrapper.logOutPopUp();
     }
-    dispatch(signOutSuccess(true));
+    dispatch(signOutSuccess([]));
   };
 }
 

--- a/src/app/services/actions/auth-action-creators.ts
+++ b/src/app/services/actions/auth-action-creators.ts
@@ -20,7 +20,7 @@ export function getConsentedScopesSuccess(response: string[]): IAction {
   };
 }
 
-export function signOutSuccess(response: string []): any {
+export function signOutSuccess(response: boolean): any {
   return {
     type: LOGOUT_SUCCESS,
     response
@@ -43,7 +43,7 @@ export function signOut() {
     } else {
       authenticationWrapper.logOutPopUp();
     }
-    dispatch(signOutSuccess([]));
+    dispatch(signOutSuccess(true));
   };
 }
 

--- a/src/app/services/reducers/auth-reducers.ts
+++ b/src/app/services/reducers/auth-reducers.ts
@@ -38,7 +38,7 @@ export function consentedScopes(state: string[] = [], action: IAction): any {
     case GET_CONSENTED_SCOPES_SUCCESS:
       return action.response;
     case LOGOUT_SUCCESS:
-      return action.response;
+      return [];
     default:
       return state;
   }


### PR DESCRIPTION
## Overview
Fixes #2161 

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
Sign in to the app 
Click on Modify Permissions tab
Click on the Profile component and sign out
Sign in again ensuring that the Modify Permissions tab is still open
Notice that the app no longer crashes