### PR TITLE
Fix: Permission search results

### DIFF
--- a/src/app/views/query-runner/request/permissions/PanelList.tsx
+++ b/src/app/views/query-runner/request/permissions/PanelList.tsx
@@ -71,11 +71,11 @@ const PanelList = ({ messages,
 
   useEffect(() => {
     if (shouldGenerateGroups.current) {
-      if(permissionsList.length === 0){ return }
       setGroups(generateGroupsFromList(permissionsList, 'groupName'));
       if(groups && groups.length > 0) {
         shouldGenerateGroups.current = false;
       }
+      if(permissionsList.length === 0){ return }
     }
   }, [permissions, searchStarted])
 
@@ -101,7 +101,8 @@ const PanelList = ({ messages,
 
       filteredPermissions = fullPermissions.filter((permission: IPermission) => {
         const name = permission.value.toLowerCase();
-        return name.includes(keyword);
+        const groupName = permission.value.split('.')[0].toLowerCase();
+        return name.includes(keyword) || groupName.includes(keyword);
       });
     }
     setPermissions(filteredPermissions);
@@ -188,19 +189,6 @@ const PanelList = ({ messages,
 
   return (
     <div>
-      <Label className={classes.permissionText}>
-        <FormattedMessage id='Select different permissions' />
-      </Label>
-      <hr />
-      <SearchBox
-        className={classes.searchBox}
-        placeholder={messages['Search permissions']}
-        onChange={(event?: React.ChangeEvent<HTMLInputElement>, newValue?: string) =>
-          searchValueChanged(event, newValue)}
-        styles={searchBoxStyles}
-      />
-      <Announced message={`${permissions.length} search results available.`} />
-      <hr />
       <Panel
         isOpen={permissionsPanelOpen}
         onDismiss={() => changePanelState()}
@@ -213,7 +201,7 @@ const PanelList = ({ messages,
         overlayProps={panelOverlayProps}
         styles={permissionPanelStyles}
       >
-        {loading || groups && groups.length === 0 ? displayLoadingPermissionsText() :
+        {loading ? displayLoadingPermissionsText() :
           <>
             <Label className={classes.permissionText}>
               <FormattedMessage id='Select different permissions' />
@@ -251,8 +239,8 @@ const PanelList = ({ messages,
               onRenderCheckbox={(props?: IDetailsListCheckboxProps) => renderCustomCheckbox(props)}
             />
           </>}
-      </Panel>
-      {permissions && permissions.length === 0 &&
+
+        {!loading && permissions && permissions.length === 0 &&
         <Label style={{
           display: 'flex',
           width: '100%',
@@ -262,7 +250,8 @@ const PanelList = ({ messages,
         }}>
           <FormattedMessage id='permissions not found' />
         </Label>
-      }
+        }
+      </Panel>
     </div>
   );
 };


### PR DESCRIPTION
## Overview

Fixes #2166, fixes #2168
Where a searched permission doesn't exist, the "We did not find any permissions." message is displayed. Also, there are no longer any empty groups.
Also fixes an issue with the tenant info and settings icon getting displaced

### Demo

![image](https://user-images.githubusercontent.com/18407044/196147455-1cb11ab7-fbf6-441e-ac5d-ddfe5526d1ef.png)

![image](https://user-images.githubusercontent.com/18407044/196166137-9438f113-aca6-4a45-afba-2b6920cf2a3a.png)


## Testing Instructions

* Sign in
* Navigate to the Profile icon
* Click on "Consent to Permissions"
* In the search box, type out a permission that doesn't exist
* Observe the fix

