### PR TITLE
Task: more-info telemetry capture

### DIFF
--- a/src/app/views/query-runner/query-input/auto-complete/suffix/HintList.tsx
+++ b/src/app/views/query-runner/query-input/auto-complete/suffix/HintList.tsx
@@ -1,12 +1,15 @@
 import { DefaultButton, Separator, Stack, Text } from '@fluentui/react';
 import React from 'react';
-import { componentNames, telemetry, eventTypes } from '../../../../../../telemetry';
-import { validateExternalLink } from '../../../../../utils/external-link-validation';
 
+import { componentNames, eventTypes, telemetry } from '../../../../../../telemetry';
+import { GRAPH_URL } from '../../../../../services/graph-constants';
+import { validateExternalLink } from '../../../../../utils/external-link-validation';
+import { sanitizeQueryUrl } from '../../../../../utils/query-url-sanitization';
+import { parseSampleUrl } from '../../../../../utils/sample-url-generation';
 import { IHint } from './suffix-util';
 import { styles } from './suffix.styles';
 
-export const HintList = ({ hints }: any) => {
+export const HintList = ({ hints, requestUrl }: any) => {
 
   const onDocumentationLinkClicked = (item: IHint) => {
     window.open(item.link?.url, '_blank');
@@ -14,11 +17,10 @@ export const HintList = ({ hints }: any) => {
   };
 
   const trackDocumentLinkClickedEvent = async (item: IHint): Promise<void> => {
+    const parsed = parseSampleUrl(sanitizeQueryUrl(`${GRAPH_URL}/v1.0/${requestUrl}`));
     const properties: { [key: string]: any } = {
-      ComponentName: componentNames.DOCUMENTATION_LINK,
-      SampleId: 'Autocomplete',
-      SampleName: 'Autocomplete',
-      SampleCategory: 'Autocomplete',
+      ComponentName: componentNames.AUTOCOMPLETE_DOCUMENTATION_LINK,
+      QueryUrl: parsed.requestUrl,
       Link: item.link?.url
     };
     telemetry.trackEvent(eventTypes.LINK_CLICK_EVENT, properties);

--- a/src/app/views/query-runner/query-input/auto-complete/suffix/SuffixRenderer.tsx
+++ b/src/app/views/query-runner/query-input/auto-complete/suffix/SuffixRenderer.tsx
@@ -129,7 +129,7 @@ const SuffixRenderer = () => {
           <Text block variant='xLarge' className={styles.title} id={labelId}>
             /{requestUrl}
           </Text>
-          <HintList hints={hints} />
+          <HintList hints={hints} requestUrl={requestUrl} />
         </Callout>
       )}
     </>

--- a/src/telemetry/component-names.ts
+++ b/src/telemetry/component-names.ts
@@ -53,6 +53,7 @@ export const QUERY_URL_AUTOCOMPLETE_DROPDOWN = 'Query URL autocomplete dropdown'
 
 // Links
 export const DOCUMENTATION_LINK = 'Documentation link';
+export const AUTOCOMPLETE_DOCUMENTATION_LINK = 'Autocomplete documentation link';
 export const REPORT_AN_ISSUE_LINK = 'Report an issue link';
 export const OFFICE_DEV_PROGRAM_LINK = 'Office dev program link';
 export const GRAPH_TOOLKIT_PLAYGROUND_LINK = 'Graph toolkit playground link';


### PR DESCRIPTION

## Overview

Closes #2186

The component identifier used to track telemetry for the more info button documentation link was similar to the sidebar documentation link. This PR aims to distinguish each for easier identification later.
