### PR TITLE
Task: Move codeowners to team, add JIT admin access cfig

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @thewahome @ElinorW @adhiambovivian @millicentachieng @ddyett @Onokaev
+* @microsoft-graph-explorer-v4-write

--- a/.github/policies/jit.yml
+++ b/.github/policies/jit.yml
@@ -1,0 +1,12 @@
+name: JIT_Access
+description: Policy for admin JIT for microsoft-graph-explorer-v4 repo
+
+resource: repository
+
+configuration:
+  jitAccess:
+    enabled: true
+    maxHours: 2
+    approvers:
+    requestors:
+      role: write


### PR DESCRIPTION
## Overview

Enables JIT admin access to repo using https://repos.opensource.microsoft.com/orgs/microsoftgraph/repos/microsoft-graph-explorer-v4. Removes the need to manage CODEOWNERS via commits, just update the team.
