### PR TITLE
Fix: pattern matching urls

### DIFF
--- a/src/app/utils/resources/resources-filter.ts
+++ b/src/app/utils/resources/resources-filter.ts
@@ -1,4 +1,5 @@
 import { IResource } from '../../../types/resources';
+import { hasPlaceHolders } from '../sample-url-generation';
 
 function getResourcesSupportedByVersion(
   resources: IResource[],
@@ -42,8 +43,25 @@ function searchResources(haystack: IResource[], needle: string): IResource[] {
   return foundResources;
 }
 
+function getMatchingResourceForUrl(url: string, resources: IResource[]): IResource | undefined {
+  const parts = url.split('/').filter(k => k !== '');
+  let matching = [...resources];
+  let node;
+  for (const path of parts) {
+    if (hasPlaceHolders(path)) {
+      node = matching.find(k => hasPlaceHolders(k.segment));
+      matching = node?.children || [];
+    } else {
+      node = matching.find(k => k.segment === path);
+      matching = node?.children || [];
+    }
+  }
+  return node;
+}
+
 export {
   searchResources,
   getResourcesSupportedByVersion,
-  versionExists
+  versionExists,
+  getMatchingResourceForUrl
 }

--- a/src/modules/suggestions/suggestions.ts
+++ b/src/modules/suggestions/suggestions.ts
@@ -1,6 +1,7 @@
 import { ISuggestions, SignContext } from '.';
 import { parseOpenApiResponse } from '../../app/utils/open-api-parser';
 import {
+  getMatchingResourceForUrl,
   getResourcesSupportedByVersion
 } from '../../app/utils/resources/resources-filter';
 import { IOpenApiParseContent, IOpenApiResponse, IParsedOpenApiResponse } from '../../types/open-api';
@@ -44,13 +45,9 @@ class Suggestions implements ISuggestions {
     if (!url) {
       return this.createOpenApiResponse(versionedResources, url);
     } else {
-      const parts = url.split('/');
-      let toSearch = [...versionedResources];
-      for (const element of parts) {
-        toSearch = toSearch.find(k => k.segment === element)?.children || [];
-      }
-      if (toSearch.length > 0) {
-        return this.createOpenApiResponse(toSearch, url)
+      const matching = getMatchingResourceForUrl(url, versionedResources);
+      if (matching && matching.children.length > 0) {
+        return this.createOpenApiResponse(matching.children, url)
       }
     }
     return null;


### PR DESCRIPTION
## Overview

Fixes #2257 

The matching has been failing because the urls in resource explorer do not match with how the URL sanitization is done in Graph Explorer.

For example `/users/abcd-efgh` will be sanitised to `/users/{users-id}` while resource explorer comes with the content as `/users/{user-id}`.
We have been using exact matches for strings to get the next resources available instead of checking whether they follow the same pattern.



## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output