### PR TITLE
Fix: % symbol crash

### DIFF
--- a/src/modules/validation/abnf.spec.ts
+++ b/src/modules/validation/abnf.spec.ts
@@ -20,7 +20,8 @@ const validUrls = [
 
 const invalidUrls = [
   'https://graph.microsoft.com/me+you',
-  'https://graph.microsoft.com/v1.0/me/messages?$$select=id'
+  'https://graph.microsoft.com/v1.0/me/messages?$$select=id',
+  'https://graph.microsoft.com/v1.0/me/drive/root:/Encoded%'
 ];
 
 /*

--- a/src/modules/validation/abnf.spec.ts
+++ b/src/modules/validation/abnf.spec.ts
@@ -21,7 +21,8 @@ const validUrls = [
 const invalidUrls = [
   'https://graph.microsoft.com/me+you',
   'https://graph.microsoft.com/v1.0/me/messages?$$select=id',
-  'https://graph.microsoft.com/v1.0/me/drive/root:/Encoded%'
+  'https://graph.microsoft.com/v1.0/me/drive/root:/Encoded%',
+  'https://graph.microsoft.com/v1.0/me/drive/root:/Encoded%2'
 ];
 
 /*

--- a/src/modules/validation/abnf.ts
+++ b/src/modules/validation/abnf.ts
@@ -38,10 +38,12 @@ export class ValidatedUrl {
   }
 
   public validate(graphUrl: string): ValidationResult {
+    let decodedGraphUrl = graphUrl;
+    try { decodedGraphUrl = decodeURI(graphUrl); } catch (error) { /* empty */ }
     const result = ValidatedUrl.parser.parse(
       ValidatedUrl.getGrammar(),
       'odataUri',
-      decodeURI(graphUrl)
+      decodedGraphUrl
     );
     return result;
   }


### PR DESCRIPTION
## Overview

Fixes #2265 

### Notes

Adding a % in a random location fails the decodeUrl function in the abnf validator. 