### PR TITLE
Fix: Inform user if URL is incomplete

### DIFF
--- a/src/app/views/query-runner/query-input/QueryInput.tsx
+++ b/src/app/views/query-runner/query-input/QueryInput.tsx
@@ -61,7 +61,7 @@ const QueryInput = (props: IQueryInputProps) => {
   }
 
   const runQuery = () => {
-    if (!sampleQuery.sampleUrl || sampleQuery.sampleUrl.indexOf('https://') === -1) {
+    if (!sampleQuery.sampleUrl || sampleQuery.sampleUrl.indexOf('http') === -1) {
       return;
     }
     handleOnRunQuery(sampleQuery);

--- a/src/app/views/query-runner/query-input/QueryInput.tsx
+++ b/src/app/views/query-runner/query-input/QueryInput.tsx
@@ -61,7 +61,7 @@ const QueryInput = (props: IQueryInputProps) => {
   }
 
   const runQuery = () => {
-    if (!sampleQuery.sampleUrl) {
+    if (!sampleQuery.sampleUrl || sampleQuery.sampleUrl.indexOf('https://') === -1) {
       return;
     }
     handleOnRunQuery(sampleQuery);

--- a/src/app/views/query-runner/query-input/QueryInput.tsx
+++ b/src/app/views/query-runner/query-input/QueryInput.tsx
@@ -61,7 +61,7 @@ const QueryInput = (props: IQueryInputProps) => {
   }
 
   const runQuery = () => {
-    if (!sampleQuery.sampleUrl || sampleQuery.sampleUrl.indexOf('http') === -1) {
+    if (!sampleQuery.sampleUrl || sampleQuery.sampleUrl.indexOf('graph.microsoft.com') === -1) {
       return;
     }
     handleOnRunQuery(sampleQuery);

--- a/src/app/views/query-runner/query-input/auto-complete/auto-complete.util.ts
+++ b/src/app/views/query-runner/query-input/auto-complete/auto-complete.util.ts
@@ -51,6 +51,9 @@ function getErrorMessage(queryUrl: string) {
   if (error) {
     return `${translateMessage('Possible error found in URL near')}: ${error}`;
   }
+  if (queryUrl.indexOf('https://graph.microsoft.com/') === -1){
+    return translateMessage('The URL must start with https://graph.microsoft.com/');
+  }
   return '';
 }
 

--- a/src/app/views/query-runner/query-input/auto-complete/auto-complete.util.ts
+++ b/src/app/views/query-runner/query-input/auto-complete/auto-complete.util.ts
@@ -51,8 +51,8 @@ function getErrorMessage(queryUrl: string) {
   if (error) {
     return `${translateMessage('Possible error found in URL near')}: ${error}`;
   }
-  if (queryUrl.indexOf('https://graph.microsoft.com/') === -1){
-    return translateMessage('The URL must start with https://graph.microsoft.com/');
+  if (queryUrl.indexOf('http') === -1){
+    return translateMessage('The URL must start with http');
   }
   return '';
 }

--- a/src/app/views/query-runner/query-input/auto-complete/auto-complete.util.ts
+++ b/src/app/views/query-runner/query-input/auto-complete/auto-complete.util.ts
@@ -51,8 +51,8 @@ function getErrorMessage(queryUrl: string) {
   if (error) {
     return `${translateMessage('Possible error found in URL near')}: ${error}`;
   }
-  if (queryUrl.indexOf('http') === -1){
-    return translateMessage('The URL must start with http');
+  if (queryUrl.indexOf('graph.microsoft.com') === -1){
+    return translateMessage('The URL must contain graph.microsoft.com');
   }
   return '';
 }

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -471,5 +471,5 @@
   "Scope consent successful": "Scope consent successful",
   "Query documentation": "Query documentation",
   "This token is not a jwt token and cannot be decoded by jwt.ms": "This token is not a jwt token and cannot be decoded by jwt.ms",
-  "The URL must start with https://graph.microsoft.com/": "The URL must start with https://graph.microsoft.com/"
+  "The URL must start with http": "The URL must start with http"
 }

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -471,5 +471,5 @@
   "Scope consent successful": "Scope consent successful",
   "Query documentation": "Query documentation",
   "This token is not a jwt token and cannot be decoded by jwt.ms": "This token is not a jwt token and cannot be decoded by jwt.ms",
-  "The URL must start with http": "The URL must start with http"
+  "The URL must contain graph.microsoft.com": "The URL must contain graph.microsoft.com"
 }

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -470,5 +470,6 @@
   "Permission propagation delay": "Permission propagation delay",
   "Scope consent successful": "Scope consent successful",
   "Query documentation": "Query documentation",
-  "This token is not a jwt token and cannot be decoded by jwt.ms": "This token is not a jwt token and cannot be decoded by jwt.ms"
+  "This token is not a jwt token and cannot be decoded by jwt.ms": "This token is not a jwt token and cannot be decoded by jwt.ms",
+  "The URL must start with https://graph.microsoft.com/": "The URL must start with https://graph.microsoft.com/"
 }


### PR DESCRIPTION
## Overview
Closes #2359 

### Demo
![image](https://user-images.githubusercontent.com/45680252/215702462-28824dff-4444-453d-a2e7-655d1f02cbb2.png)


### Notes
The ABNF validator only validates URLs that have the http/https protocol appended. We therefore need extra validation when the abnf validator is not returning an error. 

## Testing Instructions

* How to test this PR
Backspace on the query URL until there's only http left
See fix