### PR TITLE
Fix: Screen blanking on render

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,8 @@
       justify-content: center;
       align-items: center;
       flex-direction: column;
+      z-index: 9999999999;
+      position: relative;
     }
 
     #spinner-text {
@@ -41,6 +43,10 @@
       border-color: #258ede transparent transparent transparent;
     }
 
+    #spinner p {
+      margin: 0;
+    }
+
     #lds-ring div:nth-child(1) {
       animation-delay: -0.45s;
     }
@@ -51,6 +57,16 @@
 
     #lds-ring div:nth-child(3) {
       animation-delay: -0.15s;
+    }
+
+    .hidden {
+      display: none;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      border: 0;
     }
 
     @keyframes lds-ring {
@@ -77,7 +93,7 @@
     <p id="spinner-text">Loading Graph Explorer</p>
   </div>
   <noscript>You need to enable JavaScript to run this app.</noscript>
-  <div id="root"></div>
+  <div id="root" class="hidden"></div>
 </body>
 
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,6 @@
       justify-content: center;
       align-items: center;
       flex-direction: column;
-      z-index: 9999999999;
       position: relative;
     }
 

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -34,6 +34,7 @@ import { QueryRunner } from './query-runner';
 import { parse } from './query-runner/util/iframe-message-parser';
 import { Sidebar } from './sidebar/Sidebar';
 import { MainHeader } from './main-header/MainHeader';
+import { removeSpinners } from '../..';
 
 export interface IAppProps {
   theme?: ITheme;
@@ -85,6 +86,7 @@ class App extends Component<IAppProps, IAppState> {
   }
 
   public componentDidMount = async () => {
+    removeSpinners();
     this.displayToggleButton(this.mediaQueryList);
     this.mediaQueryList.addListener(this.displayToggleButton);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,21 +28,27 @@ import { IDevxAPI } from './types/devx-api';
 import { Mode } from './types/enums';
 import { fetchResources } from './app/services/actions/resource-explorer-action-creators';
 
-// removes the loading spinner from GE html after the app is loaded
-const spinner = document.getElementById('spinner');
-if (spinner !== null) {
-  (spinner as any).parentElement.removeChild(spinner);
-}
-
-// removes the loading spinner from the portal team html after GE loads
-const apiExplorer = document.getElementsByTagName('api-explorer')[0];
-if (apiExplorer) {
-  (apiExplorer as any).parentElement.removeChild(apiExplorer);
-}
-
+const appRoot: HTMLElement = document.getElementById('root')!;
 initializeIcons();
 
 let currentTheme = readTheme() || 'light';
+export function removeSpinners() {
+  // removes the loading spinner from GE html after the app is loaded
+  const spinner = document.getElementById('spinner');
+  if (spinner !== null) {
+    (spinner as any).parentElement.removeChild(spinner);
+  }
+
+  // removes the loading spinner from the portal team html after GE loads
+  const apiExplorer = document.getElementsByTagName('api-explorer')[0];
+  if (apiExplorer) {
+    (apiExplorer as any).parentElement.removeChild(apiExplorer);
+  }
+
+  // makes appRoot visible
+  appRoot.classList.remove('hidden');
+}
+
 function setCurrentSystemTheme(): void {
   const themeFromLocalStorage = readTheme();
 
@@ -186,5 +192,5 @@ const Root = () => {
     </Provider>
   );
 };
-const root = ReactDOM.createRoot(document.getElementById('root')!);
+const root = ReactDOM.createRoot(appRoot);
 root.render(<Root />);


### PR DESCRIPTION
## Overview
Closes #2402 

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes
React rendering in React18 is a bit different with the other versions. From the documentation, `root.render` clears all HTML before rendering the main component https://beta.reactjs.org/reference/react-dom/client/createRoot#:~:text=The%20first%20time%20you%20call%20root.render%2C%20React%20will%20clear%20all%20the%20existing%20HTML%20content%20inside%20the%20React%20root%20before%20rendering%20the%20React%20component%20into%20it.
 This is why the screen blanks before the main component is rendered. 
Within the componentDidMount method, we are sure that the main component is already in the DOM, so we can safely remove the spinners

## Testing Instructions

* How to test this PR
Load this branch and run GE
Notice that the transition between the loading spinner and the main page is seamless