### PR TITLE
Feature: anonymous experience search queries

### DIFF
--- a/src/app/views/query-runner/query-input/QueryInput.tsx
+++ b/src/app/views/query-runner/query-input/QueryInput.tsx
@@ -10,6 +10,7 @@ import { getStyleFor } from '../../../utils/http-methods.utils';
 import { parseSampleUrl } from '../../../utils/sample-url-generation';
 import { translateMessage } from '../../../utils/translate-messages';
 import SubmitButton from '../../../views/common/submit-button/SubmitButton';
+import { shouldRunQuery } from '../../sidebar/sample-queries/sample-query-utils';
 import { queryRunnerStyles } from '../QueryRunner.styles';
 import { AutoComplete } from './auto-complete';
 import { ShareQuery } from './share-query';
@@ -36,7 +37,10 @@ const QueryInput = (props: IQueryInputProps) => {
   const authenticated = !!authToken.token;
   const { mobileScreen } = sidebarProperties;
 
-  const showError = !authenticated && sampleQuery.selectedVerb !== 'GET';
+  const showError = shouldRunQuery({
+    method: sampleQuery.selectedVerb, authenticated,
+    url: sampleQuery.sampleUrl
+  });
   const { queryButtonStyles, verbSelector, shareQueryButtonStyles } = queryRunnerStyles();
   verbSelector.title = {
     ...verbSelector.title,

--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -25,7 +25,7 @@ import { classNames } from '../../classnames';
 import { NoResultsFound } from '../sidebar-utils/SearchResult';
 import { sidebarStyles } from '../Sidebar.styles';
 import {
-  isJsonString, performSearch, trackDocumentLinkClickedEvent,
+  isJsonString, performSearch, shouldRunQuery, trackDocumentLinkClickedEvent,
   trackSampleQueryClickEvent
 } from './sample-query-utils';
 
@@ -167,7 +167,7 @@ const UnstyledSampleQueries = (sampleProps?: ISampleQueriesProps): JSX.Element =
       onRender: (item: ISampleQuery) => {
         const signInText = translateMessage('Sign In to try this sample');
 
-        if (item.method === 'GET' || tokenPresent) {
+        if (!shouldRunQuery({ method: item.method, authenticated: tokenPresent, url: item.requestUrl })) {
           return <div aria-hidden='true' />;
         }
 
@@ -270,7 +270,8 @@ const UnstyledSampleQueries = (sampleProps?: ISampleQueriesProps): JSX.Element =
     }
 
     if (props) {
-      if (!tokenPresent && props.item.method !== 'GET') {
+      const query: ISampleQuery = props.item!;
+      if (shouldRunQuery({ method: query.method, authenticated: tokenPresent, url: query.requestUrl })) {
         selectionDisabled = true;
       }
       return (
@@ -280,7 +281,6 @@ const UnstyledSampleQueries = (sampleProps?: ISampleQueriesProps): JSX.Element =
             styles={customStyles}
             onClick={() => {
               if (!selectionDisabled) {
-                const query: ISampleQuery = props.item!;
                 querySelected(query);
               }
               setSelectedQuery(props.item)

--- a/src/app/views/sidebar/sample-queries/sample-query-utils.ts
+++ b/src/app/views/sidebar/sample-queries/sample-query-utils.ts
@@ -4,7 +4,7 @@ import { GRAPH_URL } from '../../../services/graph-constants';
 import { validateExternalLink } from '../../../utils/external-link-validation';
 import { sanitizeQueryUrl } from '../../../utils/query-url-sanitization';
 
-export function isJsonString(str: string): boolean {
+function isJsonString(str: string): boolean {
   try {
     JSON.parse(str);
     return true;
@@ -13,7 +13,7 @@ export function isJsonString(str: string): boolean {
   }
 }
 
-export function performSearch(queries: ISampleQuery[], value: string): ISampleQuery[] {
+function performSearch(queries: ISampleQuery[], value: string): ISampleQuery[] {
   const keyword = value.toLowerCase();
   return queries.filter((sample: any) => {
     const name = sample.humanName.toLowerCase();
@@ -22,7 +22,7 @@ export function performSearch(queries: ISampleQuery[], value: string): ISampleQu
   });
 }
 
-export const trackSampleQueryClickEvent = (query: ISampleQuery) => {
+const trackSampleQueryClickEvent = (query: ISampleQuery) => {
   const sanitizedUrl = sanitizeQueryUrl(GRAPH_URL + query.requestUrl);
   telemetry.trackEvent(
     eventTypes.LISTITEM_CLICK_EVENT,
@@ -35,7 +35,7 @@ export const trackSampleQueryClickEvent = (query: ISampleQuery) => {
     });
 }
 
-export const trackDocumentLinkClickedEvent = async (item: ISampleQuery): Promise<void> => {
+const trackDocumentLinkClickedEvent = async (item: ISampleQuery): Promise<void> => {
   const properties: { [key: string]: any } = {
     ComponentName: componentNames.DOCUMENTATION_LINK,
     SampleId: item.id,
@@ -47,4 +47,24 @@ export const trackDocumentLinkClickedEvent = async (item: ISampleQuery): Promise
 
   // Check if link throws error
   validateExternalLink(item.docLink || '', componentNames.DOCUMENTATION_LINK, item.id);
+}
+
+interface ShouldRunQueryArgs {
+  method: string;
+  url: string;
+  authenticated: boolean;
+}
+
+const shouldRunQuery = ({ method, url, authenticated }: ShouldRunQueryArgs): boolean => {
+  const isPOSTException = method === 'POST' && url.contains('search/query');
+  const shouldRun = method === 'GET' || authenticated || isPOSTException;
+  return !shouldRun;
+}
+
+export {
+  trackDocumentLinkClickedEvent,
+  trackSampleQueryClickEvent,
+  performSearch,
+  isJsonString,
+  shouldRunQuery
 }


### PR DESCRIPTION
## Overview

Closes #2230

Allows a user in the anonymous experience to be able to make a POST request tp endpoints in the sample queries `search` category