### PR TITLE
Fix: Enable code selection in Expand view

### DIFF
--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -133,6 +133,7 @@ const QueryResponse = () => {
           isOpen={showModal}
           onDismiss={toggleExpandResponse}
           styles={modalStyles}
+          layerProps={{ eventBubblingEnabled: true }}
         >
           <IconButton
             styles={{


### PR DESCRIPTION
## Overview

Closes #2420

### Demo

![image](https://user-images.githubusercontent.com/18407044/223133520-3fca9b14-5997-433a-a9a0-a39e8b56e5f4.png)

### Notes

The issue was due to React 17 upgrade, this affected how events are controlled and fluentUI mentions this in the docs.
Ref: https://developer.microsoft.com/en-us/fluentui#/controls/web/layer#ILayerProps

## Testing Instructions

* Checkout branch
* Run GET my profile query
* Select Expand Tab
* Try to select/highlight the code on the tab