### PR TITLE
Fix: Suspending letters get cut off

### DIFF
--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -306,7 +306,8 @@ const UnstyledSampleQueries = (sampleProps?: ISampleQueriesProps): JSX.Element =
           check: { display: 'none' },
           title: {
             fontSize: FontSizes.medium,
-            fontWeight: FontWeights.semibold
+            fontWeight: FontWeights.semibold,
+            paddingBottom: 2
           },
           expand: {
             fontSize: FontSizes.small


### PR DESCRIPTION
## Overview
Fixes #2460 : Letters that are supposed to suspend ('g', 'p', 'y') are getting cut off. 


### Demo
Before:
<img width="80" alt="image" src="https://user-images.githubusercontent.com/58787602/226598206-889c4dad-a106-4c6b-ba52-372af8a46379.png">

After
<img width="100" alt="image" src="https://user-images.githubusercontent.com/58787602/226598072-1cecc478-e7ea-4680-b538-15476a3f2078.png">


### Notes

Added a padding to the bottom of the title