### PR TITLE
Fix: Missing return statement

### DIFF
--- a/src/app/views/query-runner/request/permissions/TabList.tsx
+++ b/src/app/views/query-runner/request/permissions/TabList.tsx
@@ -43,13 +43,14 @@ const TabList = ({ columns, classes, renderItemColumn, renderDetailsHeader, maxH
   }
 
   const displayNoPermissionsFoundMessage = () : JSX.Element => {
-    return (<Label styles={permissionsTabStyles}>
-      <FormattedMessage id='permissions not found in permissions tab' />
-      <Link underline onClick={openPermissionsPanel}>
-        <FormattedMessage id='open permissions panel' />
-      </Link>
-      <FormattedMessage id='permissions list' />
-    </Label>);
+    return (
+      <Label styles={permissionsTabStyles}>
+        <FormattedMessage id='permissions not found in permissions tab' />
+        <Link underline onClick={openPermissionsPanel}>
+          <FormattedMessage id='open permissions panel' />
+        </Link>
+        <FormattedMessage id='permissions list' />
+      </Label>);
   }
 
   const displayNotSignedInMessage = () : JSX.Element => {

--- a/src/app/views/query-runner/request/permissions/TabList.tsx
+++ b/src/app/views/query-runner/request/permissions/TabList.tsx
@@ -43,14 +43,13 @@ const TabList = ({ columns, classes, renderItemColumn, renderDetailsHeader, maxH
   }
 
   const displayNoPermissionsFoundMessage = () : JSX.Element => {
-    return (
-      <Label styles={permissionsTabStyles}>
-        <FormattedMessage id='permissions not found in permissions tab' />
-        <Link underline onClick={openPermissionsPanel}>
-          <FormattedMessage id='open permissions panel' />
-        </Link>
-        <FormattedMessage id='permissions list' />
-      </Label>);
+    return (<Label styles={permissionsTabStyles}>
+      <FormattedMessage id='permissions not found in permissions tab' />
+      <Link underline onClick={openPermissionsPanel}>
+        <FormattedMessage id='open permissions panel' />
+      </Link>
+      <FormattedMessage id='permissions list' />
+    </Label>);
   }
 
   const displayNotSignedInMessage = () : JSX.Element => {
@@ -65,7 +64,7 @@ const TabList = ({ columns, classes, renderItemColumn, renderDetailsHeader, maxH
   }
 
   if(permissions.length === 0){
-    displayNoPermissionsFoundMessage()
+    return displayNoPermissionsFoundMessage();
   }
 
   return (

--- a/src/tests/ui/anonymous-experiences/request.spec.ts
+++ b/src/tests/ui/anonymous-experiences/request.spec.ts
@@ -322,6 +322,17 @@ test.describe('Permissions', () => {
     expect(await page.screenshot()).toMatchSnapshot();
     const DirectoryPermission =  page.locator('div[role="gridcell"]:has-text("Directory.Read.AllDirectory.Read.All")');
     expect(DirectoryPermission).toBeDefined();
+  });
+
+  test('should show a message for opening permissions panel when permission requested is not available', async () => {
+    const queryInput = page.locator('[aria-label="Query sample input"]');
+    await queryInput.click();
+    queryInput.fill('https://graph.microsoft.com/v1.0/userssssss');
+    await page.locator('[aria-label="Modify permissions"]').click();
+    await page.evaluate(() => document.fonts.ready);
+    await page.waitForTimeout(100);
+    expect(page.getByText('Permissions for the query are missing on this tab. Sign in to use the Select per')).toBeDefined();
+
   })
 })
 

--- a/src/tests/ui/authenticated-experiences/authenticated-experiences.spec.ts
+++ b/src/tests/ui/authenticated-experiences/authenticated-experiences.spec.ts
@@ -45,6 +45,16 @@ test.describe('Request', () => {
     ]);
     expect(page5.url().indexOf('https://jwt.ms/')).toBeGreaterThan(-1);
   })
+
+  test('Permissions tab asks user to open permissions panel to view more permissions if missing on the tab', async () => {
+    const queryInput = authenticatedPage.locator('[aria-label="Query sample input"]');
+    await queryInput.click();
+    queryInput.fill('https://graph.microsoft.com/v1.0/userssssss');
+    await authenticatedPage.locator('[aria-label="Modify permissions"]').click();
+    await authenticatedPage.evaluate(() => document.fonts.ready);
+    await authenticatedPage.waitForTimeout(100);
+    expect(authenticatedPage.getByText('Permissions for the query are missing on this tab. Open the permissions panel to')).toBeDefined();
+  })
 })
 
 test.describe.serial('Profile', () => {


### PR DESCRIPTION
## Overview
When peermissions are not found on the permissions tab, the correct message is not displayed

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
Type a query like https://graph.microsoft.com/v1.0/meeeeees
Click on the Modify Permissions tab
Notice fix