### PR TITLE
Fix: Modify permissions tab resize

### DIFF
--- a/src/app/views/query-runner/request/Request.tsx
+++ b/src/app/views/query-runner/request/Request.tsx
@@ -134,6 +134,18 @@ const Request = (props: any) => {
     dispatch(setDimensions(dimen));
   };
 
+  // Resizable element does not update it's size when the browser window is resized.
+  // This is a workaround to reset the height
+  window.addEventListener('resize', () => {
+    const resizable = document.getElementsByClassName('request-resizable');
+    if (resizable && resizable.length > 0) {
+      const resizableElement = resizable[0] as HTMLElement;
+      if(resizableElement && resizableElement.style && resizableElement.style.height){
+        resizableElement.style.height = '';
+      }
+    }
+  });
+
   return (
     <>
       <Resizable
@@ -155,6 +167,7 @@ const Request = (props: any) => {
         enable={{
           bottom: true
         }}
+        className='request-resizable'
       >
         <div className='query-request'>
           <Pivot

--- a/src/app/views/query-runner/request/request.scss
+++ b/src/app/views/query-runner/request/request.scss
@@ -53,4 +53,5 @@
 
 .query-request {
     overflow: hidden;
+    height: inherit;
 }


### PR DESCRIPTION
## Overview
Closes #2516 

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes
Test on monitors above 25inches

## Testing Instructions

* How to test this PR
1. Resize the browser window
2. Click on Modify Permissions tab
3. Drag the resize handler at the bottom of the permissions tab
4. Resize the browser window again to full screen
5. Notice that the tab resizes well into the screen