### PR TITLE
Fix: Persist sample body

### DIFF
--- a/src/app/views/query-runner/QueryRunner.tsx
+++ b/src/app/views/query-runner/QueryRunner.tsx
@@ -36,6 +36,9 @@ const QueryRunner = (props: any) => {
 
   const handleOnEditorChange = (value?: string) => {
     setSampleBody(value!);
+    const query = { ...sampleQuery };
+    query.sampleBody = value;
+    dispatch(setSampleQuery(query));
   };
 
   const handleOnRunQuery = (query?: IQuery) => {
@@ -55,8 +58,6 @@ const QueryRunner = (props: any) => {
           setSampleBody('');
           return;
         }
-      } else {
-        sampleQuery.sampleBody = sampleBody;
       }
     }
     if(query) {

--- a/src/app/views/query-runner/QueryRunner.tsx
+++ b/src/app/views/query-runner/QueryRunner.tsx
@@ -37,29 +37,24 @@ const QueryRunner = (props: any) => {
   const handleOnEditorChange = (value?: string) => {
     setSampleBody(value!);
     const query = { ...sampleQuery };
-    query.sampleBody = value;
-    dispatch(setSampleQuery(query));
+    const headers = query.sampleHeaders;
+    const contentType = headers.find(k => k.name.toLowerCase() === 'content-type');
+    if (!contentType || (contentType.value === ContentType.Json)) {
+      try {
+        query.sampleBody = JSON.parse(sampleBody);
+        dispatch(setSampleQuery(query));
+      } catch (error) {
+        dispatch(setQueryResponseStatus({
+          ok: false,
+          statusText: translateMessage('Malformed JSON body'),
+          status: `${translateMessage('Review the request body')} ${error}`,
+          messageType: MessageBarType.error
+        }));
+      }
+    }
   };
 
   const handleOnRunQuery = (query?: IQuery) => {
-    if (sampleBody) {
-      const headers = sampleQuery.sampleHeaders;
-      const contentType = headers.find(k => k.name.toLowerCase() === 'content-type');
-      if (!contentType || (contentType.value === ContentType.Json)) {
-        try {
-          sampleQuery.sampleBody = JSON.parse(sampleBody);
-        } catch (error) {
-          dispatch(setQueryResponseStatus({
-            ok: false,
-            statusText: translateMessage('Malformed JSON body'),
-            status: `${translateMessage('Review the request body')} ${error}`,
-            messageType: MessageBarType.error
-          }));
-          setSampleBody('');
-          return;
-        }
-      }
-    }
     if(query) {
       sampleQuery.sampleUrl = query.sampleUrl;
       sampleQuery.selectedVersion = query.selectedVersion;


### PR DESCRIPTION
## Overview
Closes #2517 

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes
The Request body monaco editor gets its content from the redux state. To persist the sample body, we have to update the sample query in the redux store whenever the samplebody changes

We are no longer clearing the sample body when a user adds a malformed JSON. This allows a user to edit the sample body

## Testing Instructions

* How to test this PR
Add a query that has a sample body
Tab through the app
Notice that the sample body is persisted through tabs