### PR TITLE
Fix: collection status for nodes with IDs

### DIFF
--- a/src/app/views/sidebar/resource-explorer/resourcelink.utils.spec.ts
+++ b/src/app/views/sidebar/resource-explorer/resourcelink.utils.spec.ts
@@ -1,0 +1,139 @@
+import { IResourceLink, ResourceLinkType } from '../../../../types/resources';
+import { existsInCollection } from './resourcelink.utils';
+
+const collectionPaths: IResourceLink[] = [
+  {
+    key: '3-{agreementAcceptance-id}-{agreementAcceptance-id}-get-v1.0',
+    url: '/agreementAcceptances/{agreementAcceptance-id}',
+    name: '{agreementAcceptance-id}',
+    labels: [],
+    isExpanded: false,
+    parent: '{agreementAcceptance-id}',
+    level: 3,
+    paths: [
+      '/',
+      'agreementAcceptances',
+      '{agreementAcceptance-id}'
+    ],
+    method: 'Get',
+    type: ResourceLinkType.PATH,
+    links: [],
+    docLink: '',
+    version: 'v1.0'
+  },
+  {
+    key: '3-{agreementAcceptance-id}-{agreementAcceptance-id}-patch-v1.0',
+    url: '/agreementAcceptances/{agreementAcceptance-id}',
+    name: '{agreementAcceptance-id}',
+    labels: [],
+    isExpanded: false,
+    parent: '{agreementAcceptance-id}',
+    level: 3,
+    paths: [
+      '/',
+      'agreementAcceptances',
+      '{agreementAcceptance-id}'
+    ],
+    method: 'Patch',
+    type: ResourceLinkType.PATH,
+    links: [],
+    docLink: '',
+    version: 'v1.0'
+  }
+]
+describe('Resource link should', () => {
+  it('find if parameter node exists in collection', async () => {
+    const link = {
+      key: '2-agreementAcceptances-{agreementAcceptance-id}',
+      url: '2-agreementAcceptances-{agreementAcceptance-id}',
+      name: '{agreementAcceptance-id} (3)',
+      labels: [
+        {
+          name: 'beta',
+          methods: [
+            'Get',
+            'Patch',
+            'Delete'
+          ]
+        },
+        {
+          name: 'v1.0',
+          methods: [
+            'Get',
+            'Patch',
+            'Delete'
+          ]
+        }
+      ],
+      isExpanded: false,
+      parent: 'agreementAcceptances',
+      level: 2,
+      paths: [
+        '/',
+        'agreementAcceptances'
+      ],
+      type: 'node',
+      links: [
+        {
+          key: '3-{agreementAcceptance-id}-{agreementAcceptance-id}-get',
+          url: '3-{agreementAcceptance-id}-{agreementAcceptance-id}-get',
+          name: '{agreementAcceptance-id}',
+          labels: [],
+          isExpanded: false,
+          parent: '{agreementAcceptance-id}',
+          level: 3,
+          paths: [
+            '/',
+            'agreementAcceptances',
+            '{agreementAcceptance-id}'
+          ],
+          method: 'Get',
+          type: 'path',
+          links: [],
+          docLink: ''
+        },
+        {
+          key: '3-{agreementAcceptance-id}-{agreementAcceptance-id}-patch',
+          url: '3-{agreementAcceptance-id}-{agreementAcceptance-id}-patch',
+          name: '{agreementAcceptance-id}',
+          labels: [],
+          isExpanded: false,
+          parent: '{agreementAcceptance-id}',
+          level: 3,
+          paths: [
+            '/',
+            'agreementAcceptances',
+            '{agreementAcceptance-id}'
+          ],
+          method: 'Patch',
+          type: 'path',
+          links: [],
+          docLink: ''
+        }
+      ],
+      docLink: ''
+    } as IResourceLink;
+    const version = 'v1.0';
+
+    expect(existsInCollection(link, collectionPaths, version)).toBeTruthy();
+    expect(existsInCollection(
+      {
+        key: '3-{agreementAcceptance-id}-{agreementAcceptance-id}-delete',
+        url: '3-{agreementAcceptance-id}-{agreementAcceptance-id}-delete',
+        name: '{agreementAcceptance-id}',
+        labels: [],
+        isExpanded: false,
+        parent: '{agreementAcceptance-id}',
+        level: 3,
+        paths: [
+          '/',
+          'agreementAcceptances',
+          '{agreementAcceptance-id}'
+        ],
+        method: 'Delete',
+        type: ResourceLinkType.PATH,
+        links: [],
+        docLink: ''
+      }, collectionPaths, 'beta')).toBeFalsy();
+  });
+});

--- a/src/app/views/sidebar/resource-explorer/resourcelink.utils.ts
+++ b/src/app/views/sidebar/resource-explorer/resourcelink.utils.ts
@@ -6,7 +6,8 @@ export const existsInCollection = (link: IResourceLink, paths: IResourceLink[], 
     const found = paths.find(p => p.key === `${link.key}-${version}` || p.key === link.key);
     return !!found;
   } else {
-    const resourceUrl = getUrlFromLink(link) + '/' + link.url.split('-').pop();
+    let resourceUrl = getUrlFromLink(link) + '/';
+    resourceUrl += link.type === 'node' ? link.name.split(' ')[0] : link.url.split('-').pop();
     const pathsInCollection = paths.filter(p => p.url.startsWith(resourceUrl) &&
       p.key!.split('-').pop() === version);
     if (pathsInCollection.length > 0) {


### PR DESCRIPTION
## Overview

Nodes that are ids e.g. {agreementAcceptance-id} were not showing the correct status when all their children have been added to a collection. This confirms that they are captured correctly