### PR TITLE
Chore: ensure unique paths

### DIFF
--- a/src/app/middleware/localStorageMiddleware.ts
+++ b/src/app/middleware/localStorageMiddleware.ts
@@ -5,6 +5,7 @@ import { saveTheme } from '../../themes/theme-utils';
 import { AppAction } from '../../types/action';
 import { ResourcePath } from '../../types/resources';
 import { addResourcePaths } from '../services/actions/collections-action-creators';
+import { getUniquePaths } from '../services/reducers/collections-reducer.util';
 import {
   CHANGE_THEME_SUCCESS, COLLECTION_CREATE_SUCCESS, FETCH_RESOURCES_ERROR, FETCH_RESOURCES_SUCCESS,
   RESOURCEPATHS_ADD_SUCCESS, RESOURCEPATHS_DELETE_SUCCESS, SAMPLES_FETCH_SUCCESS
@@ -23,7 +24,7 @@ const localStorageMiddleware = (store: any) => (next: any) => async (action: App
     case RESOURCEPATHS_ADD_SUCCESS: {
       const collections = await collectionsCache.read();
       const item = collections.find(k => k.isDefault)!;
-      item.paths = Array.from(new Set([...item.paths, ...action.response]));
+      item.paths = getUniquePaths(item.paths, action.response);
       await collectionsCache.update(item.id, item);
       break;
     }

--- a/src/app/services/reducers/collections-reducer.spec.ts
+++ b/src/app/services/reducers/collections-reducer.spec.ts
@@ -109,4 +109,15 @@ describe('Collections Reducer', () => {
     expect(state_).toEqual(newState);
   });
 
+  it('should handle RESOURCEPATHS_ADD_SUCCESS and return unique paths', () => {
+    const newState = [...initialState];
+    newState[0].paths = paths;
+    const action_ = {
+      type: RESOURCEPATHS_ADD_SUCCESS,
+      response: [paths[0]]
+    }
+    const state_ = collections(newState, action_);
+    expect(state_[0].paths.length).toEqual(paths.length);
+  });
+
 });

--- a/src/app/services/reducers/collections-reducer.ts
+++ b/src/app/services/reducers/collections-reducer.ts
@@ -4,6 +4,7 @@ import {
   COLLECTION_CREATE_SUCCESS,
   RESOURCEPATHS_ADD_SUCCESS, RESOURCEPATHS_DELETE_SUCCESS
 } from '../redux-constants';
+import { getUniquePaths } from './collections-reducer.util';
 
 const initialState: Collection[] = [];
 
@@ -18,9 +19,7 @@ export function collections(state: Collection[] = initialState, action: AppActio
     case RESOURCEPATHS_ADD_SUCCESS:
       const index = state.findIndex(k => k.isDefault);
       if (index > -1) {
-        const paths: ResourcePath[] = Array.from(
-          new Set([...state[index].paths, ...action.response])
-        );
+        const paths: ResourcePath[] = getUniquePaths(state[index].paths, action.response);
         const context = [...state];
         context[index].paths = paths;
         return context;

--- a/src/app/services/reducers/collections-reducer.util.ts
+++ b/src/app/services/reducers/collections-reducer.util.ts
@@ -1,0 +1,12 @@
+import { AppAction } from '../../../types/action';
+import { ResourcePath } from '../../../types/resources';
+
+const getUniquePaths = (paths: ResourcePath[], action: AppAction): ResourcePath[] => {
+  return Array.from(
+    new Set([...paths, ...action.response])
+  );
+}
+
+export {
+  getUniquePaths
+}

--- a/src/app/services/reducers/collections-reducer.util.ts
+++ b/src/app/services/reducers/collections-reducer.util.ts
@@ -1,12 +1,16 @@
-import { AppAction } from '../../../types/action';
 import { ResourcePath } from '../../../types/resources';
 
-const getUniquePaths = (paths: ResourcePath[], action: AppAction): ResourcePath[] => {
-  return Array.from(
-    new Set([...paths, ...action.response])
-  );
+const getUniquePaths = (paths: ResourcePath[], items: ResourcePath[]): ResourcePath[] => {
+  const content: ResourcePath[] = [...paths];
+  items.forEach((element: any) => {
+    const exists = !!content.find(k => k.key === element.key);
+    if (!exists) {
+      content.push(element);
+    }
+  });
+  return content;
 }
 
 export {
   getUniquePaths
-}
+};


### PR DESCRIPTION
## Overview

The current check doesn't guarantee that items added to the collection are unique. 
This PR also guarantees that the logic is repeated when updating the underlying collection
