### PR TITLE
Create microsoft-graph-explorer-v4-branch-protection.yml

### DIFF
--- a/.github/policies/microsoft-graph-explorer-v4-branch-protection.yml
+++ b/.github/policies/microsoft-graph-explorer-v4-branch-protection.yml
@@ -1,0 +1,86 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# File initially created using https://github.com/MIchaelMainer/policyservicetoolkit/blob/main/branch_protection_export.ps1.
+
+name: microsoft-graph-explorer-v4-branch-protection
+description: Branch protection policy for the microsoft-graph-explorer-v4 repository
+resource: repository
+configuration:
+  branchProtectionRules:
+
+  - branchNamePattern: dev
+    # This branch pattern applies to the following branches as of 06/09/2023 14:08:40:
+    # dev
+
+    # Specifies whether this branch can be deleted. boolean
+    allowsDeletions: false
+    # Specifies whether forced pushes are allowed on this branch. boolean
+    allowsForcePushes: false
+    # Specifies whether new commits pushed to the matching branches dismiss pull request review approvals. boolean
+    dismissStaleReviews: true
+    # Specifies whether admins can overwrite branch protection. boolean
+    isAdminEnforced: false
+    # Indicates whether "Require a pull request before merging" is enabled. boolean
+    requiresPullRequestBeforeMerging: true
+    # Specifies the number of pull request reviews before merging. int (0-6). Should be null/empty if PRs are not required
+    requiredApprovingReviewsCount: 1
+    # Require review from Code Owners. Requires requiredApprovingReviewsCount. boolean
+    requireCodeOwnersReview: true
+    # Are commits required to be signed. boolean. TODO: all contributors must have commit signing on local machines.
+    requiresCommitSignatures: false
+    # Are conversations required to be resolved before merging? boolean
+    requiresConversationResolution: true
+    # Are merge commits prohibited from being pushed to this branch. boolean
+    requiresLinearHistory: true
+    # Required status checks to pass before merging. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
+    requiredStatusChecks:
+    - license/cla
+    - Build packages
+    - Test (1)
+    - Test (2)
+    - Test (3)
+    - Test (4)
+    - Test (5)
+    - Test (6)
+    - Lint
+    # Require branches to be up to date before merging. Requires requiredStatusChecks. boolean
+    requiresStrictStatusChecks: true
+    # Indicates whether there are restrictions on who can push. boolean. Should be set with whoCanPush.
+    restrictsPushes: false
+    # Restrict who can dismiss pull request reviews. boolean
+    restrictsReviewDismissals: false
+
+  - branchNamePattern: master
+    # This branch pattern applies to the following branches as of 06/09/2023 14:08:40:
+    # master
+
+    # Specifies whether this branch can be deleted. boolean
+    allowsDeletions: false
+    # Specifies whether forced pushes are allowed on this branch. boolean
+    allowsForcePushes: false
+    # Specifies whether new commits pushed to the matching branches dismiss pull request review approvals. boolean
+    dismissStaleReviews: true
+    # Specifies whether admins can overwrite branch protection. boolean
+    isAdminEnforced: false
+    # Indicates whether "Require a pull request before merging" is enabled. boolean
+    requiresPullRequestBeforeMerging: true
+    # Specifies the number of pull request reviews before merging. int (0-6). Should be null/empty if PRs are not required
+    requiredApprovingReviewsCount: 1
+    # Require review from Code Owners. Requires requiredApprovingReviewsCount. boolean
+    requireCodeOwnersReview: true
+    # Are commits required to be signed. boolean. TODO: all contributors must have commit signing on local machines.
+    requiresCommitSignatures: false
+    # Are conversations required to be resolved before merging? boolean
+    requiresConversationResolution: false
+    # Are merge commits prohibited from being pushed to this branch. boolean
+    requiresLinearHistory: false
+    # Required status checks to pass before merging. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
+    requiredStatusChecks:
+    # Require branches to be up to date before merging. Requires requiredStatusChecks. boolean
+    requiresStrictStatusChecks: true
+    # Indicates whether there are restrictions on who can push. boolean. Should be set with whoCanPush.
+    restrictsPushes: true
+    # Restrict who can dismiss pull request reviews. boolean
+    restrictsReviewDismissals: false
+


### PR DESCRIPTION
Capture current policy state so that we can make versioned changes to branch protection policies. This will enable policy history, auditing, review, standardization, and templatization. We will update policy in later PR.

We can ignore the rule that states: `At least one value under RequiredStatusChecks must be specified when RequiresStrictStatusChecks is true.` This is getting removed https://github.com/microsoft/GitOps.Branches/pull/73 https://github.com/microsoft/GitOps.Branches/issues/72
