### PR TITLE
Fix: remove all trailing dots

### DIFF
--- a/src/app/views/app-sections/StatusMessages.tsx
+++ b/src/app/views/app-sections/StatusMessages.tsx
@@ -46,6 +46,7 @@ const StatusMessages = () => {
 
   function setQuery(link: string) {
     const query: IQuery = { ...sampleQuery };
+    link = link.replace(/\.$/, '');
     query.sampleUrl = link;
     query.selectedVerb = 'GET';
     dispatch(setSampleQuery(query));


### PR DESCRIPTION

## Overview

Fixes #2616

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Spin up this branch locally
* Expand 'Excel' in the sample queries
* Click on 'GET worksheets in a workbook'
* Tip is displayed reading "Tip - This query requires a driveItem id…"
* Click the sample query to copy it to the query textbox
* Notice the query is added without the trailing dot
