### PR TITLE
Chore: Mention user in external issues

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1076,7 +1076,7 @@
           {
             "name": "addReply",
             "parameters": {
-              "comment": "Hello ${issueAuthor}\n\nThank you for reporting your concern. Unfortunately, we in the Graph Explorer team do not have any ownership of the APIs that are causing you issues. If you report this issue in the Microsoft Q&A forum, it will get routed to the appropriate team for them to triage.\n\nhttps://aka.ms/askgraph"
+              "comment": "Hello @${issueAuthor}\n\nThank you for reporting your concern. Unfortunately, we in the Graph Explorer team do not have any ownership of the APIs that are causing you issues. If you report this issue in the Microsoft Q&A forum, it will get routed to the appropriate team for them to triage.\n\nhttps://aka.ms/askgraph"
             }
           },
           {
@@ -1337,7 +1337,7 @@
           {
             "name": "addReply",
             "parameters": {
-              "comment": "Hello ${issueAuthor}\n\nThank you for reporting your concern. Unfortunately, we in the Graph Explorer team do not have any ownership of the APIs that are causing you issues. If you report this issue in the Microsoft Q&A forum, it will get routed to the appropriate team for them to triage.\n\nhttps://aka.ms/askgraph"
+              "comment": "Hello @${issueAuthor}\n\nThank you for reporting your concern. Unfortunately, we in the Graph Explorer team do not have any ownership of the APIs that are causing you issues. If you report this issue in the Microsoft Q&A forum, it will get routed to the appropriate team for them to triage.\n\nhttps://aka.ms/askgraph"
             }
           }
         ]


### PR DESCRIPTION
## Overview

This PR solves a nit pick. When users leave comments on issues that are responded to by the bot, they are not mentioned. Their usernames are just commented. Adding an '@' infront of the username would make sure that Github recognises it as a mention