### PR TITLE
Fix: Show documentation URL for supported Resource Explorer items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-explorer-v2",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
         "name": "graph-explorer-v2",
-        "version": "9.0.0",
+        "version": "9.0.1",
         "private": true,
         "dependencies": {
                 "@augloop/types-core": "file:packages/types-core-2.16.189.tgz",

--- a/src/app/views/sidebar/resource-explorer/ResourceLink.tsx
+++ b/src/app/views/sidebar/resource-explorer/ResourceLink.tsx
@@ -7,9 +7,12 @@ import { CSSProperties, useEffect } from 'react';
 import { useAppSelector } from '../../../../store';
 import { componentNames, eventTypes, telemetry } from '../../../../telemetry';
 import { IResourceLink, ResourceOptions } from '../../../../types/resources';
+import { GRAPH_URL } from '../../../services/graph-constants';
 import { validateExternalLink } from '../../../utils/external-link-validation';
 import { getStyleFor } from '../../../utils/http-methods.utils';
 import { translateMessage } from '../../../utils/translate-messages';
+import DocumentationService from '../../query-runner/query-input/auto-complete/suffix/documentation';
+import { getUrlFromLink } from './resource-explorer.utils';
 import { existsInCollection, setExisting } from './resourcelink.utils';
 
 interface IResourceLinkProps {
@@ -21,7 +24,7 @@ interface IResourceLinkProps {
 
 const ResourceLink = (props: IResourceLinkProps) => {
   const { classes, version } = props;
-  const { collections } = useAppSelector(state => state);
+  const { collections, resources } = useAppSelector(state => state);
   const link = props.link as IResourceLink;
 
   const paths = collections?.find(k => k.isDefault)?.paths || [];
@@ -77,6 +80,17 @@ const ResourceLink = (props: IResourceLinkProps) => {
     margin: 2,
     textTransform: 'uppercase'
   }
+
+  resourceLink.docLink = resourceLink.docLink ? resourceLink.docLink : resourceLink.method ? new DocumentationService({
+    sampleQuery: {
+      sampleUrl: `${GRAPH_URL}/${version}${getUrlFromLink(resourceLink.paths)}`,
+      selectedVerb: resourceLink.method,
+      selectedVersion: version!,
+      sampleBody: '',
+      sampleHeaders: []
+    },
+    source: resources.data.children
+  }).getDocumentationLink() : null;
 
   const openDocumentationLink = () => {
     window.open(resourceLink.docLink, '_blank');

--- a/src/app/views/sidebar/resource-explorer/ResourceLink.tsx
+++ b/src/app/views/sidebar/resource-explorer/ResourceLink.tsx
@@ -6,7 +6,7 @@ import { CSSProperties, useEffect } from 'react';
 
 import { useAppSelector } from '../../../../store';
 import { componentNames, eventTypes, telemetry } from '../../../../telemetry';
-import { IResourceLink, ResourceOptions } from '../../../../types/resources';
+import { IResourceLink, IResources, ResourceOptions } from '../../../../types/resources';
 import { GRAPH_URL } from '../../../services/graph-constants';
 import { validateExternalLink } from '../../../utils/external-link-validation';
 import { getStyleFor } from '../../../utils/http-methods.utils';
@@ -81,16 +81,8 @@ const ResourceLink = (props: IResourceLinkProps) => {
     textTransform: 'uppercase'
   }
 
-  resourceLink.docLink = resourceLink.docLink ? resourceLink.docLink : resourceLink.method ? new DocumentationService({
-    sampleQuery: {
-      sampleUrl: `${GRAPH_URL}/${version}${getUrlFromLink(resourceLink.paths)}`,
-      selectedVerb: resourceLink.method,
-      selectedVersion: version!,
-      sampleBody: '',
-      sampleHeaders: []
-    },
-    source: resources.data.children
-  }).getDocumentationLink() : null;
+  resourceLink.docLink = resourceLink.docLink ? resourceLink.docLink
+    : getDocumentationLink(resourceLink, version, resources);
 
   const openDocumentationLink = () => {
     window.open(resourceLink.docLink, '_blank');
@@ -200,3 +192,21 @@ const ResourceLink = (props: IResourceLinkProps) => {
 
 
 export default ResourceLink;
+
+function getDocumentationLink(resourceLink: IResourceLink, version: string, resources: IResources): string | null {
+  if (!resourceLink.method) {
+    return null;
+  }
+
+  return new DocumentationService({
+    sampleQuery: {
+      sampleUrl: `${GRAPH_URL}/${version}${getUrlFromLink(resourceLink.paths)}`,
+      selectedVerb: resourceLink.method,
+      selectedVersion: version,
+      sampleBody: '',
+      sampleHeaders: []
+    },
+    source: resources.data.children
+  }).getDocumentationLink();
+}
+


### PR DESCRIPTION
## Overview

Some nodes like chats in the Resource Explorer, which have documentation links, didn't have their links showing. This changes now with a difference in implementation to make it similar to the Query bar.

### Demo

Before: 
![image](https://github.com/microsoftgraph/microsoft-graph-explorer-v4/assets/58787602/b24bebb8-62cb-49a5-8763-72fbe3b9bf46)

After:
![image](https://github.com/microsoftgraph/microsoft-graph-explorer-v4/assets/58787602/b128a53d-ac0b-4f0a-9183-7c8d443d0e4f)

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Spin up GE locally
* Append ?devx-api=https://graphexplorerapi-staging.azurewebsites.net to change the destination
* open the chats node
* Notice children in the chats node have their documentation showing