### PR TITLE
Fix: Ensure collections are initiated in store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-explorer-v2",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
         "name": "graph-explorer-v2",
-        "version": "9.0.0",
+        "version": "9.0.1",
         "private": true,
         "dependencies": {
                 "@augloop/types-core": "file:packages/types-core-2.16.189.tgz",

--- a/src/app/views/sidebar/resource-explorer/ResourceExplorer.tsx
+++ b/src/app/views/sidebar/resource-explorer/ResourceExplorer.tsx
@@ -38,7 +38,7 @@ const UnstyledResourceExplorer = (props: any) => {
 
   const dispatch: AppDispatch = useDispatch();
   const classes = classNames(props);
-  const selectedLinks = collections ? collections.find(k => k.isDefault)!.paths : [];
+  const selectedLinks = collections && collections.length > 0 ? collections.find(k => k.isDefault)!.paths : [];
   const versions: any[] = [
     { key: 'v1.0', text: 'v1.0' },
     { key: 'beta', text: 'beta' }

--- a/src/app/views/sidebar/resource-explorer/ResourceLink.tsx
+++ b/src/app/views/sidebar/resource-explorer/ResourceLink.tsx
@@ -7,9 +7,12 @@ import { CSSProperties, useEffect } from 'react';
 import { useAppSelector } from '../../../../store';
 import { componentNames, eventTypes, telemetry } from '../../../../telemetry';
 import { IResourceLink, ResourceOptions } from '../../../../types/resources';
+import { GRAPH_URL } from '../../../services/graph-constants';
 import { validateExternalLink } from '../../../utils/external-link-validation';
 import { getStyleFor } from '../../../utils/http-methods.utils';
 import { translateMessage } from '../../../utils/translate-messages';
+import DocumentationService from '../../query-runner/query-input/auto-complete/suffix/documentation';
+import { getUrlFromLink } from './resource-explorer.utils';
 import { existsInCollection, setExisting } from './resourcelink.utils';
 
 interface IResourceLinkProps {
@@ -21,7 +24,7 @@ interface IResourceLinkProps {
 
 const ResourceLink = (props: IResourceLinkProps) => {
   const { classes, version } = props;
-  const { collections } = useAppSelector(state => state);
+  const { collections, resources } = useAppSelector(state => state);
   const link = props.link as IResourceLink;
 
   const paths = collections?.find(k => k.isDefault)?.paths || [];
@@ -77,6 +80,17 @@ const ResourceLink = (props: IResourceLinkProps) => {
     margin: 2,
     textTransform: 'uppercase'
   }
+
+  resourceLink.docLink = resourceLink.docLink ? resourceLink.docLink : resourceLink.method ? new DocumentationService({
+    sampleQuery: {
+      sampleUrl: `${GRAPH_URL}/${version}${getUrlFromLink(resourceLink.paths)}`,
+      selectedVerb: resourceLink.method,
+      selectedVersion: version!,
+      sampleBody: '',
+      sampleHeaders: []
+    },
+    source: resources.data.children
+  }).getDocumentationLink() : null;
 
   const openDocumentationLink = () => {
     window.open(resourceLink.docLink, '_blank');

--- a/src/app/views/sidebar/resource-explorer/ResourceLink.tsx
+++ b/src/app/views/sidebar/resource-explorer/ResourceLink.tsx
@@ -6,7 +6,7 @@ import { CSSProperties, useEffect } from 'react';
 
 import { useAppSelector } from '../../../../store';
 import { componentNames, eventTypes, telemetry } from '../../../../telemetry';
-import { IResourceLink, ResourceOptions } from '../../../../types/resources';
+import { IResourceLink, IResources, ResourceOptions } from '../../../../types/resources';
 import { GRAPH_URL } from '../../../services/graph-constants';
 import { validateExternalLink } from '../../../utils/external-link-validation';
 import { getStyleFor } from '../../../utils/http-methods.utils';
@@ -81,16 +81,8 @@ const ResourceLink = (props: IResourceLinkProps) => {
     textTransform: 'uppercase'
   }
 
-  resourceLink.docLink = resourceLink.docLink ? resourceLink.docLink : resourceLink.method ? new DocumentationService({
-    sampleQuery: {
-      sampleUrl: `${GRAPH_URL}/${version}${getUrlFromLink(resourceLink.paths)}`,
-      selectedVerb: resourceLink.method,
-      selectedVersion: version!,
-      sampleBody: '',
-      sampleHeaders: []
-    },
-    source: resources.data.children
-  }).getDocumentationLink() : null;
+  resourceLink.docLink = resourceLink.docLink ? resourceLink.docLink
+    : getDocumentationLink(resourceLink, version, resources);
 
   const openDocumentationLink = () => {
     window.open(resourceLink.docLink, '_blank');
@@ -200,3 +192,21 @@ const ResourceLink = (props: IResourceLinkProps) => {
 
 
 export default ResourceLink;
+
+function getDocumentationLink(resourceLink: IResourceLink, version: string, resources: IResources): string | null {
+  if (!resourceLink.method) {
+    return null;
+  }
+
+  return new DocumentationService({
+    sampleQuery: {
+      sampleUrl: `${GRAPH_URL}/${version}${getUrlFromLink(resourceLink.paths)}`,
+      selectedVerb: resourceLink.method,
+      selectedVersion: version,
+      sampleBody: '',
+      sampleHeaders: []
+    },
+    source: resources.data.children
+  }).getDocumentationLink();
+}
+

--- a/src/app/views/sidebar/resource-explorer/collection/PreviewCollection.tsx
+++ b/src/app/views/sidebar/resource-explorer/collection/PreviewCollection.tsx
@@ -23,7 +23,7 @@ const PathsReview: React.FC<PopupsComponent<IPathsReview>> = (props) => {
   const { collections } = useAppSelector(
     (state) => state
   );
-  const items = collections ? collections.find(k => k.isDefault)!.paths : [];
+  const items = collections && collections.length > 0 ? collections.find(k => k.isDefault)!.paths : [];
   const [selectedItems, setSelectedItems] = useState<IResourceLink[]>([]);
 
   const columns = [

--- a/src/app/views/sidebar/resource-explorer/command-options/CommandOptions.tsx
+++ b/src/app/views/sidebar/resource-explorer/command-options/CommandOptions.tsx
@@ -24,7 +24,7 @@ const CommandOptions = (props: ICommandOptions) => {
   const theme = getTheme();
 
   const { collections } = useAppSelector((state) => state);
-  const paths = collections ? collections.find(k => k.isDefault)!.paths : [];
+  const paths = collections && collections.length > 0 ? collections.find(k => k.isDefault)!.paths : [];
 
   const itemStyles = resourceExplorerStyles(theme).itemStyles;
   const commandStyles = resourceExplorerStyles(theme).commandBarStyles;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -39,7 +39,8 @@ const initialState: any = {
     sampleHeaders: [],
     selectedVersion: 'v1.0'
   },
-  termsOfUse: true
+  termsOfUse: true,
+  collections: []
 };
 
 export const store = createStore(


### PR DESCRIPTION
## Overview

When the store is not initialized to start with an empty collections list, and the network call is slow, the page breaks.
This change guarantees that an empty list is initialised so that even on slow internet the resources are prepopulated and the paths do not break.