### PR TITLE
Fix: Get documentation on resource render

### DIFF
--- a/src/app/views/sidebar/resource-explorer/resource-explorer.utils.ts
+++ b/src/app/views/sidebar/resource-explorer/resource-explorer.utils.ts
@@ -31,7 +31,7 @@ export function createResourcesList(
     paths: string[],
     methods: Method[]
   ): IResourceLink[] {
-    const { segment, children } = parent;
+    const { segment, children, labels } = parent;
     const links: IResourceLink[] = [];
     const childPaths = Array.from(new Set([...paths, segment]));
     if (methods.length > 1) {
@@ -49,7 +49,8 @@ export function createResourcesList(
               },
               segment,
               childPaths,
-              method
+              method,
+              getLink(labels, version, method)
             )
           );
         });
@@ -81,7 +82,8 @@ export function createResourcesList(
     info: IResource,
     parent: string,
     paths: string[] = [],
-    method?: Method
+    method?: Method,
+    docLink?: string
   ): IResourceLink {
     const { segment, labels } = info;
     const level = paths.length;
@@ -110,7 +112,6 @@ export function createResourcesList(
         ? true
         : false;
 
-    const docLink = getLink(labels, version, method);
     const pathItems = Array.from(new Set([...paths, segment]));
     const key = generateKey(method, pathItems, version);
 
@@ -126,7 +127,8 @@ export function createResourcesList(
       method: method?.toUpperCase(),
       type,
       links: versionedChildren,
-      docLink
+      docLink: docLink ? docLink : getLink(labels, version, method)
+
     };
   }
 


### PR DESCRIPTION
## Overview

Fixes #2629 

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

To ensure that items have documentation, a previous update made sure that when resource links are being rendered, the DocumentationService would get the documentation for the rendering item. This works, however, it takes a visible performance hit when the page is forced to re-render multiple times e.g when doing a search.

It makes sense to force the tree to get the documentation at the point of creating the tree so that all the items always show up on render with their documentation.

## Testing Instructions

* Run GE locally on the branch
* Open resource explorer
* Notice that documenation for GET chats exists
* In the search box, write something like 'device m' notice that the page says there's nothing to see
* Backspace slowly and notice the app doesn't hang