### PR TITLE
Fix: Add overflow option for code snippet languages tab

### DIFF
--- a/src/app/views/query-response/snippets/Snippets.tsx
+++ b/src/app/views/query-response/snippets/Snippets.tsx
@@ -5,6 +5,7 @@ import { AppDispatch, useAppSelector } from '../../../../store';
 import { componentNames, telemetry } from '../../../../telemetry';
 import { setSnippetTabSuccess } from '../../../services/actions/snippet-action-creator';
 import { renderSnippets } from './snippets-helper';
+import { translateMessage } from '../../../utils/translate-messages';
 function GetSnippets() {
   const dispatch: AppDispatch = useDispatch();
   const { snippets, sampleQuery } = useAppSelector((state) => state);
@@ -56,6 +57,8 @@ function GetSnippets() {
     selectedKey={snippets.snippetTab}
     onLinkClick={handlePivotItemClick}
     styles={{ text: { fontSize: FontSizes.size14 } }}
+    overflowBehavior='menu'
+    overflowAriaLabel={translateMessage('More items')}
   >
     {renderSnippets(supportedLanguages)}
   </Pivot>;


### PR DESCRIPTION
## Overview

fixes #2741 

### Demo

![image](https://github.com/microsoftgraph/microsoft-graph-explorer-v4/assets/18407044/43bbe0d9-b7e1-4422-9956-6391ddd7516b)


### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* checkout branch and launch GE locally
* Navigate to code snippets tab
* Change screen dimensions to fit that of a mobile device
* Observe fix