### PR TITLE
Fix: Support unicode characters

### DIFF
--- a/src/app/views/query-runner/query-input/auto-complete/auto-complete.util.ts
+++ b/src/app/views/query-runner/query-input/auto-complete/auto-complete.util.ts
@@ -61,11 +61,8 @@ function getValidationError(queryUrl: string): string | null {
   try {
     const validator = new ValidatedUrl();
     const validation = validator.validate(queryUrl);
-    if (!validation.success) {
-      return queryUrl.substring(validation.matched, validation.maxMatched);
-    } else {
-      return null;
-    }
+    return (!validation.success) ?
+      queryUrl.substring(validation.matched, validation.maxMatched) : null;
   } catch (error) {
     return null;
   }

--- a/src/app/views/query-runner/query-input/auto-complete/auto-complete.util.ts
+++ b/src/app/views/query-runner/query-input/auto-complete/auto-complete.util.ts
@@ -58,12 +58,16 @@ function getErrorMessage(queryUrl: string) {
 }
 
 function getValidationError(queryUrl: string): string | null {
-  const validator = new ValidatedUrl();
-  const validation = validator.validate(queryUrl);
-  if (!validation.success) {
-    return queryUrl.substring(validation.matched, validation.maxMatched);
+  try {
+    const validator = new ValidatedUrl();
+    const validation = validator.validate(queryUrl);
+    if (!validation.success) {
+      return queryUrl.substring(validation.matched, validation.maxMatched);
+    }
+    throw new Error('Validation unsuccessful');
+  } catch (error) {
+    return null;
   }
-  return null;
 }
 
 function getSearchText(input: string, index: number) {

--- a/src/app/views/query-runner/query-input/auto-complete/auto-complete.util.ts
+++ b/src/app/views/query-runner/query-input/auto-complete/auto-complete.util.ts
@@ -51,7 +51,7 @@ function getErrorMessage(queryUrl: string) {
   if (error) {
     return `${translateMessage('Possible error found in URL near')}: ${error}`;
   }
-  if (queryUrl.indexOf('graph.microsoft.com') === -1){
+  if (queryUrl.indexOf('graph.microsoft.com') === -1) {
     return translateMessage('The URL must contain graph.microsoft.com');
   }
   return '';
@@ -63,8 +63,9 @@ function getValidationError(queryUrl: string): string | null {
     const validation = validator.validate(queryUrl);
     if (!validation.success) {
       return queryUrl.substring(validation.matched, validation.maxMatched);
+    } else {
+      return null;
     }
-    throw new Error('Validation unsuccessful');
   } catch (error) {
     return null;
   }


### PR DESCRIPTION

## Overview

Fixes #2756

### Notes

The ABNF parser is unable to correctly validate the characters in the URL and crashes. 

Adding a try catch block ensures the page fails gracefully since a failure in validation should not break the experience

## Testing Instructions

* Run Graph Explorer
* In the address bar, write `https://graph.microsoft.com/v1.0/me/💕`
* Page does not crash