### PR TITLE
Fix: missing paths available in resource tree

### DIFF
--- a/src/app/utils/resources/resources-filter.ts
+++ b/src/app/utils/resources/resources-filter.ts
@@ -22,10 +22,11 @@ function getResourcesSupportedByVersion(
 }
 
 function versionExists(resource: IResource, version: string): boolean {
-  return resource &&
-    resource.labels &&
-    resource.labels.length > 0 &&
-    resource.labels.some((k) => k.name === version);
+  if (resource && resource.labels) {
+    return (resource.labels.length === 0) || (resource.labels.length > 0 &&
+      resource.labels.some((k) => k.name === version));
+  }
+  return false;
 }
 
 function searchResources(haystack: IResource[], needle: string): IResource[] {

--- a/src/app/views/sidebar/resource-explorer/resource-explorer.utils.ts
+++ b/src/app/views/sidebar/resource-explorer/resource-explorer.utils.ts
@@ -19,7 +19,7 @@ export function createResourcesList(
 ): INavLinkGroup[] {
   function getLinkType({ segment, links }: any): ResourceLinkType {
     const isGraphFunction = segment.startsWith('microsoft.graph');
-    const hasChildren = links && links.length > 0;
+    const hasChildren = links && links.length > 1;
     if (hasChildren) {
       return ResourceLinkType.NODE;
     }
@@ -34,11 +34,8 @@ export function createResourcesList(
     const { segment, children, labels } = parent;
     const links: IResourceLink[] = [];
     const childPaths = Array.from(new Set([...paths, segment]));
-    if (methods.length > 1) {
-      if (
-        !searchText ||
-        (searchText && childPaths.some((path) => path.contains(searchText)))
-      ) {
+    if (methods.length >= 1) {
+      if (!searchText || (searchText && childPaths.some((path) => path.contains(searchText)))) {
         methods.forEach((method) => {
           links.push(
             createNavLink(
@@ -94,14 +91,14 @@ export function createResourcesList(
       availableMethods
     ).sort(sortResourceLinks); // show graph functions at the top
 
-    // if segment has one method only and no children, do not make segment a node
-    if (availableMethods.length === 1 && versionedChildren.length === 0) {
+    // if segment has one method only and at most 1 child, do not make segment a node
+    if (availableMethods.length === 1 && versionedChildren.length <= 1 ) {
       paths = [...paths, segment];
       method = availableMethods[0];
     }
     const type = getLinkType({ ...info, links: versionedChildren });
     const enclosedCounter =
-      versionedChildren && versionedChildren.length > 0
+      versionedChildren && versionedChildren.length > 1
         ? ` (${versionedChildren.length})`
         : '';
 
@@ -126,7 +123,7 @@ export function createResourcesList(
       paths: pathItems,
       method: method?.toUpperCase(),
       type,
-      links: versionedChildren,
+      links: versionedChildren.length > 1 ? versionedChildren : [],
       docLink: docLink ? docLink : getLink(labels, version, method)
 
     };

--- a/src/app/views/sidebar/resource-explorer/resource-explorer.utils.ts
+++ b/src/app/views/sidebar/resource-explorer/resource-explorer.utils.ts
@@ -123,7 +123,7 @@ export function createResourcesList(
       paths: pathItems,
       method: method?.toUpperCase(),
       type,
-      links: versionedChildren.length > 1 ? versionedChildren : [],
+      links: versionedChildren,
       docLink: docLink ? docLink : getLink(labels, version, method)
 
     };


### PR DESCRIPTION
## Overview

Fixes #2820

### Demo

![image](https://github.com/microsoftgraph/microsoft-graph-explorer-v4/assets/58787602/414ac289-9993-45c5-94fe-a3296eb04fa8)

### Notes

`/places` for example, does not have indicators of which version it belongs to. Hence it was not visible in the list of tree nodes. This PR has changed this to make `places` and similar ones that have no version to appear on the list.

## Testing Instructions

* Check for sites as one of the root nodes
* Confirm GET sites as one of the children