### PR TITLE
Hotfix: Upgrade msal-browser version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
                         "dependencies": {
                                 "@augloop/types-core": "file:packages/types-core-2.16.189.tgz",
                                 "@axe-core/webdriverjs": "4.7.3",
-                                "@azure/msal-browser": "3.1.0",
+                                "@azure/msal-browser": "3.5.0",
                                 "@babel/core": "7.23.0",
                                 "@babel/runtime": "7.23.1",
                                 "@fluentui/react": "8.112.0",
@@ -174,20 +174,20 @@
                         }
                 },
                 "node_modules/@azure/msal-browser": {
-                        "version": "3.1.0",
-                        "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.1.0.tgz",
-                        "integrity": "sha512-zQpL/mR6Xif+WltcRMej8wRsBQu+lW8e1/su8SMkF41i+Pnn/a/a/l+VoT4D+cQrBAq3PL5IaLfuUoNVTRUjKw==",
+                        "version": "3.5.0",
+                        "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.5.0.tgz",
+                        "integrity": "sha512-2NtMuel4CI3UEelCPKkNRXgKzpWEX48fvxIvPz7s0/sTcCaI08r05IOkH2GkXW+czUOtuY6+oGafJCpumnjRLg==",
                         "dependencies": {
-                                "@azure/msal-common": "14.0.3"
+                                "@azure/msal-common": "14.4.0"
                         },
                         "engines": {
                                 "node": ">=0.8.0"
                         }
                 },
                 "node_modules/@azure/msal-common": {
-                        "version": "14.0.3",
-                        "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.0.3.tgz",
-                        "integrity": "sha512-Vl5SsC3zvQ8913GnO5Typox+35M6CaXmO/2FXi35LfMAV3ZB/HLCsldLxylI01c3CmtOm7pICWpOjp/DlQ9RWA==",
+                        "version": "14.4.0",
+                        "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.4.0.tgz",
+                        "integrity": "sha512-ffCymScQuMKVj+YVfwNI52A5Tu+uiZO2eTf+c+3TXxdAssks4nokJhtr+uOOMxH0zDi6d1OjFKFKeXODK0YLSg==",
                         "engines": {
                                 "node": ">=0.8.0"
                         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
         "name": "graph-explorer-v2",
-        "version": "9.3.2",
+        "version": "9.3.3",
         "lockfileVersion": 3,
         "requires": true,
         "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
         "name": "graph-explorer-v2",
-        "version": "9.3.2",
+        "version": "9.3.3",
         "private": true,
         "dependencies": {
                 "@augloop/types-core": "file:packages/types-core-2.16.189.tgz",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "dependencies": {
                 "@augloop/types-core": "file:packages/types-core-2.16.189.tgz",
                 "@axe-core/webdriverjs": "4.7.3",
-                "@azure/msal-browser": "3.1.0",
+                "@azure/msal-browser": "3.5.0",
                 "@babel/core": "7.23.0",
                 "@babel/runtime": "7.23.1",
                 "@fluentui/react": "8.112.0",


### PR DESCRIPTION
## Overview

The current msal-browser version 3.1.0 breaks for some users as highlighted in [issue 2895](https://github.com/microsoftgraph/microsoft-graph-explorer-v4/issues/2895)

Upgrading to the latest version 3.5.0 ensures we have their needs covered since version 3.2.0 fixes their problem as mentioned in the [Msal Browser changelog](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/CHANGELOG.md#320)