### PR TITLE
Task: add employeeexperience to CORS supported list

### DIFF
--- a/src/app/services/actions/query-action-creator-util.ts
+++ b/src/app/services/actions/query-action-creator-util.ts
@@ -261,7 +261,7 @@ export function parseResponse(
 export function queryResultsInCorsError(sampleUrl: string): boolean {
   sampleUrl = sampleUrl.toLowerCase();
   if (
-    (['/drive/', '/drives/', '/driveItem/'].some((x) =>
+    (['/drive/', '/drives/', '/driveItem/', '/employeeexperience/'].some((x) =>
       sampleUrl.includes(x)) && sampleUrl.endsWith('/content')) ||
     sampleUrl.includes('/reports/')
   ) {


### PR DESCRIPTION
## Overview

Closes #2872 

There is already support for responses that fetch content. The list that should get support needs to be updated to include `employeeexperience`