### PR TITLE
Fix: failing permissions panel load

### DIFF
--- a/src/app/services/reducers/permissions-reducer.spec.ts
+++ b/src/app/services/reducers/permissions-reducer.spec.ts
@@ -71,7 +71,10 @@ describe('Permissions reducer', () => {
     }
     const expectedState = {
       pending: { isSpecificPermissions: false, isFullPermissions: false },
-      data: {},
+      data: {
+        fullPermissions: [],
+        specificPermissions: []
+      },
       error: 'error'
     }
 

--- a/src/app/services/reducers/permissions-reducer.ts
+++ b/src/app/services/reducers/permissions-reducer.ts
@@ -43,7 +43,7 @@ export function scopes(state: IScopes = initialState, action: AppAction): any {
       return {
         pending: { isFullPermissions: false, isSpecificPermissions: false },
         error: action.response,
-        data: {}
+        data: state.data
       };
     case FETCH_URL_SCOPES_PENDING:
       return {


### PR DESCRIPTION
## Overview

Fixes #2999 

### Notes

There was a state reset needed after getting an error when fetching permissions for one endpoint

## Testing Instructions

* Go to [this jolly sand link](https://jolly-sand-0ac78c710-3000.centralus.azurestaticapps.net)
* On the samples search, type goals and pick the first sample available.
* Open the modify permissions tab, and follow the instructions to open the panel
* See that the panel loads