### PR TITLE
Enable openApi Snippets for Java tab

### DIFF
--- a/src/app/services/actions/snippet-action-creator.ts
+++ b/src/app/services/actions/snippet-action-creator.ts
@@ -53,7 +53,7 @@ export function getSnippet(language: string) {
       if (language !== 'csharp') {
         snippetsUrl += `?lang=${language}`;
       }
-      const openApiSnippets: string[] = ['go', 'powershell', 'python', 'cli', 'php'];
+      const openApiSnippets: string[] = ['go', 'powershell', 'python', 'cli', 'php', 'java'];
       if (openApiSnippets.includes(language)) {
         snippetsUrl += '&generation=openapi';
       }


### PR DESCRIPTION
Currently graph explorer is not showing v6 snippets for java. 
This PR enables openApiSnippets for v6 of java and we should present the corresponding openApi/kiota snippets.  