### PR TITLE
Fix: show dollar sign paths on autocomplete

### DIFF
--- a/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
+++ b/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
@@ -241,9 +241,9 @@ const AutoComplete = (props: IAutoCompleteProps) => {
 
   const appendSuggestionToUrl = (selected: string) => {
     if (!selected) { return; }
-
+    const { context } = getLastDelimiterInUrl(queryUrl);
     let query = selected;
-    if (selected.startsWith(delimiters.DOLLAR.symbol)) {
+    if (selected.startsWith(delimiters.DOLLAR.symbol) && context === 'parameters') {
       selected += delimiters.EQUALS.symbol;
       query = '';
     }

--- a/src/modules/suggestions/suggestions.ts
+++ b/src/modules/suggestions/suggestions.ts
@@ -52,20 +52,12 @@ class Suggestions implements ISuggestions {
   }
 
   private createOpenApiResponse(versionedResources: IResource[], url: string): IParsedOpenApiResponse {
-    const paths: string[] = [];
-
-    versionedResources.forEach((resource: IResource) => {
-      if (!resource.segment.contains('$')) {
-        paths.push(resource.segment);
-      }
-    });
-
     const response: IParsedOpenApiResponse = {
       createdAt: '',
       parameters: [{
         verb: 'get',
         values: [],
-        links: paths
+        links: versionedResources.map((resource: IResource) => resource.segment)
       }],
       url
     };


### PR DESCRIPTION
## Overview

When typing in `/me/photo/$value`, **$value** was not showing up in the list of suggestions provided.

### Notes

Previously, adding a `$` appended suggestion would trigger the `=` sign to show properties. This fix isolates the `=` sign addition to the context of the url. This now makes it possible to have `$` sign paths appear as suggestions e.g `$count`, `$value` etc

## Testing Instructions

* Write `me/photo/`
* Notice `$value` in the list of items