### PR TITLE
Fix: Canary urls crashing

### DIFF
--- a/src/app/utils/query-url-sanitization.ts
+++ b/src/app/utils/query-url-sanitization.ts
@@ -102,7 +102,7 @@ function sanitizedQueryUrl(url: string): string {
  * @param segment
  */
 function sanitizePathSegment(previousSegment: string, segment: string): string {
-  const segmentsToIgnore = ['$value', '$count', '$ref', '$batch'];
+  const segmentsToIgnore = ['$value', '$count', '$ref', '$batch', '$metadata'];
 
   if (
     isAllAlpha(segment) ||

--- a/src/app/utils/query-url-sanitization.ts
+++ b/src/app/utils/query-url-sanitization.ts
@@ -102,14 +102,13 @@ function sanitizedQueryUrl(url: string): string {
  * @param segment
  */
 function sanitizePathSegment(previousSegment: string, segment: string): string {
-  const segmentsToIgnore = ['$value', '$count', '$ref', '$batch', '$metadata'];
 
   if (
     isAllAlpha(segment) ||
     isAlphaNumeric(segment) ||
     isDeprecation(segment) ||
     SANITIZED_ITEM_PATH_REGEX.test(segment) ||
-    segmentsToIgnore.includes(segment.toLowerCase()) ||
+    segment.startsWith('$') ||
     ENTITY_NAME_REGEX.test(segment)
   ) {
     return segment;

--- a/src/app/utils/resources/resources-filter.ts
+++ b/src/app/utils/resources/resources-filter.ts
@@ -24,7 +24,7 @@ function getMatchingResourceForUrl(url: string, resources: IResource[]): IResour
   let matching = [...resources];
   let node;
   for (const path of parts) {
-    if (hasPlaceHolders(path)) {
+    if (hasPlaceHolders(path) && path !== '{undefined-id}') {
       node = matching.find(k => hasPlaceHolders(k.segment));
       matching = node?.children || [];
     } else {

--- a/src/app/views/query-runner/query-input/auto-complete/suffix/documentation.ts
+++ b/src/app/views/query-runner/query-input/auto-complete/suffix/documentation.ts
@@ -35,7 +35,7 @@ class DocumentationService implements IDocumentationService {
 
   public getDocumentationLink = (): string => {
     const link = this.getSampleDocumentationUrl() || this.getResourceDocumentationUrl();
-    return link ? link : '';
+    return link || '';
   }
 
   private getSampleDocumentationUrl = (): string => {

--- a/src/app/views/query-runner/query-input/auto-complete/suffix/documentation.ts
+++ b/src/app/views/query-runner/query-input/auto-complete/suffix/documentation.ts
@@ -35,7 +35,7 @@ class DocumentationService implements IDocumentationService {
 
   public getDocumentationLink = (): string => {
     const link = this.getSampleDocumentationUrl() || this.getResourceDocumentationUrl();
-    return link || '';
+    return link ? link : '';
   }
 
   private getSampleDocumentationUrl = (): string => {
@@ -69,7 +69,7 @@ class DocumentationService implements IDocumentationService {
     if (matchingResource && matchingResource.labels.length > 0) {
       const currentLabel = matchingResource.labels.filter(k => k.name === this.queryVersion)[0];
 
-      const method = currentLabel.methods[0];
+      const method = currentLabel?.methods[0];
       if (typeof method === 'string') {
         return null;
       }


### PR DESCRIPTION
## Overview

Fixes #3063 

### Demo
https://github.com/microsoftgraph/microsoft-graph-explorer-v4/assets/18407044/f92898d7-d367-4498-a9cf-961952248412


### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Check out PR
* Load GE
* Paste test link  `https://canary.graph.microsoft.com/testprodbetatamy-pps-offboarding/me/insights/trending`
* Click anywhere on the page and observe the page doesn't crash