### PR TITLE
Feature: support text csv

### DIFF
--- a/src/app/services/actions/query-action-creator-util.ts
+++ b/src/app/services/actions/query-action-creator-util.ts
@@ -236,6 +236,7 @@ export function parseResponse(
         return response.json();
       case ContentType.XML:
       case ContentType.HTML:
+      case ContentType.TextCsv:
       case ContentType.TextPlain:
         return response.text();
 

--- a/src/app/services/context/validation-context/ValidationProvider.tsx
+++ b/src/app/services/context/validation-context/ValidationProvider.tsx
@@ -34,6 +34,9 @@ export const ValidationProvider = ({ children }: ValidationProviderProps) => {
   }, [resources])
 
   useEffect(() => {
+    if (!queryVersion || !query || Object.keys(resources.data).length === 0) {
+      return;
+    }
     if (version !== queryVersion && GRAPH_API_VERSIONS.includes(queryVersion)
       && resources.data[queryVersion].children!.length > 0) {
       setVersionedResources(resources.data[queryVersion].children!);

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -15,6 +15,7 @@ export enum ContentType {
   TextPlain = 'text/plain',
   HTML = 'text/html',
   BinaryResponse = 'application/octet-stream',
+  TextCsv = 'text/csv',
 }
 
 export enum AppTheme {


### PR DESCRIPTION
## Overview

Closes #2872 

The query mentioned returns a text/csv response that can be properly handled by the browser. This PR adds text/csv headers as supported headers and enables showing the response as plain text on the response viewer

### Demo

![image](https://github.com/microsoftgraph/microsoft-graph-explorer-v4/assets/58787602/0d351a11-98ad-4355-9544-e661a3932902)
