### PR TITLE
refactor: use strong types in authentication module

### DIFF
--- a/src/modules/authentication/msal-app.ts
+++ b/src/modules/authentication/msal-app.ts
@@ -1,12 +1,13 @@
+/* eslint-disable no-console */
 import { Configuration, LogLevel, PublicClientApplication } from '@azure/msal-browser';
 import { eventTypes, telemetry } from '../../telemetry';
 
 function getClientIdFromWindow() {
-  return (window as any).ClientId;
+  return window?.ClientId ?? '';
 }
 
 function getClientIdFromEnv() {
-  return process.env.REACT_APP_CLIENT_ID;
+  return process.env?.REACT_APP_CLIENT_ID ?? '';
 }
 
 const windowHasClientId = getClientIdFromWindow();

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,0 +1,8 @@
+export {};
+declare global {
+  interface Window {
+    ClientId: string | undefined
+  }
+}
+
+window.ClientId = window.ClientId || undefined;


### PR DESCRIPTION
## Overview

Use strong types in `src/modules/authentication`. Closes #3187 

## Testing Instructions

* open any files in `src/modules/authentication`
* ensure no use of `any` types
* ensure `npm run test` passes in `src/modules/authentication` without fails

## Some stats

### before

5 `any` counts in 2/10 files

```bash
AuthenticationWrapper.ts:4
msal-app.ts:1
```

### after
```
authentication-error-hints.ts:0
AuthenticationWrapper.spec.ts:0
AuthenticationWrapper.ts:0
authUtils.spec.ts:0
authUtils.ts:0
ClaimsChallenge.ts:0
index.ts:0
interfaces/IAuthenticationWrapper.ts:0
interfaces/IClaimsChallenge.ts:0
msal-app.ts:0
```