### PR TITLE
Fix: add parameters to token request

### DIFF
--- a/src/modules/authentication/AuthenticationWrapper.ts
+++ b/src/modules/authentication/AuthenticationWrapper.ts
@@ -76,7 +76,8 @@ export class AuthenticationWrapper implements IAuthenticationWrapper {
       authority: this.getAuthority(),
       prompt: 'select_account',
       redirectUri: getCurrentUri(),
-      extraQueryParameters: getExtraQueryParameters()
+      extraQueryParameters: getExtraQueryParameters(),
+      tokenQueryParameters: getExtraQueryParameters()
     };
     try {
       const result = await msalApplication.loginPopup(popUpRequest);
@@ -207,8 +208,9 @@ export class AuthenticationWrapper implements IAuthenticationWrapper {
       authority: this.getAuthority(),
       prompt: 'select_account',
       redirectUri: getCurrentUri(),
+      claims: this.getClaims(),
       extraQueryParameters: getExtraQueryParameters(),
-      claims: this.getClaims()
+      tokenQueryParameters: getExtraQueryParameters()
     };
 
     if (this.consentingToNewScopes || this.performingStepUpAuth) {

--- a/src/modules/authentication/msal-app.ts
+++ b/src/modules/authentication/msal-app.ts
@@ -30,20 +30,6 @@ export const configuration: Configuration = {
           return;
         }
         telemetry.trackEvent(eventTypes.AUTH_REQUEST_EVENT, { message, level });
-        switch (level) {
-          case LogLevel.Error:
-            console.error('[MSAL]', message);
-            return;
-          case LogLevel.Info:
-            console.info('[MSAL]', message);
-            return;
-          case LogLevel.Verbose:
-            console.debug('[MSAL]', message);
-            return;
-          case LogLevel.Warning:
-            console.warn('[MSAL]', message);
-            return;
-        }
       },
       piiLoggingEnabled: false
     }


### PR DESCRIPTION
## Overview

We've been using the `extraQueryParameters` property to handle the code migration. This handles the `/authorize` path only. To cater for all paths, we need to also use the `tokenQueryParameters` property to make sure that the `/token` path is also taken care of.

## Testing Instructions

* Run the application
* Attempt to log in.
* Check the network calls, 
* Notice the `/token` URL has extra query parameters