### PR TITLE
Fix: Monaco 404 errors

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -389,6 +389,10 @@ module.exports = function (webpackEnv) {
               )
             },
             {
+              test: /\.css$/,
+              use: ['style-loader', 'css-loader']
+            },
+            {
               test: /\.ttf$/,
               type: 'asset/resource'
             },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -160,6 +160,32 @@ function loadResources() {
 }
 loadResources();
 
+/**
+ * Set's up Monaco Editor's Workers.
+ */
+enum Workers {
+  Json = 'json',
+  Editor = 'editor',
+}
+
+(window as any).MonacoEnvironment = {
+  getWorkerUrl(moduleId: any, label: string) {
+    if (label === 'json') {
+      return getWorkerFor(Workers.Json);
+    }
+    return getWorkerFor(Workers.Editor);
+  }
+};
+
+function getWorkerFor(worker: string): string {
+  // tslint:disable-next-line:max-line-length
+  const WORKER_PATH =
+    'https://graphstagingblobstorage.blob.core.windows.net/staging/vendor/bower_components/explorer-v2/build';
+
+  return `data:text/javascript;charset=utf-8,${encodeURIComponent(`
+	    importScripts('${WORKER_PATH}/${worker}.worker.js');`)}`;
+}
+
 variantService.initialize();
 const telemetryProvider: ITelemetry = telemetry;
 telemetryProvider.initialize();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -166,23 +166,25 @@ loadResources();
 enum Workers {
   Json = 'json',
   Editor = 'editor',
-}
-
-import { Environment } from 'monaco-editor/esm/vs/editor/editor.api';
-// ... other imports
-
-declare global {
-  interface Window {
-    MonacoEnvironment: Environment;
-  }
+  Typescript='ts',
+  Css='css',
+  Html='html'
 }
 
 window.MonacoEnvironment = {
   getWorkerUrl(moduleId: any, label: string) {
-    if (label === 'json') {
-      return getWorkerFor(Workers.Json);
+    switch (label) {
+      case 'json':
+        return getWorkerFor(Workers.Json);
+      case 'css':
+        return getWorkerFor(Workers.Css);
+      case 'html':
+        return getWorkerFor(Workers.Html);
+      case 'typescript':
+        return getWorkerFor(Workers.Typescript);
+      default:
+        return getWorkerFor(Workers.Editor);
     }
-    return getWorkerFor(Workers.Editor);
   }
 };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -168,7 +168,16 @@ enum Workers {
   Editor = 'editor',
 }
 
-(window as any).MonacoEnvironment = {
+import { Environment } from 'monaco-editor/esm/vs/editor/editor.api';
+// ... other imports
+
+declare global {
+  interface Window {
+    MonacoEnvironment: Environment;
+  }
+}
+
+window.MonacoEnvironment = {
   getWorkerUrl(moduleId: any, label: string) {
     if (label === 'json') {
       return getWorkerFor(Workers.Json);

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,7 +1,10 @@
+import { Environment } from 'monaco-editor/esm/vs/editor/editor.api';
+
 export {};
 declare global {
   interface Window {
     ClientId: string | undefined
+    MonacoEnvironment: Environment;
   }
 }
 


### PR DESCRIPTION
## Overview
Fix #3221 
updates code to fetch web workers from the correct destination

### Demo
Updated 
![image](https://github.com/microsoftgraph/microsoft-graph-explorer-v4/assets/18407044/16ff2649-7143-4d78-ad15-d7b7e116a8d7)


### Notes
The worker URL functions previously existed but we removed them as we had stopped using the monaco-editor webpack plugin. Once we bundled Monaco, we resumed using the plugin and must have forgotten to update the worker urls. 
Ref: https://github.com/microsoftgraph/microsoft-graph-explorer-v4/pull/2615

## Testing Instructions

* Checkout this branch
* Load GE
* Check network tab on developer tools
* Observe 200 OK on editor.worker.js/json.worker.js calls 