### PR TITLE
fix: move getting resource version children to a function

### DIFF
--- a/src/app/views/query-runner/query-input/auto-complete/suffix/SuffixRenderer.tsx
+++ b/src/app/views/query-runner/query-input/auto-complete/suffix/SuffixRenderer.tsx
@@ -23,11 +23,15 @@ const SuffixRenderer = () => {
 
   const getDocumentationLink = (): string | null => {
     const { queries } = samples;
-
+    const getChildren = ()=> {
+      if (resources.data && Object.keys(resources.data).length > 0 && sampleQuery.selectedVersion in resources.data){
+        return resources.data[sampleQuery.selectedVersion].children ?? [];
+      }
+      return [];
+    }
     const resourceDocumentationUrl = new DocumentationService({
       sampleQuery,
-      source: Object.keys(resources.data).length > 0 ?
-        resources.data[sampleQuery.selectedVersion].children! : []
+      source: getChildren()
     }).getDocumentationLink();
 
     const sampleDocumentationUrl = new DocumentationService({


### PR DESCRIPTION
## Overview

Closes #3234 

Move getting the resource.version.children values to a function.