### PR TITLE
chore: add starting commit where changelog commits gathering will stop

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "pull-request-header": ":rocket: A new Graph Explorer release is coming up!",
   "include-component-in-tag": false,
+  "bootstrap-sha": "439726b8e93371c61bb3ad76836603b1e822481f",
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
Release please is pulling in all commits for the changelog https://github.com/microsoftgraph/microsoft-graph-explorer-v4/pull/3344. This should hopefully stop it at the last release.