### PR TITLE
chore: Remove reference to a deprecated rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,7 +33,6 @@ module.exports = {
         accessibility: 'explicit'
       }
     ],
-    '@typescript-eslint/indent': ['error', 2],
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/member-delimiter-style': [
       'off',


### PR DESCRIPTION
## Overview

Linting fails with the rule as it is deprecated and moved to eslint stylistic plugin (https://eslint.style)

https://typescript-eslint.io/rules/indent/

Required to close https://github.com/microsoftgraph/microsoft-graph-explorer-v4/pull/3362