### PR TITLE
fix: update the sample queries signed in/out click functionality

### DIFF
--- a/src/app/views/sidebar/sample-queries/SampleQueriesV9.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueriesV9.tsx
@@ -224,7 +224,13 @@ const RenderSampleLeafs = (props: SampleLeaf) => {
       {leafs.map((query: ISampleQuery) => {
         const notSignedIn = !isSignedIn && query.method !== 'GET';
         const handleOnClick = (item:ISampleQuery)=>{
-          if(isSignedIn) {handleSelectedSample(item)}
+          if (!isSignedIn) {
+            if (query.method === 'GET') {
+              handleSelectedSample(item)
+            }
+          } else {
+            handleSelectedSample(item)
+          }
         }
 
         return (


### PR DESCRIPTION
Enable processing a clicked query item when signed out for GET and signed in for all http methods.