### PR TITLE
fix: enhance request permissions tab

### DIFF
--- a/src/app/services/context/resize-context/ResizeContext.tsx
+++ b/src/app/services/context/resize-context/ResizeContext.tsx
@@ -1,0 +1,11 @@
+import { createContext } from 'react';
+
+interface ResizeContext {
+  sidebarSize: number;
+  responseAreaSize: number;
+  dragValue: number;
+  parentHeight: number;
+  initiator: string;
+}
+
+export const ResizeContext = createContext<ResizeContext>({} as ResizeContext);

--- a/src/app/services/context/resize-context/ResizeProvider.tsx
+++ b/src/app/services/context/resize-context/ResizeProvider.tsx
@@ -1,0 +1,53 @@
+import { ReactNode, useEffect, useMemo, useState } from 'react';
+import { ResizeContext } from './ResizeContext';
+
+interface ResizeProviderProps {
+  children: ReactNode;
+}
+export const ResizeProvider = (props: ResizeProviderProps) => {
+  const { children } = props;
+  const [sidebarSize, setSidebarSize] = useState(0);
+  const [responseSize, setResponseSize] = useState(0);
+  const [parentHeight, setParentHeight] = useState(0);
+  const [initiatorValue, setInitiatorValue] = useState('');
+  const [dragValue, setDragValue] = useState(-1);
+
+  useEffect(() => {
+    const handleResize = (e: Event) => {
+      const layout = document.getElementById('layout');
+      if (layout) {
+        const parentOffset = layout.parentElement?.offsetHeight ?? 0;
+        setParentHeight(parentOffset);
+        const customEvent = e as CustomEvent;
+        const { initiator, value } = customEvent.detail as {
+          initiator: string;
+          value: number;
+        };
+        if (initiator === 'responseSize') {
+          setResponseSize(value);
+        } else if (initiator === 'sidebar') {
+          setSidebarSize(value);
+        }
+        setInitiatorValue(initiator);
+        setDragValue(value);
+      }
+    };
+    window.addEventListener('onResizeDragEnd', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  const contextValue = useMemo(() => {
+    return {
+      sidebarSize,
+      responseAreaSize: responseSize,
+      parentHeight,
+      initiator: initiatorValue,
+      dragValue
+    };
+  }, [sidebarSize, responseSize, parentHeight, initiatorValue, dragValue]);
+  return (
+    <ResizeContext.Provider value={contextValue}>
+      {children}
+    </ResizeContext.Provider>
+  );
+};

--- a/src/app/views/layout/Layout.tsx
+++ b/src/app/views/layout/Layout.tsx
@@ -8,6 +8,7 @@ import {
 import { useEffect, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../../../store';
 import CollectionPermissionsProvider from '../../services/context/collection-permissions/CollectionPermissionsProvider';
+import { ResizeProvider } from '../../services/context/resize-context/ResizeProvider';
 import { ValidationProvider } from '../../services/context/validation-context/ValidationProvider';
 import { BANNER_IS_VISIBLE } from '../../services/graph-constants';
 import { setSampleQuery } from '../../services/slices/sample-query.slice';
@@ -189,60 +190,63 @@ const Layout = (props: LayoutProps) => {
         <div className={mergeClasses(boxStyles, styles.areaHeader)}>
           <MainHeaderV9 />
         </div>
-        <div
-          className={mergeClasses(boxStyles, styles.areaSidebar)}
-          ref={sidebarElementRef}
-        >
-          {/* TODO: use the onDrag event to resize this sidebar */}
-          <SidebarV9 />
-          <LayoutResizeHandler
-            position='end'
-            ref={sidebarHandleRef}
-            onDoubleClick={resetSidebarArea}
-          />
-        </div>
-        <div className={mainAreaStyles} ref={responseAreaWrapperRef}>
-          {bannerIsVisible && (
-            <div
-              id='notification'
-              className={mergeClasses(boxStyles, styles.notificationArea)}
-            >
-              <Notification
-                header={translateMessage('Banner notification 1 header')}
-                content={translateMessage('Banner notification 1 content')}
-                link={translateMessage('Banner notification 1 link')}
-                linkText={translateMessage('Banner notification 1 link text')}
-              />
-            </div>
-          )}
-          <ValidationProvider>
-            <div className={mergeClasses(boxStyles, styles.queryArea)}>
-              <QueryRunner onSelectVerb={props.handleSelectVerb} />
-            </div>
-            <div className={mergeClasses(boxStyles, styles.requestArea)}>
-              <RequestV9
-                handleOnEditorChange={handleOnEditorChange}
-                sampleQuery={sampleQuery}
-              />
-              <StatusMessagesV9 />
-            </div>
-            <div
-              className={mergeClasses(boxStyles, styles.responseArea)}
-              ref={responseAreaElementRef}
-              id='layout'
-            >
-              <QueryResponse />
-              <LayoutResizeHandler
-                position='top'
-                ref={responseAreaHandleRef}
-                onDoubleClick={resetResponseArea}
-              />
-            </div>
-          </ValidationProvider>
-          <CollectionPermissionsProvider>
-            <PopupsWrapper />
-          </CollectionPermissionsProvider>
-        </div>
+        <ResizeProvider>
+          <div
+            className={mergeClasses(boxStyles, styles.areaSidebar)}
+            ref={sidebarElementRef}
+          >
+            {/* TODO: use the onDrag event to resize this sidebar */}
+            <SidebarV9 />
+            <LayoutResizeHandler
+              position='end'
+              ref={sidebarHandleRef}
+              onDoubleClick={resetSidebarArea}
+            />
+          </div>
+          <div className={mainAreaStyles} ref={responseAreaWrapperRef}>
+            {bannerIsVisible && (
+              <div
+                id='notification'
+                className={mergeClasses(boxStyles, styles.notificationArea)}
+              >
+                <Notification
+                  header={translateMessage('Banner notification 1 header')}
+                  content={translateMessage('Banner notification 1 content')}
+                  link={translateMessage('Banner notification 1 link')}
+                  linkText={translateMessage('Banner notification 1 link text')}
+                />
+              </div>
+            )}
+            <ValidationProvider>
+              <div className={mergeClasses(boxStyles, styles.queryArea)}>
+                <QueryRunner onSelectVerb={props.handleSelectVerb} />
+              </div>
+              <div className={mergeClasses(boxStyles, styles.requestArea)}>
+                <RequestV9
+                  handleOnEditorChange={handleOnEditorChange}
+                  sampleQuery={sampleQuery}
+                />
+                <StatusMessagesV9 />
+              </div>
+              <div
+                className={mergeClasses(boxStyles, styles.responseArea)}
+                ref={responseAreaElementRef}
+                id='layout'
+              >
+                <QueryResponse />
+                <LayoutResizeHandler
+                  position='top'
+                  ref={responseAreaHandleRef}
+                  onDoubleClick={resetResponseArea}
+                />
+              </div>
+            </ValidationProvider>
+            <CollectionPermissionsProvider>
+              <PopupsWrapper />
+            </CollectionPermissionsProvider>
+          </div>
+        </ResizeProvider>
+
         <div className={mergeClasses(boxStyles, styles.areaFooter)}>
           <TermsOfUseMessageV9 />
         </div>

--- a/src/app/views/query-runner/request/permissions/Permission.stylesV9.ts
+++ b/src/app/views/query-runner/request/permissions/Permission.stylesV9.ts
@@ -33,7 +33,7 @@ const permissionStyles = makeStyles({
   },
   icon: {
     position: 'relative',
-    top: '4px',
+    top: '2px',
     cursor: 'pointer'
   },
   iconButton: {
@@ -48,6 +48,10 @@ const permissionStyles = makeStyles({
   },
   headerText: {
     marginLeft: '8px'
+  },
+  value: {
+    display: 'flex',
+    gap: '2px'
   }
 });
 

--- a/src/app/views/query-runner/request/permissions/PermissionItemV9.tsx
+++ b/src/app/views/query-runner/request/permissions/PermissionItemV9.tsx
@@ -1,8 +1,9 @@
 import {
   Button,
-  Tooltip,
-  Label
+  Label,
+  Tooltip
 } from '@fluentui/react-components';
+import { InfoRegular } from '@fluentui/react-icons';
 import { useAppDispatch, useAppSelector } from '../../../../../store';
 import { IPermission, IPermissionGrant } from '../../../../../types/permissions';
 import { revokeScopes } from '../../../../services/actions/revoke-scopes.action';
@@ -11,7 +12,6 @@ import { consentToScopes } from '../../../../services/slices/auth.slice';
 import { getAllPrincipalGrant, getSinglePrincipalGrant } from '../../../../services/slices/permission-grants.slice';
 import { translateMessage } from '../../../../utils/translate-messages';
 import { PermissionConsentType } from './ConsentType';
-import { InfoRegular } from '@fluentui/react-icons';
 import permissionStyles from './Permission.stylesV9';
 
 interface PermissionItemProps {
@@ -89,7 +89,10 @@ const PermissionItem = (props: PermissionItemProps): JSX.Element | null => {
         );
       }
       return (
-        <Tooltip content={translateMessage('You require the following permissions to revoke')} relationship='label'>
+        <Tooltip
+          withArrow
+          content={translateMessage('You require the following permissions to revoke')}
+          relationship='label'>
           <Button appearance='primary' disabled className={styles.button}>
             {translateMessage('Revoke')}
           </Button>
@@ -108,10 +111,10 @@ const PermissionItem = (props: PermissionItemProps): JSX.Element | null => {
     switch (column.key) {
     case 'value':
       return (
-        <div>
+        <div className={styles.value}>
           {content}
           {props.index === 0 && (
-            <Tooltip content={translateMessage('Least privileged permission')} relationship='label'>
+            <Tooltip withArrow content={translateMessage('Least privileged permission')} relationship='label'>
               <span className={styles.icon}><InfoRegular /></span>
             </Tooltip>
           )}
@@ -130,7 +133,7 @@ const PermissionItem = (props: PermissionItemProps): JSX.Element | null => {
 
     case 'consentDescription':
       return (
-        <Tooltip content={item.consentDescription} relationship='label'>
+        <Tooltip withArrow content={item.consentDescription} relationship='label'>
           <span>{item.consentDescription}</span>
         </Tooltip>
       );
@@ -140,7 +143,7 @@ const PermissionItem = (props: PermissionItemProps): JSX.Element | null => {
 
     default:
       return (
-        <Tooltip content={content} relationship='label'>
+        <Tooltip withArrow content={content} relationship='label'>
           <span>{content}</span>
         </Tooltip>
       );

--- a/src/app/views/query-runner/request/permissions/columnsV9.tsx
+++ b/src/app/views/query-runner/request/permissions/columnsV9.tsx
@@ -45,6 +45,7 @@ const createRenderColumnHeader = (styles: ReturnType<typeof permissionStyles>) =
     return (
       <div className={styles.headerContainer}>
         <Tooltip
+          withArrow
           content={tooltipMessage}
           relationship='label'>
           <Button


### PR DESCRIPTION
- Adds a context that passes the resize values to a component in the request, response and side bar area.
- Adds calculation to infer the height of the permissions tab content and set it appropriately
- Fixes layout of tooltip icons, sets arrows on the tooltips
- General formatting.