### PR TITLE
fix: disable save all button after saving changes

### DIFF
--- a/src/app/views/sidebar/resource-explorer/collection/EditScopePanel.tsx
+++ b/src/app/views/sidebar/resource-explorer/collection/EditScopePanel.tsx
@@ -69,6 +69,7 @@ const EditScopePanel: React.FC<EditScopePanelProps> = ({ closePopup }) => {
 
       dispatch(updateResourcePaths(updatedItems));
     }
+    setPendingChanges([]);
   };
 
   return (


### PR DESCRIPTION
## Overview

Disable Save All button after saving edited scopes