### PR TITLE
fix: accessibility issues on share query dialog

### DIFF
--- a/src/app/views/common/copy-button/CopyButton.tsx
+++ b/src/app/views/common/copy-button/CopyButton.tsx
@@ -31,6 +31,19 @@ export default function CopyButton(props: ICopyButtonProps) {
 
   return (
     <>
+      <div
+        role="status"
+        aria-live="assertive"
+        style={{
+          position: 'absolute',
+          left: '-9999px',
+          width: '1px',
+          height: '1px',
+          overflow: 'hidden'
+        }}
+      >
+        {copied && translateMessage('Copied')}
+      </div>
       {props.isIconButton ? (
         <Tooltip content={copyLabel} relationship='label'>
           <Button

--- a/src/app/views/common/copy-button/CopyButton.tsx
+++ b/src/app/views/common/copy-button/CopyButton.tsx
@@ -40,7 +40,7 @@ export default function CopyButton(props: ICopyButtonProps) {
           />
         </Tooltip>
       ) : (
-        <Button appearance='transparent' onClick={handleCopyClick}>
+        <Button appearance='primary' onClick={handleCopyClick}>
           {copyLabel}
         </Button>
       )}

--- a/src/app/views/common/popups/DialogWrapper.tsx
+++ b/src/app/views/common/popups/DialogWrapper.tsx
@@ -7,16 +7,23 @@ import {
   DialogTitle,
   Spinner
 } from '@fluentui/react-components';
-import { Suspense } from 'react';
+import { Suspense, useEffect, useRef } from 'react';
 
 import { WrapperProps } from './popups.types';
 
 export function DialogWrapper(props: WrapperProps) {
   const { isOpen, dismissPopup, Component, popupsProps, closePopup } = props;
   const { settings: { title, subtitle } } = popupsProps;
+  const firstFocusableRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isOpen && firstFocusableRef.current) {
+      firstFocusableRef.current.focus();
+    }
+  }, [isOpen]);
 
   return (
-    <Dialog modalType='modal' open={isOpen} onOpenChange={(_, data) => !data.open && dismissPopup()}>
+    <Dialog modalType='modal' aria-modal='true' open={isOpen} onOpenChange={(_, data) => !data.open && dismissPopup()}>
       <DialogSurface>
         <DialogBody>
           {title && <DialogTitle>{title.toString()}</DialogTitle>}

--- a/src/app/views/common/popups/DialogWrapper.tsx
+++ b/src/app/views/common/popups/DialogWrapper.tsx
@@ -16,7 +16,7 @@ export function DialogWrapper(props: WrapperProps) {
   const { settings: { title, subtitle } } = popupsProps;
 
   return (
-    <Dialog modalType='non-modal' open={isOpen} onOpenChange={(_, data) => !data.open && dismissPopup()}>
+    <Dialog modalType='modal' open={isOpen} onOpenChange={(_, data) => !data.open && dismissPopup()}>
       <DialogSurface>
         <DialogBody>
           {title && <DialogTitle>{title.toString()}</DialogTitle>}

--- a/src/app/views/common/popups/DialogWrapper.tsx
+++ b/src/app/views/common/popups/DialogWrapper.tsx
@@ -14,11 +14,11 @@ import { WrapperProps } from './popups.types';
 export function DialogWrapper(props: WrapperProps) {
   const { isOpen, dismissPopup, Component, popupsProps, closePopup } = props;
   const { settings: { title, subtitle } } = popupsProps;
-  const firstFocusableRef = useRef<HTMLDivElement>(null);
+  const focusableRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (isOpen && firstFocusableRef.current) {
-      firstFocusableRef.current.focus();
+    if (isOpen && focusableRef.current) {
+      focusableRef.current.focus();
     }
   }, [isOpen]);
 

--- a/src/app/views/query-runner/query-input/share-query/ShareQuery.tsx
+++ b/src/app/views/query-runner/query-input/share-query/ShareQuery.tsx
@@ -59,7 +59,7 @@ const ShareQuery: React.FC<PopupsComponent<null>> = (props) => {
 
       <DialogActions>
         <CopyButton handleOnClick={handleCopy} isIconButton={false} />
-        <Button appearance="secondary" onClick={() => props.dismissPopup()}>
+        <Button appearance='secondary' onClick={() => props.dismissPopup()}>
           {translateMessage('Close')}
         </Button>
       </DialogActions>


### PR DESCRIPTION
## Overview

Fixes https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_queries/edit/?tempQueryId=1a372e96-5f51-4c15-88b0-26a65a9df1e3&id=30642&queryId=30642
Fixes https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_queries/edit/?tempQueryId=1a372e96-5f51-4c15-88b0-26a65a9df1e3&id=30687&queryId=30642

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions
### Test 1

1. Open URL in web
2. Graph explorer page will open.
3. Navigate till share query and activate it.
4. Observe the focus remains in dialog

###Test 2

1. Turn on narraror.
2. Open URL in web
3. Graph explorer page will open.
4. Navigate till share query and activate it.
5. Navigate to copy button and activate it.
6. Observe the narrator announces copied