### PR TITLE
fix: closing expand dialog returns focus to expand button

### DIFF
--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -7,7 +7,8 @@ import {
   DialogTrigger,
   makeStyles,
   tokens,
-  Tooltip
+  Tooltip,
+  useRestoreFocusTarget
 } from '@fluentui/react-components';
 import { DismissRegular, ExpandUpLeftRegular } from '@fluentui/react-icons';
 import { useState } from 'react';
@@ -44,6 +45,8 @@ const useStyles = makeStyles({
 const PivotItemsDialog = () => {
   const [open, setOpen] = useState(false);
   const styles = useStyles();
+  const restoreFocusTargetAttribute = useRestoreFocusTarget();
+
 
   return (
     <div>
@@ -53,6 +56,7 @@ const PivotItemsDialog = () => {
           icon={<ExpandUpLeftRegular />}
           aria-label={translateMessage('Expand')}
           className={styles.dialogBtn}
+          {...restoreFocusTargetAttribute}
           onClick={() => setOpen(true)}
         />
       </Tooltip>


### PR DESCRIPTION
## Overview

Fixes https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_queries/edit/?tempQueryId=1a372e96-5f51-4c15-88b0-26a65a9df1e3&id=30720&queryId=30642

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

1. Open URL in web
2. Graph explorer page will open.
3. Navigate till expand button and activate it.
4. Navigate till close button and activate it or press esc key to close the dialog.
5. Observe the fix