### PR TITLE
fix: refocus to the trigger button after closing the ShareQuery dialog

### DIFF
--- a/src/app/services/context/popups-context/index.ts
+++ b/src/app/services/context/popups-context/index.ts
@@ -1,3 +1,4 @@
+import { RefObject } from 'react';
 import { PopupsProvider, usePopupsDispatchContext, usePopupsStateContext } from './PopupsContext';
 
 export interface PopupsComponent<Data = {}> {
@@ -11,6 +12,7 @@ interface PopupSettings {
   title: React.ReactNode | string;
   subtitle?: string;
   width?: width;
+  trigger?: RefObject<HTMLElement>;
   renderFooter?: () => JSX.Element;
 }
 

--- a/src/app/views/common/popups/PopupsWrapper.tsx
+++ b/src/app/views/common/popups/PopupsWrapper.tsx
@@ -18,11 +18,19 @@ const PopupWrapper = () => {
     }
     payload.status = 'closed';
     dispatch({ type: POPUPS.DELETE_POPUPS, payload });
+    const triggerBtn = payload.popupsProps.settings.trigger;
+    if (triggerBtn?.current){
+      triggerBtn.current?.focus();
+    }
   }
 
   const dismiss = (payload: Popup) => {
     payload.status = 'dismissed';
     dispatch({ type: POPUPS.DELETE_POPUPS, payload });
+    const triggerBtn = payload.popupsProps.settings.trigger;
+    if (triggerBtn?.current){
+      triggerBtn.current?.focus();
+    }
   }
 
   return (

--- a/src/app/views/query-runner/query-input/share-query/ShareButton.tsx
+++ b/src/app/views/query-runner/query-input/share-query/ShareButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { makeStyles, Button, Tooltip } from '@fluentui/react-components';
 import { Share24Regular } from '@fluentui/react-icons';
 
@@ -20,10 +20,13 @@ const ShareButton = () => {
     showShareQuery({
       settings: {
         title: translateMessage('Share Query'),
-        subtitle: translateMessage('Share Query Message')
+        subtitle: translateMessage('Share Query Message'),
+        trigger: shareTriggerBtnRef
       }
     });
   };
+
+  const shareTriggerBtnRef = useRef<HTMLButtonElement>(null);
 
   return (
     <Tooltip
@@ -32,6 +35,7 @@ const ShareButton = () => {
       relationship="label"
     >
       <Button
+        ref={shareTriggerBtnRef}
         icon={<Share24Regular />}
         className={classes.iconButton}
         appearance="subtle"

--- a/src/app/views/query-runner/query-input/share-query/ShareQuery.tsx
+++ b/src/app/views/query-runner/query-input/share-query/ShareQuery.tsx
@@ -29,7 +29,7 @@ const useStyles = makeStyles({
 
 const ShareQuery: React.FC<PopupsComponent<null>> = (props) => {
   const styles = useStyles();
-  const { sampleQuery } = useAppSelector((state) => state);
+  const sampleQuery = useAppSelector((state) => state.sampleQuery);
   const query = { ...sampleQuery };
   const sanitizedQueryUrl = sanitizeQueryUrl(query.sampleUrl);
   const shareLink = createShareLink(sampleQuery);


### PR DESCRIPTION
## Overview

- [ ] https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_workitems/edit/30646


## Description
- Adds functionality to focus on the trigger for a dialog after closing it.