### PR TITLE
fix: return focus to previous element on close/back button

### DIFF
--- a/src/app/views/sidebar/resource-explorer/ResourceExplorer.tsx
+++ b/src/app/views/sidebar/resource-explorer/ResourceExplorer.tsx
@@ -11,7 +11,8 @@ import {
   Tooltip,
   TreeItemValue,
   TreeOpenChangeData,
-  TreeOpenChangeEvent
+  TreeOpenChangeEvent,
+  useRestoreFocusTarget
 } from '@fluentui/react-components';
 import { Collections20Regular, AddSquare20Regular, SubtractSquare20Regular } from '@fluentui/react-icons';
 import debounce from 'lodash.debounce';
@@ -44,6 +45,7 @@ const ResourceExplorer = () => {
   const resourceExplorerStyles = useResourceExplorerStyles();
   const searchBoxStyles = useSearchBoxStyles();
   const spinnerStyles = useSpinnerStyles();
+  const restoreFocusTargetAttribute = useRestoreFocusTarget();
 
   const dispatch: AppDispatch = useAppDispatch();
   const selectedLinks = collections && collections.length > 0 ? collections.find(k => k.isDefault)!.paths : [];
@@ -283,6 +285,7 @@ const ResourceExplorer = () => {
       />
       <Button onClick={openPreviewCollection}
         icon={<Collections20Regular />}
+        {...restoreFocusTargetAttribute}
         aria-label={translateMessage(`My API Collection: ${selectedLinks?.length} ${translateMessage('items')}`)}
         className={resourceExplorerStyles.apiCollectionButton}
       >

--- a/src/app/views/sidebar/resource-explorer/collection/APICollection.tsx
+++ b/src/app/views/sidebar/resource-explorer/collection/APICollection.tsx
@@ -11,7 +11,7 @@ import {
   DialogTitle,
   Button,
   makeStyles,
-  tokens
+  tokens,  useRestoreFocusTarget
 } from '@fluentui/react-components';
 import { Edit20Regular, Key20Regular, ArrowUpload20Regular, List20Regular } from '@fluentui/react-icons';
 import { useAppDispatch, useAppSelector } from '../../../../../store';
@@ -58,6 +58,7 @@ const APICollection: React.FC<PopupsComponent<APICollection>> = (props) => {
   const [items, setItems] = useState<ResourcePath[]>([]);
   const [loading, setLoading] = useState(true);
   const labelStyles = useStyles();
+  const restoreFocusTargetAttribute = useRestoreFocusTarget();
 
   useEffect(() => {
     const timeoutId = setTimeout(() => {
@@ -244,6 +245,7 @@ const APICollection: React.FC<PopupsComponent<APICollection>> = (props) => {
               disabled={option.disabled}
               onClick={option.onClick}
               style={{ marginInlineEnd: '30px' }}
+              {...restoreFocusTargetAttribute}
             >
               {option.text}
             </ToolbarButton>
@@ -256,6 +258,7 @@ const APICollection: React.FC<PopupsComponent<APICollection>> = (props) => {
               icon={item.icon}
               disabled={item.disabled}
               onClick={item.onClick}
+              {...restoreFocusTargetAttribute}
             >
               {item.text}
             </ToolbarButton>


### PR DESCRIPTION
## Overview

Fixes

- [x] https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_workitems/edit/30684/?view=edit
- [x] https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_workitems/edit/30719/?view=edit

## Testing Instructions
### Test 1

1. Open URL in web
2. Graph explorer page will open.
3. Navigate till My API Collection button and activate it.
4. Press on Close button.
5. Observe the focus return to My API Collection button.

### Test 2

1. Open URL in web
2. Graph explorer page will open.
3. Add items to collection using + buttons on API Explorer.
4. Navigate till My API Collection button and activate it.
5. Navigate to Edit Collection button and activate it.
6. Press on Back button.
8. Observe the focus return to Edit collection button