### PR TITLE
fix: components visible at various page resolutions/zoom sizes

### DIFF
--- a/src/app/views/layout/LayoutStyles.tsx
+++ b/src/app/views/layout/LayoutStyles.tsx
@@ -26,7 +26,6 @@ export const useLayoutStyles = makeStyles({
     maxWidth: '50vw',
     minWidth: '48px',
     position: 'relative',
-    height: 'calc(100vh - 98px)',
     overflow: 'hidden',
     transition: 'flex-basis 0.2s ease-in-out',
 
@@ -73,7 +72,7 @@ export const useLayoutStyles = makeStyles({
     flexDirection: 'column',
     minHeight: '200px',
     height:'auto',
-    maxHeight: '100%',
+    maxHeight: '40%',
     overflow: 'auto',
     borderRadius: tokens.borderRadiusMedium,
     padding: tokens.spacingHorizontalS

--- a/src/app/views/layout/LayoutStyles.tsx
+++ b/src/app/views/layout/LayoutStyles.tsx
@@ -11,7 +11,7 @@ export const useLayoutStyles = makeStyles({
     display: 'flex',
     flexDirection: 'column',
     padding: tokens.spacingHorizontalS,
-    height: '100vh',
+    height: 'clamp(100vh, auto, 200vh)',
     overflow: 'hidden'
   },
   content: {
@@ -41,35 +41,40 @@ export const useLayoutStyles = makeStyles({
     }
   },
   mainContent: {
-    flex: '1 1 auto',
+    flex: 1,
     display: 'flex',
     flexDirection: 'column',
     minWidth: '300px',
-    height: 'calc(100vh - 98px)',
+    minHeight: 'calc(100vh - 98px)',
     overflow: 'hidden'
   },
   requestResponseArea: {
-    flex: '1',
+    flex: '1 1 auto',
     display: 'flex',
     flexDirection: 'column',
-    height: '100%',
+    height: '60vh',
+    minHeight: '550px',
     overflow: 'hidden'
   },
   responseArea: {
-    flex: '1',
+    flex: '1 1 auto',
     display: 'flex',
     flexDirection: 'column',
-    maxHeight: '60%',
-    overflow: 'hidden',
+    minHeight: '300px',
+    height: 'auto',
+    maxHeight: '100%',
+    overflow: 'auto',
     borderRadius: tokens.borderRadiusMedium,
     padding: tokens.spacingHorizontalS
   },
   requestArea: {
-    flex: '1',
+    flex: '1 1 40%',
     display: 'flex',
     flexDirection: 'column',
-    maxHeight: '40%',
-    overflow: 'hidden',
+    minHeight: '200px',
+    height:'auto',
+    maxHeight: '100%',
+    overflow: 'auto',
     borderRadius: tokens.borderRadiusMedium,
     padding: tokens.spacingHorizontalS
   }

--- a/src/app/views/query-response/pivot-items/pivot-item.tsx
+++ b/src/app/views/query-response/pivot-items/pivot-item.tsx
@@ -47,7 +47,7 @@ const useStyles = makeStyles({
     flexDirection: 'column',
     width: '100%',
     flex: 1,
-    height: '100%',
+    height: '-webkit-fill-available',
     overflow: 'hidden'
   },
   tabList:{
@@ -57,13 +57,13 @@ const useStyles = makeStyles({
     flex: 1,
     display: 'flex',
     flexDirection: 'column',
-    minHeight: 0,
+    minHeight: '0',
     border: `1px solid ${tokens.colorNeutralStroke1}`,
     borderRadius: tokens.borderRadiusMedium,
     padding: tokens.spacingHorizontalS,
     marginTop: tokens.spacingHorizontalS,
     backgroundColor: tokens.colorNeutralBackground1,
-    overflow: 'hidden'
+    overflow: 'auto'
   }
 });
 

--- a/src/app/views/sidebar/Sidebar.tsx
+++ b/src/app/views/sidebar/Sidebar.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles({
     display: 'flex',
     flexDirection: 'column',
     overflow: 'hidden',
-    height: '100vh',
+    height: '90vh',
     padding: `0 ${tokens.spacingHorizontalS}`,
     backgroundColor: tokens.colorNeutralBackground2,
     borderRightWidth: tokens.strokeWidthThin,

--- a/src/app/views/sidebar/Sidebar.tsx
+++ b/src/app/views/sidebar/Sidebar.tsx
@@ -21,11 +21,15 @@ const useStyles = makeStyles({
     display: 'flex',
     flexDirection: 'column',
     overflow: 'hidden',
-    height: '100%',
+    height: '100vh',
     padding: `0 ${tokens.spacingHorizontalS}`,
     backgroundColor: tokens.colorNeutralBackground2,
     borderRightWidth: tokens.strokeWidthThin,
-    borderRight: `1px solid ${tokens.colorNeutralForeground3}`
+    borderRight: `1px solid ${tokens.colorNeutralForeground3}`,
+    '@media (max-width: 768px)': {
+      height: 'auto',
+      minHeight: '100%'
+    }
   },
   sidebarToggle: {
     marginLeft: 'auto'

--- a/src/app/views/sidebar/history/History.styles.ts
+++ b/src/app/views/sidebar/history/History.styles.ts
@@ -2,8 +2,7 @@ import { makeStyles } from '@fluentui/react-components'
 export const useHistoryStyles = makeStyles({
   container: {
     display: 'flex',
-    flexDirection: 'column',
-    marginTop: '8px'
+    flexDirection: 'column'
   },
   tree: {
     flexGrow: 1,

--- a/src/app/views/sidebar/history/History.styles.ts
+++ b/src/app/views/sidebar/history/History.styles.ts
@@ -2,12 +2,14 @@ import { makeStyles } from '@fluentui/react-components'
 export const useHistoryStyles = makeStyles({
   container: {
     display: 'flex',
-    flexDirection: 'column'
+    flexDirection: 'column',
+    marginTop: '8px'
   },
   tree: {
-    height: 'calc(100vh - 374px)',
+    flexGrow: 1,
     overflowY: 'auto',
-    padding: '5px'
+    padding: '5px',
+    maxHeight: 'calc(100vh - 100px)'
   },
   searchBox: {
     width: '100%',

--- a/src/app/views/sidebar/resource-explorer/resourceExplorerStyles.ts
+++ b/src/app/views/sidebar/resource-explorer/resourceExplorerStyles.ts
@@ -45,9 +45,10 @@ export const useResourceExplorerStyles = makeStyles({
     }
   },
   tree: {
-    height: 'calc(100vh - 374px)',
+    flexGrow: 1,
     overflowY: 'auto',
-    padding: '5px'
+    padding: '5px',
+    maxHeight: 'calc(100vh - 100px)'
   },
   treeItemLayout: {
     width: '100%',

--- a/src/app/views/sidebar/sample-queries/SampleQueries.styles.ts
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.styles.ts
@@ -37,5 +37,8 @@ export const useStyles = makeStyles({
       outline: '2px solid !important',
       outlineOffset: '2px !important'
     }
+  },
+  messageBar: {
+    whiteSpace: 'wrap'
   }
 });

--- a/src/app/views/sidebar/sample-queries/SampleQueries.styles.ts
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.styles.ts
@@ -1,7 +1,7 @@
 import { makeStyles, tokens } from '@fluentui/react-components';
 export const useStyles = makeStyles({
   container: {
-    marginTop: '6px'
+    marginTop: '8px'
   },
   searchBox: {
     width: '100%',
@@ -24,9 +24,10 @@ export const useStyles = makeStyles({
     }
   },
   tree: {
-    height: 'calc(100vh - 374px)',
+    flexGrow: 1,
     overflowY: 'auto',
-    padding: '5px'
+    padding: '5px',
+    maxHeight: 'calc(100vh - 100px)'
   },
   itemLayout: {
     paddingLeft: tokens.spacingHorizontalXXL

--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -142,8 +142,9 @@ const CachedSetMessageBar = () => {
  * @returns {JSX.Element} The rendered MessageBar component with a link.
  */
 const SeeMoreQueriesMessageBar = () => {
+  const sampleQueriesStyles = useStyles();
   return (
-    <MessageBar intent={'info'}>
+    <MessageBar className={sampleQueriesStyles.messageBar} intent={'info'}>
       <MessageBarBody>
         {translateMessage('see more queries')}{' '}
         <Link


### PR DESCRIPTION
## Overview

fixes https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_queries/edit/?tempQueryId=39d0a1af-392a-4ee4-94ba-e8c2d52c6efb&id=30685&queryId=30685
fixes https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_queries/edit/?tempQueryId=39d0a1af-392a-4ee4-94ba-e8c2d52c6efb&id=30722&queryId=30685
fixes https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_queries/edit/?tempQueryId=1a372e96-5f51-4c15-88b0-26a65a9df1e3&id=30723&queryId=30642

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions
### Test 1
Settings > display resolution > 1280x 768>
 browser-zoom to 200%> refresh the page.

### Test 2
1. Inspect the page.
2. Zoom till 200%.
3. Set display resolution to 320x 250px
4. Refresh the page.