### PR TITLE
fix: announce changed scope activation after selecting checkbox items

### DIFF
--- a/src/app/views/sidebar/resource-explorer/ResourceExplorer.tsx
+++ b/src/app/views/sidebar/resource-explorer/ResourceExplorer.tsx
@@ -175,8 +175,8 @@ const ResourceExplorer = () => {
     };
 
     return (
-      <>
-        <div className='action-button'>
+      <div className={resourceExplorerStyles.treeActions}>
+        <div>
           {isInCollection ? (
             <Tooltip
               withArrow
@@ -213,7 +213,7 @@ const ResourceExplorer = () => {
             aria-label={messageCount + translateMessage('Resources')}
           />
         )}
-      </>
+      </div>
     );
   };
 

--- a/src/app/views/sidebar/resource-explorer/collection/EditScopePanel.tsx
+++ b/src/app/views/sidebar/resource-explorer/collection/EditScopePanel.tsx
@@ -6,7 +6,7 @@ import {
   useId
 } from '@fluentui/react-components';
 import { translateMessage } from '../../../../utils/translate-messages';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { IResourceLink } from '../../../../../types/resources';
 import { resetSaveState, updateResourcePaths } from '../../../../services/slices/collections.slice';
 import Paths from './Paths';
@@ -40,6 +40,7 @@ const EditScopePanel: React.FC<EditScopePanelProps> = ({ closePopup }) => {
   const items = collections && collections.length > 0 ? collections.find(k => k.isDefault)!.paths : [];
   const styles = useStyles();
   const dropdownId = useId('dropdown-scope');
+  const dropdownRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     if (saved) {
@@ -47,6 +48,12 @@ const EditScopePanel: React.FC<EditScopePanelProps> = ({ closePopup }) => {
       setPendingChanges([]);
     }
   }, [saved]);
+
+  useEffect(() => {
+    if (selectedItems.length > 0 && dropdownRef.current) {
+      dropdownRef.current.focus();
+    }
+  }, [selectedItems]);
 
   const columns = [
     { key: 'url', name: 'Select all', fieldName: 'url', minWidth: 300, maxWidth: 1100, isResizable: true },
@@ -104,6 +111,8 @@ const EditScopePanel: React.FC<EditScopePanelProps> = ({ closePopup }) => {
           onOptionSelect={handleScopeChange}
           disabled={selectedItems.length === 0}
           className={styles.dropdown}
+          aria-label={translateMessage('Select one scope')}
+          ref={dropdownRef}
         >
           {scopeOptions.map(option => (
             <Option key={option.key} value={option.key}>

--- a/src/app/views/sidebar/resource-explorer/resourceExplorerStyles.ts
+++ b/src/app/views/sidebar/resource-explorer/resourceExplorerStyles.ts
@@ -43,6 +43,10 @@ export const useResourceExplorerStyles = makeStyles({
     padding: '5px',
     maxHeight: 'calc(100vh - 100px)'
   },
+  treeActions: {
+    display: 'flex',
+    alignItems: 'center'
+  },
   treeItemLayout: {
     width: '100%',
     ':hover, :focus, :focus-visible, :focus-within': {


### PR DESCRIPTION
## Overview

Closes https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_workitems/edit/30737/?view=edit

Also fixes misaligned action buttons on resource tree

## Testing Instructions

1. Go to url provided
2. Activate My API Collection
3. Navigate to Edit Scope
4. Activate and using keyboard or mouse, check items
5. Observe the Change scope dropdown gets activated and announced.