### PR TITLE
fix: code snippet loads when a sample is selected

### DIFF
--- a/src/app/services/slices/snippet.slice.ts
+++ b/src/app/services/slices/snippet.slice.ts
@@ -89,7 +89,9 @@ const snippetSlice = createSlice({
       })
       .addCase(getSnippet.fulfilled, (state, action) => {
         state.pending = false;
-        state.data = action.payload as Snippet;
+        const [rawKey, value] = Object.entries(action.payload)[0];
+        const key = rawKey.toLowerCase();
+        state.data = { [key]: value };
         state.error = {} as SnippetError;
       })
       .addCase(getSnippet.rejected, (state, action) => {

--- a/src/app/views/query-response/snippets/Snippets.tsx
+++ b/src/app/views/query-response/snippets/Snippets.tsx
@@ -195,6 +195,8 @@ const RenderSnippets = () => {
   const onTabSelect = (_event: SelectTabEvent, data: SelectTabData) => {
     const newLang = data.value as string;
     dispatch(setSnippetTabSuccess(newLang));
+    dispatch(getSnippet(newLang.toLowerCase()));
+    telemetry.trackTabClickEvent(newLang);
   };
   return (
     <div id='snippets-tablist' className={styles.container}>
@@ -239,13 +241,13 @@ const SnippetContent: React.FC<SnippetContentProps> = (
 
   useEffect(() => {
     if (snippetTab) {
-      dispatch(getSnippet(snippetTab));
+      dispatch(getSnippet(snippetTab.toLowerCase()));
     }
   }, [snippetTab]);
 
   useEffect(() => {
     if (sampleQuery && snippetTab) {
-      dispatch(getSnippet(snippetTab));
+      dispatch(getSnippet(snippetTab.toLowerCase()));
     }
   }, [sampleQuery]);
 


### PR DESCRIPTION
## Overview

fixes #3766 

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Check out branch
* Load Graph Explorer
* Select Code Snippets tab
* Select any sample query
* Observe snippet refreshes