### PR TITLE
fix: Add check for shared query url on page load

### DIFF
--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -371,7 +371,12 @@ const Samples: React.FC<SamplesProps> = ({ queries, groups, searchValue }) => {
   }, [queries]);
 
   useEffect(() => {
-    if (!mobileScreen && !hasAutoSelected && queries.length > 0) {
+    const urlParams = new URLSearchParams(window.location.search);
+    const hasSharedQuery = urlParams.has('request') && urlParams.has('method');
+
+    const shouldAutoSelect = !hasAutoSelected && !selectedQueryKey && !hasSharedQuery;
+
+    if (!mobileScreen && queries.length > 0 && shouldAutoSelect) {
       const defaultSample = queries.find(q =>
         q.method === 'GET' && q.humanName.toLowerCase().includes('my profile')
       );
@@ -384,7 +389,7 @@ const Samples: React.FC<SamplesProps> = ({ queries, groups, searchValue }) => {
         dispatch({ type: 'samples/setHasAutoSelectedDefault', payload: true });
       }
     }
-  }, [mobileScreen, queries, hasAutoSelected, dispatch]);
+  }, [mobileScreen, queries, hasAutoSelected, dispatch, selectedQueryKey]);
   useEffect(() => {
     if (groups && groups.length > 0) {
       setOpenItems(prev => {


### PR DESCRIPTION
## Overview

Fixes #3813 

### Demo

![image](https://github.com/user-attachments/assets/701cc2a6-4866-4fec-8286-9ae1a324a9d8)

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Load Graph Explorer
* Select any sample like GET list all applications with count
* Select share query button
* Paste link on a new tab and edit this part of the URL `https://developer.microsoft.com/graph/graph-explorer?` and replace with the url you're using to test i.e. `http://localhost:3000` or the calm-wave link
* Observe fix