### PR TITLE
fix: Add login redirect if no account is found

### DIFF
--- a/src/modules/authentication/AuthenticationWrapper.spec.ts
+++ b/src/modules/authentication/AuthenticationWrapper.spec.ts
@@ -150,4 +150,14 @@ describe('AuthenticationWrapper should', () => {
     const token = await authenticationWrapper.getToken();
     expect(token.account!.homeAccountId).toBe('homeAccountId');
   });
+
+  it('redirects to login if no account is found in cache or memory', async () => {
+    const { msalApplication } = require('./msal-app.ts');
+    msalApplication.getAllAccounts.mockReturnValueOnce([]);
+
+    msalApplication.loginRedirect = jest.fn(() => Promise.resolve());
+
+    await expect(authenticationWrapper.getToken()).rejects.toThrow('Login redirect initiated');
+    expect(msalApplication.loginRedirect).toHaveBeenCalled();
+  });
 })

--- a/src/modules/authentication/AuthenticationWrapper.ts
+++ b/src/modules/authentication/AuthenticationWrapper.ts
@@ -169,7 +169,11 @@ export class AuthenticationWrapper implements IAuthenticationWrapper {
           throw new Error(`Silent token acquisition failed for cached account: ${error}`);
         }
       } else {
-        throw new Error('No active or cached account found. User login required.');
+        await msalApplication.loginRedirect({
+          scopes: defaultScopes,
+          redirectUri: getCurrentUri()
+        });
+        throw new Error('Login redirect initiated');
       }
     }
 


### PR DESCRIPTION
## Overview

Fixes an error where a login pop up doesn't show when no account is present

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* 
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output