### PR TITLE
chore: update release please to use gh app token

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,3 +1,0 @@
-manifest: true
-primaryBranch: dev
-handleGHRelease: true

--- a/.github/workflows/release-please-master.yml
+++ b/.github/workflows/release-please-master.yml
@@ -1,3 +1,13 @@
+## -----------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+## -----------------------------------------------------------------------------
+#
+# Summary:
+# This GitHub Actions workflow automates the release process using Release Please.
+# It triggers on pushes to the main branch, generates a GitHub App token using organization
+# variables and secrets, and then runs the release-please-action to manage versioning and changelogs.
+
 name: Release Please for Master
 
 on:
@@ -10,12 +20,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Run Release Please for Master
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_TOKEN_PROVIDER_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_TOKEN_PROVIDER_PEM }}
+
+      - name: Release Please
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          target-branch: master
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          manifest: true
+          primaryBranch: dev
+          handleGHRelease: true


### PR DESCRIPTION
## Overview

Move off of PATs, use GH app token.

## Testing Instructions

Commit to dev. Success is if a release PR is automatically made after the commit to dev.