### PR TITLE
fix: Update node-forge to version 1.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15194,10 +15194,9 @@
                         }
                 },
                 "node_modules/node-forge": {
-                        "version": "1.3.1",
-                        "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-                        "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
-                        "license": "(BSD-3-Clause OR GPL-2.0)",
+                        "version": "1.3.2",
+                        "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
+                        "integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==",
                         "engines": {
                                 "node": ">= 6.13.0"
                         }

--- a/package.json
+++ b/package.json
@@ -132,5 +132,10 @@
                 "reportPath": "reports",
                 "reportFile": "test-report.xml",
                 "indent": 4
+        },
+        "overrides": {
+                "selfsigned": {
+                        "node-forge": "1.3.2"
+                }
         }
 }


### PR DESCRIPTION
## Overview

This pull request introduces a dependency override in the `package.json` file to address a specific version requirement for a transitive dependency.

Dependency management:

* Added an `overrides` section to `package.json` to force the `selfsigned` package to use `node-forge` version `1.3.2`, ensuring compatibility or addressing a security concern.