### PR TITLE
Fixing failing npm step in precheckin pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -117,8 +117,8 @@ extends:
             versionSpec: "18.16.x"
           displayName: "Install Node.js"
         - script: |
-            npm install
-          displayName: "npm install" --no-audit
+            npm install --no-audit
+          displayName: "npm install"
         - script: |
             npm run build
           env:


### PR DESCRIPTION
## Overview

Precheckin pipeline started failing on audit step with type error. Audit step is not a production-level check or requirement, and we have cg alerts and guardian running in pipeline, making this step unnecessary. Adding --no-audit to resolve the issue.
