### PR TITLE
ci: use private npm feed for npm ci in azure-pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,8 +90,12 @@ extends:
           inputs:
             versionSpec: "25.x"
           displayName: "Install Node.js"
-        - script: |
-            npm ci
+        - task: Npm@1
+          inputs:
+            command: 'ci'
+            verbose: true
+            customRegistry: 'useFeed'
+            customFeed: 'Graph Developer Experiences/msgraph-typescript'
           displayName: "npm ci"
         - script: |
             npm run lint
@@ -116,8 +120,12 @@ extends:
           inputs:
             versionSpec: "25.x"
           displayName: "Install Node.js"
-        - script: |
-            npm ci
+        - task: Npm@1
+          inputs:
+            command: 'ci'
+            verbose: true
+            customRegistry: 'useFeed'
+            customFeed: 'Graph Developer Experiences/msgraph-typescript'
           displayName: "npm ci"
         - script: |
             npm run build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,7 +95,7 @@ extends:
             command: 'ci'
             verbose: true
             customRegistry: 'useFeed'
-            customFeed: 'Graph Developer Experiences/msgraph-typescript'
+            customFeed: 'Graph Developer Experiences/GraphDeveloperExperiences_Public'
           displayName: "npm ci"
         - script: |
             npm run lint
@@ -125,7 +125,7 @@ extends:
             command: 'ci'
             verbose: true
             customRegistry: 'useFeed'
-            customFeed: 'Graph Developer Experiences/msgraph-typescript'
+            customFeed: 'Graph Developer Experiences/GraphDeveloperExperiences_Public'
           displayName: "npm ci"
         - script: |
             npm run build


### PR DESCRIPTION
## Summary

Configures the `azure-pipelines.yml` pipeline to install npm dependencies from a private artifact feed, following the exact same approach used in [`microsoftgraph/msgraph-sdk-typescript`](https://github.com/microsoftgraph/msgraph-sdk-typescript/blob/main/.azure-pipelines/release.yml).

Both `npm ci` script steps (in the `Build and test validation` and `Publish artifacts` jobs) are replaced with the `Npm@1` task using the shared feed `Graph Developer Experiences/msgraph-typescript`:

```yaml
- task: Npm@1
  inputs:
    command: 'ci'
    verbose: true
    customRegistry: 'useFeed'
    customFeed: 'Graph Developer Experiences/msgraph-typescript'
  displayName: "npm ci"
```

## Notes

- The same registry is re-used as in the SDK repo, per the request.
- Only the `npm ci` steps need feed authentication; the subsequent `npm test` / `npm run build` script steps don't install packages, so they're left unchanged.